### PR TITLE
ENH SmallData Submission Task, and minor changes to warnings handling

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -6,6 +6,13 @@ date: "2023/10/25"
 lute-version: 0.1      # Do not be change unless need to force older version
 ...
 ---
+SubmitSMD:
+  producer: "/sdf/data/lcls/ds/mfx/mfxl1013621/results/smalldata_tools/producers/smd_producer.py"
+  run: 99
+  experiment: "mfxl1013621"
+  directory: "/sdf/home/d/dorlhiac/scratch/lute_tests/test_smd"
+  default: true
+
 # FindOverlapXSS Configuration
 FindOverlapXSS:
   # Detector selection - if left as "", will attempt to find a default

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -30,21 +30,26 @@ import subprocess
 import time
 import os
 import socket
-import threading
 import signal
 from typing import Dict, Callable, List
 from typing_extensions import Self
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import warnings
 
 from .ipc import *
 from ..tasks.task import *
 from ..io.config import TaskParameters
 
 if __debug__:
+    warnings.simplefilter("default")
+    os.environ["PYTHONWARNINGS"] = "default"
     logging.basicConfig(level=logging.DEBUG)
+    logging.captureWarnings(True)
 else:
     logging.basicConfig(level=logging.INFO)
+    warnings.simplefilter("ignore")
+    os.environ["PYTHONWARNINGS"] = "ignore"
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +274,8 @@ class BaseExecutor(ABC):
         os.set_blocking(proc.stderr.fileno(), True)
 
         self._finalize_task(proc)
+        proc.stdout.close()
+        proc.stderr.close()
 
     def _task_is_running(self, proc: subprocess.Popen) -> bool:
         """Whether a subprocess is running.

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -21,11 +21,22 @@ Exceptions:
 __all__ = ["parse_config", "TaskParameters"]
 __author__ = "Gabriel Dorlhiac"
 
+import os
 from abc import ABC
-from typing import List, Dict, Iterator, Dict, Any, Union
+from typing import List, Dict, Iterator, Dict, Any, Union, Optional
 
 import yaml
-from pydantic import BaseModel, BaseSettings, ValidationError
+import yaml
+from pydantic import (
+    BaseModel,
+    BaseSettings,
+    ValidationError,
+    HttpUrl,
+    PositiveInt,
+    NonNegativeInt,
+    Field,
+    conint,
+)
 
 
 # Parameter models
@@ -48,7 +59,8 @@ class TaskParameters(BaseSettings):
     class Config:
         env_prefix = "LUTE_"
 
-
+# Test Task models
+##################
 class TestParameters(TaskParameters):
     """Parameters for the test Task `Test`."""
 
@@ -71,6 +83,109 @@ class TestSocketParameters(TaskParameters):
     array_size: int = 10000
     num_arrays: int = 10
 
+
+# smalldata_tools Parameters
+############################
+class SMDParameters(TaskParameters):
+    """Parameters for running smalldata to produce reduced HDF5 files."""
+
+    executable: str = Field("mpirun", description="MPI executable.", flag_type="")
+    np: conint(gt=2, le=120) = Field(
+        120, description="Number of processes", flag_type="-"
+    )
+    p_arg1: str = Field(
+        "python", description="Executable to run with mpi (i.e. python).", flag_type=""
+    )
+    u: str = Field(
+        "", description="Python option for unbuffered output.", flag_type="-"
+    )
+    m: str = Field(
+        "mpi4py.run",
+        description="Python option to execute a module's contents as __main__ module.",
+        flag_type="-",
+    )
+    producer: str = Field(
+        "", description="Path to the SmallData producer Python script.", flag_type=""
+    )
+    run: str = Field(
+        os.environ.get("RUN_NUM", ""), description="DAQ Run Number.", flag_type="--"
+    )
+    experiment: str = Field(
+        os.environ.get("EXPERIMENT", ""),
+        description="LCLS Experiment Number.",
+        flag_type="--",
+    )
+    stn: NonNegativeInt = Field(0, description="Hutch endstation.", flag_type="--")
+    nevents: int = Field(
+        int(1e9), description="Number of events to process.", flag_type="--"
+    )
+    directory: Optional[str] = Field(
+        None,
+        description="Optional output directory. If None, will be in ${EXP_FOLDER}/hdf5/smalldata.",
+        flag_type="--",
+    )
+    gather_interval: PositiveInt = Field(
+        25, description="Number of events to collect at a time.", flag_type="--"
+    )
+    norecorder: bool = Field(
+        False, description="Whether to ignore recorder streams.", flag_type="--"
+    )
+    url: HttpUrl = Field(
+        "https://pswww.slac.stanford.edu/ws-auth/lgbk",
+        description="Base URL for eLog posting.",
+        flag_type="--",
+    )
+    epicsAll: bool = Field(
+        False,
+        description="Whether to store all EPICS PVs. Use with care.",
+        flag_type="--",
+    )
+    full: bool = Field(
+        False,
+        description="Whether to store all data. Use with EXTRA care.",
+        flag_type="--",
+    )
+    fullSum: bool = Field(
+        False,
+        description="Whether to store sums for all area detector images.",
+        flag_type="--",
+    )
+    default: bool = Field(
+        False,
+        description="Whether to store only the default minimal set of data.",
+        flag_type="--",
+    )
+    image: bool = Field(
+        False,
+        description="Whether to save everything as images. Use with care.",
+        flag_type="--",
+    )
+    tiff: bool = Field(
+        False,
+        description="Whether to save all images as a single TIFF. Use with EXTRA care.",
+        flag_type="--",
+    )
+    centerpix: bool = Field(
+        False,
+        description="Whether to mask center pixels for Epix10k2M detectors.",
+        flag_type="--",
+    )
+    postRuntable: bool = Field(
+        False,
+        description="Whether to post run tables. Also used as a trigger for summary jobs.",
+        flag_type="--",
+    )
+    wait: bool = Field(
+        False, description="Whether to wait for a file to appear.", flag_type="--"
+    )
+    xtcav: bool = Field(
+        False,
+        description="Whether to add XTCAV processing to the HDF5 generation.",
+        flag_type="--",
+    )
+    noarch: bool = Field(
+        False, description="Whether to not use archiver data.", flag_type="--"
+    )
 
 class FindOverlapXSSParameters(TaskParameters):
     """TaskParameter model for FindOverlapXSS Task.
@@ -96,7 +211,6 @@ class FindOverlapXSSParameters(TaskParameters):
     exp_config: ExpConfig
     thresholds: Thresholds
     analysis_flags: AnalysisFlags
-
 
 # Config IO
 ###########

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -59,6 +59,7 @@ class TaskParameters(BaseSettings):
     class Config:
         env_prefix = "LUTE_"
 
+
 # Test Task models
 ##################
 class TestParameters(TaskParameters):
@@ -187,6 +188,7 @@ class SMDParameters(TaskParameters):
         False, description="Whether to not use archiver data.", flag_type="--"
     )
 
+
 class FindOverlapXSSParameters(TaskParameters):
     """TaskParameter model for FindOverlapXSS Task.
 
@@ -211,6 +213,7 @@ class FindOverlapXSSParameters(TaskParameters):
     exp_config: ExpConfig
     thresholds: Thresholds
     analysis_flags: AnalysisFlags
+
 
 # Config IO
 ###########

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -87,7 +87,7 @@ class TestSocketParameters(TaskParameters):
 
 # smalldata_tools Parameters
 ############################
-class SMDParameters(TaskParameters):
+class SubmitSMDParameters(TaskParameters):
     """Parameters for running smalldata to produce reduced HDF5 files."""
 
     executable: str = Field("mpirun", description="MPI executable.", flag_type="")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -1,6 +1,12 @@
 from .io.config import *
 from .execution.executor import *
 
+# Tests
+#######
 Tester = Executor("Test")
 BinaryTester = Executor("TestBinary")
 SocketTester = Executor("TestSocket")
+
+# SmallData-related
+###################
+SmallDataProducer = Executor("SubmitSMD")

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -49,6 +49,7 @@ if __debug__:
 else:
     warnings.simplefilter("ignore")
 
+
 class TaskStatus(Enum):
     """Possible Task statuses."""
 


### PR DESCRIPTION
# Description

This PR introduces:
- `SMDParameters` Configuration model for submitting a prepared SmallData producer file.
  - The submission works as a "third-party", `BinaryTask` and performs no modification of the producer file.
  - Currently also assumes that the repo has been cloned and the producer file exists where specified.
- Warnings are passed through communicator objects so they are properly read out.
- `__debug__` is used to determine whether to pass warnings and how to do so.
- Some changes to `PipeCommunicator` to handle errors arising when switching between using pickle/not using pickle for message passing.

## Checklist
- [x] `SMDParameters` config model specification.
- [x] Changes to warnings
- [x] Permanent debug options
- [x] `PipeCommunicator` fixes

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- NA

# Testing
- Tested using the configuration included in the `test.yaml` YAML as part of this PR. Tested on a single run (99) of experiment `mfxl1013621`. The data is saved to a separate directory to avoid interferring with the standard smalldata outputs.
- Steps to test:
  1. Checkout this branch in `/sdf/home/d/dorlhiac/scratch/lute_tests/lute_dorlhiac`
  2. Submit `sbatch /sdf/home/d/dorlhiac/scratch/lute_tests/test_smalldata.sh`
    - The file may need to be copied and the socket paths changed in the corresponding environment variable to avoid permissions issues. 
  3. Output from the batch script (if unmodified) should include an hdf5 file: `/sdf/home/d/dorlhiac/scratch/lute_tests/test_smd/mfxl1013621_Run0099.h5`
  The text output will be available in `smd_test.err` in the same directory as the batch script. It should end with a message similar to:
```
INFO:lute.execution.executor:Current Event / rank : 101

INFO:lute.execution.executor:########## JOB TIME: 0.651822 minutes ###########

INFO:lute.execution.executor:
INFO:lute.execution.executor:
INFO:lute.execution.executor: (Closing remaining open files:/sdf/home/d/dorlhiac/scratch/lute_tests/test_smd/mfxl1013621_Run0099.h5...)
INFO:lute.execution.executor:(done
)
```
# Screenshots
NA