### PR TITLE
ENH Utility functions for working with the eLog

### DIFF
--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -158,10 +158,10 @@ if __name__ == "__main__":
         for inst in instance_information:
             task_id: str = inst["task_id"]
             task_state: Optional[str] = inst["state"]
-            if task_id not in completed_tasks and task_state:
+            if task_id not in completed_tasks and task_state not in (None, "scheduled"):
                 if task_id not in logged_running:
                     # Should be "running" by first time it reaches here.
-                    # Or e.g. "upstream_failed"...
+                    # Or e.g. "upstream_failed"... Setup to skip "scheduled"
                     logger.info(f"{task_id} state: {task_state}")
                     logged_running.append(task_id)
 

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -1,4 +1,4 @@
-#!/sdf/group/lcls/ds/ana/sw/conda1/inst/envs/ana-4.0.59-py3/bin/python
+#!/sdf/group/lcls/ds/ana/sw/conda1/inst/envs/ana-4.0.60-py3/bin/python
 
 """Script submitted by Automated Run Processor (ARP) to trigger an Airflow DAG.
 
@@ -8,12 +8,14 @@ begin running the tasks of the specified directed acyclic graph (DAG).
 
 __author__ = "Gabriel Dorlhiac"
 
+import sys
 import os
 import uuid
 import getpass
 import datetime
 import logging
 import argparse
+import time
 from typing import Dict, Union, List
 
 import requests
@@ -69,11 +71,18 @@ if __name__ == "__main__":
     airflow_api_endpoints: Dict[str, str] = {
         "health": "api/v1/health",
         "run_dag": f"api/v1/dags/lute_{args.workflow}/dagRuns",
+        "get_tasks": f"api/v1/dags/lute_{args.workflow}/tasks",
+        "get_xcom": (
+            f"api/v1/dags/lute_{args.workflow}/{{dag_run_id}}/taskInstances"
+            f"/{{task_id}}/xcomEntries/{{xcom_key}}"
+        ),
     }
 
+    pw: str = _retrieve_pw(instance_str)
+    auth: HTTPBasicAuth = HTTPBasicAuth("btx", pw)
     resp: requests.models.Response = requests.get(
         f"{airflow_instance}/{airflow_api_endpoints['health']}",
-        auth=HTTPBasicAuth("btx", _retrieve_pw(instance_str)),
+        auth=auth,
     )
     resp.raise_for_status()
 
@@ -99,10 +108,44 @@ if __name__ == "__main__":
         },
     }
 
-    resp: requests.models.Response = requests.post(
+    resp = requests.post(
         f"{airflow_instance}/{airflow_api_endpoints['run_dag']}",
         json=dag_run_data,
-        auth=HTTPBasicAuth("btx", _retrieve_pw(instance_str)),
+        auth=auth,
     )
     resp.raise_for_status()
-    logger.info(resp.text)
+    dag_run_id: str = dag_run_data["dag_run_id"]
+    logger.info(f"Submitted DAG (Workflow): {args.workflow}\nDAG_RUN_ID: {dag_run_id}")
+    state: str = resp.json()["state"]
+    logger.info(f"DAG is {state}")
+
+    # Get Task information
+    resp = requests.get(
+        f"{airflow_instance}/{airflow_api_endpoints['get_tasks']}",
+        auth=auth,
+    )
+    resp.raise_for_status()
+    task_ids: List[str] = [task["task_id"] for task in resp.json()["tasks"]]
+    task_id_str: str = ",\n\t- ".join(tid for tid in task_ids)
+    logger.info(f"Contains Managed Tasks (in no particular order):\n\t- {task_id_str}")
+
+    # Enter loop for checking status
+    time.sleep(1)
+    # Same as run_dag endpoint, but needs to include the dag_run_id on the end
+    url: str = f"{airflow_instance}/{airflow_api_endpoints['run_dag']}/{dag_run_id}"
+    # Pulling logs for each Task via XCom
+    xcom_key: str = "log"
+    while True:
+        time.sleep(1)
+        resp = requests.get(url, auth=auth)
+        resp.raise_for_status()
+        state = resp.json()["state"]
+        if state in ("queued", "running"):
+            continue
+        logger.info(f"DAG is {state}")
+        break
+
+    if state == "failed":
+        sys.exit(-1)
+    else:
+        sys.exit(0)

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
                     logger.info(f"{task_id} state: {task_state}")
                     logged_running.append(task_id)
 
-                if task_state in ("success", "failed", "upstream_failed"):
+                if task_state in ("success", "failed"):
                     # Only pushed to XCOM at the end of each Task
                     xcom_url: str = (
                         f"{airflow_instance}/{airflow_api_endpoints['get_xcom']}"
@@ -183,6 +183,10 @@ if __name__ == "__main__":
                     print(logs, flush=True)
                     print("-" * 50, flush=True)
                     logger.info(f"End of logs for {task_id}")
+                    completed_tasks[task_id] = task_state
+
+                elif task_state in ("upstream_failed"):
+                    # upstream_failed never launches so has no log
                     completed_tasks[task_id] = task_state
 
         if dag_state in ("queued", "running"):

--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -1,7 +1,29 @@
 #!/bin/bash
+
+# Need to capture partition and account for SLURM
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        --partition=*)
+            PARTITION="${1#*=}"
+            shift
+            ;;
+        --account=*)
+            ACCOUNT="${1#*=}"
+            shift
+            ;;
+        *)
+            POS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POS[@]}"
+
 CMD="${@}"
+CMD="${CMD} --partition=${PARTITION} --account=${ACCOUNT}"
 echo $CMD
 CMD="/sdf/group/lcls/ds/tools/lute/lute_launcher ${CMD}"
-SLURM_ARGS="--partition=milano --account=lcls:data --ntasks=1"
+SLURM_ARGS="--partition=${PARTITION} --account=${ACCOUNT} --ntasks=1"
 echo "Running ${CMD} with ${SLURM_ARGS}"
 sbatch $SLURM_ARGS --wrap "${CMD}"

--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+CMD="${@}"
+echo $CMD
+CMD="/sdf/group/lcls/ds/tools/lute/lute_launcher ${CMD}"
+SLURM_ARGS="--partition=milano --account=lcls:data --ntasks=1"
+echo "Running ${CMD} with ${SLURM_ARGS}"
+sbatch $SLURM_ARGS --wrap "${CMD}"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -314,6 +314,7 @@ class BaseExecutor(ABC):
             # Ret code is 0, no exception was thrown, task forgot to set status
             self._analysis_desc.task_result.task_status = TaskStatus.COMPLETED
             logger.debug(f"Task did not change from RUNNING status. Assume COMPLETED.")
+            self.Hooks.task_done(self, msg=Message())
         self._store_configuration()
         for comm in self._communicators:
             comm.clear_communicator()

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -524,7 +524,7 @@ class MPIExecutor(Executor):
 
     def _submit_cmd(self, executable_path: str, params: str) -> str:
         """Override submission command to use `mpirun`
-        
+
         Args:
             executable_path (str): Path to the LUTE subprocess script.
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -276,6 +276,27 @@ class BaseExecutor(ABC):
         """
         ...
 
+    def _submit_cmd(self, executable_path: str, params: str) -> str:
+        """Return a formatted command for launching Task subprocess.
+
+        May be overridden by subclasses.
+
+        Args:
+            executable_path (str): Path to the LUTE subprocess script.
+
+            params (str): String of formatted command-line arguments.
+
+        Returns:
+            cmd (str): Appropriately formatted command for this Executor.
+        """
+        cmd: str = ""
+        if __debug__:
+            cmd = f"python -B {executable_path} {params}"
+        else:
+            cmd = f"python -OB {executable_path} {params}"
+
+        return cmd
+
     def execute_task(self) -> None:
         """Run the requested Task as a subprocess."""
         lute_path: Optional[str] = os.getenv("LUTE_PATH")
@@ -287,12 +308,7 @@ class BaseExecutor(ABC):
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 
-        cmd: str = ""
-        if __debug__:
-            cmd = f"python -B {executable_path} {params}"
-        else:
-            cmd = f"python -OB {executable_path} {params}"
-
+        cmd: str = self._submit_cmd(executable_path, params)
         proc: subprocess.Popen = self._submit_task(cmd)
 
         while self._task_is_running(proc):
@@ -503,20 +519,20 @@ class MPIExecutor(Executor):
     for the Executor itself.
 
     Methods:
-        execute_task(): Run the task as a subprocess using `mpirun`.
+        _submit_cmd: Run the task as a subprocess using `mpirun`.
     """
 
-    def execute_task(self) -> None:
-        """Run the requested Task as a subprocess."""
-        lute_path: Optional[str] = os.getenv("LUTE_PATH")
-        if lute_path is None:
-            logger.debug("Absolute path to subprocess.py not found.")
-            lute_path = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
-            os.environ["LUTE_PATH"] = lute_path
-        executable_path: str = f"{lute_path}/subprocess_task.py"
-        config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
-        params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
+    def _submit_cmd(self, executable_path: str, params: str) -> str:
+        """Override submission command to use `mpirun`
+        
+        Args:
+            executable_path (str): Path to the LUTE subprocess script.
 
+            params (str): String of formatted command-line arguments.
+
+        Returns:
+            cmd (str): Appropriately formatted command for this Executor.
+        """
         py_cmd: str = ""
         nprocs: int = max(
             int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1
@@ -528,30 +544,4 @@ class MPIExecutor(Executor):
             py_cmd = f"python -OB -u -m mpi4py.run {executable_path} {params}"
 
         cmd: str = f"{mpi_cmd} {py_cmd}"
-        proc: subprocess.Popen = self._submit_task(cmd)
-
-        while self._task_is_running(proc):
-            self._task_loop(proc)
-            time.sleep(self._analysis_desc.poll_interval)
-
-        os.set_blocking(proc.stdout.fileno(), True)
-        os.set_blocking(proc.stderr.fileno(), True)
-
-        self._finalize_task(proc)
-        proc.stdout.close()
-        proc.stderr.close()
-        proc.wait()
-        if ret := proc.returncode:
-            logger.info(f"Task failed with return code: {ret}")
-            self._analysis_desc.task_result.task_status = TaskStatus.FAILED
-        elif self._analysis_desc.task_result.task_status == TaskStatus.RUNNING:
-            # Ret code is 0, no exception was thrown, task forgot to set status
-            self._analysis_desc.task_result.task_status = TaskStatus.COMPLETED
-            logger.debug(f"Task did not change from RUNNING status. Assume COMPLETED.")
-        self._store_configuration()
-        for comm in self._communicators:
-            comm.clear_communicator()
-
-        if self._analysis_desc.task_result.task_status == TaskStatus.FAILED:
-            logger.info("Exiting after Task failure. Result recorded.")
-            sys.exit(-1)
+        return cmd

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -338,7 +338,6 @@ def post_elog_message(
     tag: Optional[str],
     title: Optional[str],
     in_files: List[Union[str, tuple, list]],
-    auth: Optional[Union[HTTPBasicAuth, Dict]] = None,
 ) -> Optional[str]:
     """Post a new message to the eLog. Inspired by the `elog` package.
 
@@ -353,10 +352,6 @@ def post_elog_message(
 
         in_files (List[str | tuple | list]): Files to include as attachments in
             the eLog post.
-
-        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
-            be username/password or kerberos headers. If none are provided,
-            authorization will be generated based on the experiment name.
 
     Returns:
         err_msg (str | None): If successful, nothing is returned, otherwise,
@@ -373,22 +368,15 @@ def post_elog_message(
     if title:
         post["log_title"] = title
 
-    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_opr_auth(exp)
-    post_url: str = f"{BASE_URL}/{exp}/ws/new_elog_entry"
-    # post_endpoint: str = f"{exp}/ws/new_elog_entry"
+    endpoint: str = f"{exp}/ws/new_elog_entry"
 
     params: Dict[str, Any] = {"data": post}
-
-    if isinstance(auth, HTTPBasicAuth):
-        params.update({"auth": auth})
-    elif isinstance(auth, dict):
-        params.update({"headers": auth})
 
     if out_files:
         params.update({"files": out_files})
 
     status_code, resp_msg, _ = elog_http_request(
-        url=post_url, request_type="POST", **params
+        exp=exp, endpoint=endpoint, request_type="POST", **params
     )
 
     if resp_msg != "SUCCESS":
@@ -400,7 +388,6 @@ def post_elog_run_table(
     exp: str,
     run: int,
     data: Dict[str, Any],
-    auth: Optional[Union[HTTPBasicAuth, Dict]] = None,
 ) -> Optional[str]:
     """Post data for eLog run tables.
 
@@ -412,27 +399,16 @@ def post_elog_run_table(
         data (Dict[str, Any]): Data to be posted in format
             data["column_header"] = value.
 
-        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
-            be username/password or kerberos headers. If none are provided,
-            authorization will be generated based on the experiment name.
-
     Returns:
         err_msg (None | str): If successful, nothing is returned, otherwise,
             return an error message.
     """
-    table_url: str = f"{BASE_URL}/run_control/{exp}/ws/add_run_params"
-    # endpoint: str = f"run_control/{exp}/ws/add_run_params"
-    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_auth(exp)
+    endpoint: str = f"run_control/{exp}/ws/add_run_params"
 
     params: Dict[str, Any] = {"params": {"run_num": run}, "json": data}
 
-    if isinstance(auth, HTTPBasicAuth):
-        params.update({"auth": auth})
-    elif isinstance(auth, dict):
-        params.update({"headers": auth})
-
     status_code, resp_msg, _ = elog_http_request(
-        exp, url=table_url, request_type="POST", **params
+        exp=exp, endpoint=endpoint, request_type="POST", **params
     )
 
     if resp_msg != "SUCCESS":
@@ -449,20 +425,12 @@ def get_elog_runs_by_tag(
         exp (str): Experiment name.
 
         tag (str): The tag to retrieve runs for.
-
-        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
-            be username/password or kerberos headers. If none are provided,
-            authorization will be generated based on the experiment name.
     """
-    tag_url: str = f"{BASE_URL}/{exp}/ws/get_runs_with_tag?tag={tag}"
+    endpoint: str = f"{exp}/ws/get_runs_with_tag?tag={tag}"
     params: Dict[str, Any] = {}
-    if isinstance(auth, HTTPBasicAuth):
-        params.update({"auth": auth})
-    elif isinstance(auth, dict):
-        params.update({"headers": auth})
 
     status_code, resp_msg, tagged_runs = elog_http_request(
-        url=tag_url, request_type="GET", **params
+        exp=exp, endpoint=endpoint, request_type="GET", **params
     )
 
     if not tagged_runs:

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -1,0 +1,294 @@
+"""Provides utilities for communicating with the LCLS eLog.
+
+Make use of various eLog API endpoint to retrieve information or post results.
+
+Functions:
+    get_elog_auth(exp: str): Return an authorization object to interact with
+        eLog API as an opr account for the hutch where `exp` was conducted.
+    get_elog_http_request(url: str, request_type: str, **params): Make an HTTP
+        request to the API endpoint at `url`.
+    format_file_for_post(in_file: Union[str, tuple, list]): Prepare files
+        according to the specification needed to add them as attachments to eLog
+        posts.
+    post_elog_message(exp: str, msg: str, tag: Optional[str],
+                      title: Optional[str],
+                      in_files: List[Union[str, tuple, list]],
+                      auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
+        Post a message to the eLog.
+    post_elog_runtable(exp: str, run: int, data: Dict[str, Any],
+                       auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
+        Update run table in the eLog.
+    get_elog_runs_by_tag(exp: str, tag: str,
+                         auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
+        Return a list of runs with a specific tag.
+"""
+
+__all__ = [
+    "post_elog_message",
+    "post_elog_runtable",
+    "get_elog_runs_by_tag",
+    "post_run_status",
+]
+__author__ = "Gabriel Dorlhiac"
+
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+import socket
+import mimetypes
+import os
+from typing import Any, Dict, Optional, List, Union, Tuple
+from io import BufferedReader
+
+BASE_URL: str = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
+
+
+def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict]:
+    """Produce authentication for the "opr" user associated to an experiment.
+
+    Will return different authentication methods depending on whether the
+    requested experiment is active or not.
+
+    Args:
+        exp (str): Name of the experiment to produce authentication for.
+
+    Returns:
+        auth (HTTPBasicAuth | Dict): HTTPBasicAuth for an active experiment
+            based on username and password, or Kerberos headers for an inactive
+            experiment.
+    """
+    # NEED TO FILL IN
+    return HTTPBasicAuth("fake", "fake") or {}
+
+
+def elog_http_request(
+    url: str, request_type: str, **params
+) -> Tuple[int, str, Optional[Any]]:
+    """Make an HTTP request to the eLog.
+
+    Args:
+        url (str): eLog API endpoint.
+
+        request_type (str): Type of request to make. Recognized options: POST or
+            GET.
+        **params (Dict): ALL parameters to pass with the HTTP request! Differs
+            depending on the API endpoint.
+
+    Returns:
+        status_code (int): Response status code. Can be checked for errors.
+
+        msg (str): An error message, or a message saying SUCCESS.
+
+        value (Optional[Any]): For GET requests ONLY, return the requested
+            information.
+    """
+    if request_type.upper() == "POST":
+        resp: requests.models.Response = requests.post(url, **params)
+    elif request_type.upper() == "GET":
+        resp: requests.models.Response = requests.get(url, **params)
+    else:
+        return (-1, "Invalid request type!", None)
+
+    status_code: int = resp.status_code
+    msg: str = "SUCCESS"
+
+    if resp.json()["success"] and request_type.upper() == "GET":
+        return (status_code, msg, resp.json()["value"])
+
+    if status_code >= 300:
+        msg = f"Error when posting to eLog: Response {status_code}"
+
+    if not resp.json()["success"]:
+        err_msg = resp.json()["error_msg"]
+        msg += f"\nInclude message: {err_msg}"
+    return (resp.status_code, msg, None)
+
+
+def format_file_for_post(
+    in_file: Union[str, tuple, list]
+) -> Tuple[str, Tuple[str, BufferedReader], Any]:
+    """Format a file for attachment to an eLog post.
+
+    The eLog API expects a specifically formatted tuple when adding file
+    attachments. This function prepares the tuple to specification given a
+    number of different input types.
+
+    Args:
+        in_file (str | tuple | list): File to include as an attachment in an
+            eLog post.
+    """
+    # NEED TO FILL IN FOR VARIOUS INPUT TYPES
+    out_file: Tuple[str, Tuple[str, BufferedReader], Any] = (
+        "files",
+        ("description", open("file", "rb")),
+        mimetypes.guess_type("path_to_file")[0],
+    )
+    return out_file
+
+
+def post_run_status(
+    data: Dict[str, Union[str, int, float]], update_url: Optional[str] = None
+) -> None:
+    """Post a summary to the status/report section of a specific run.
+
+    In contrast to most eLog update/post mechanisms, this function searches
+    for a specific environment variable which contains a temporary URL for
+    posting. This is updated every job/run as jobs are submitted by the JID.
+    The URL can optionally be passed to this function if it is known.
+
+    Args:
+        data (Dict[str, Union[str, int, float]]): The data to post to the eLog
+            report section. Formatted in key:value pairs.
+
+        update_url (Optional[str]): Optional update URL. If not provided, the
+            function searches for the corresponding environment variable. If
+            neither is found, the function aborts
+    """
+    post_list: List[Dict[str, str]] = [
+        {"key": f"{key}", "value": f"{value}"} for key, value in data.items()
+    ]
+
+    if not update_url:
+        update_url = os.environ.get("JID_UPDATE_COUNTERS")
+
+    params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
+    if update_url:
+        status_code, resp_msg, _ = elog_http_request(
+            url=update_url, request_type="POST", **params
+        )
+
+
+def post_elog_message(
+    exp: str,
+    msg: str,
+    *,
+    tag: Optional[str],
+    title: Optional[str],
+    in_files: List[Union[str, tuple, list]],
+    auth: Optional[Union[HTTPBasicAuth, Dict]] = None,
+) -> Optional[str]:
+    """Post a new message to the eLog. Inspired by the `elog` package.
+
+    Args:
+        exp (str): Experiment name.
+
+        msg (str): BODY of the eLog post.
+
+        tag (str | None): Optional "tag" to associate with the eLog post.
+
+        title (str | None): Optional title to include in the eLog post.
+
+        in_files (List[str | tuple | list]): Files to include as attachments in
+            the eLog post.
+
+        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
+            be username/password or kerberos headers. If none are provided,
+            authorization will be generated based on the experiment name.
+
+    Returns:
+        err_msg (str | None): If successful, nothing is returned, otherwise,
+            return an error message.
+    """
+    # MOSTLY CORRECT
+    out_files: list = []
+    for f in in_files:
+        out_files.append(format_file_for_post(in_file=f))
+    post: Dict[str, str] = {}
+    post["log_text"] = msg
+    if tag:
+        post["log_tags"] = tag
+    if title:
+        post["log_title"] = title
+
+    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_auth(exp)
+    post_url: str = f"{BASE_URL}/{exp}/ws/new_elog_entry"
+
+    params: Dict[str, Any] = {"data": post}
+
+    if isinstance(auth, HTTPBasicAuth):
+        params.update({"auth": auth})
+    elif isinstance(auth, dict):
+        params.update({"headers": auth})
+
+    if out_files:
+        params.update({"files": out_files})
+
+    status_code, resp_msg, _ = elog_http_request(
+        url=post_url, request_type="POST", **params
+    )
+
+    if resp_msg != "SUCCESS":
+        return resp_msg
+    # NEED to handle/propagate errors...
+
+
+def post_elog_runtable(
+    exp: str,
+    run: int,
+    data: Dict[str, Any],
+    auth: Optional[Union[HTTPBasicAuth, Dict]] = None,
+) -> Optional[str]:
+    """Post data for eLog run tables.
+
+    Args:
+        exp (str): Experiment name.
+
+        run (int): Run number corresponding to the data being posted.
+
+        data (Dict[str, Any]): Data to be posted in format
+            data["column_header"] = value.
+
+        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
+            be username/password or kerberos headers. If none are provided,
+            authorization will be generated based on the experiment name.
+
+    Returns:
+        err_msg (None | str): If successful, nothing is returned, otherwise,
+            return an error message.
+    """
+    table_url: str = f"{BASE_URL}/run_control/{exp}/ws/add_run_params"
+    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_auth(exp)
+
+    params: Dict[str, Any] = {"params": {"run_num": run}, "json": data}
+
+    if isinstance(auth, HTTPBasicAuth):
+        params.update({"auth": auth})
+    elif isinstance(auth, dict):
+        params.update({"headers": auth})
+
+    status_code, resp_msg, _ = elog_http_request(url=table_url, request_type="POST")
+
+    if resp_msg != "SUCCESS":
+        return resp_msg
+    # NEED to handle/propagate errors....
+
+
+def get_elog_runs_by_tag(
+    exp: str, tag: str, auth: Optional[Union[HTTPBasicAuth, Dict]] = None
+) -> List[int]:
+    """Retrieve run numbers with a specified tag.
+
+    Args:
+        exp (str): Experiment name.
+
+        tag (str): The tag to retrieve runs for.
+
+        auth (None | HTTPBasicAuth | Dict): Authorization for the eLog API. Can
+            be username/password or kerberos headers. If none are provided,
+            authorization will be generated based on the experiment name.
+    """
+    tag_url: str = f"{BASE_URL}/{exp}/ws/get_runs_with_tag?tag={tag}"
+    params: Dict[str, Any] = {}
+    if isinstance(auth, HTTPBasicAuth):
+        params.update({"auth": auth})
+    elif isinstance(auth, dict):
+        params.update({"headers": auth})
+
+    status_code, resp_msg, tagged_runs = elog_http_request(
+        url=tag_url, request_type="GET", **params
+    )
+
+    if not tagged_runs:
+        tagged_runs = []
+
+    return tagged_runs

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -323,7 +323,7 @@ def format_file_for_post(
     return out_file
 
 
-def _get_current_run_status(update_url: str) -> Dict[str, str]:
+def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]]:
     """Retrieve the current 'counters' or status for a workflow.
 
     This function is intended to be called from the posting function to allow
@@ -338,7 +338,11 @@ def _get_current_run_status(update_url: str) -> Dict[str, str]:
             displayed data.
     """
     get_url: str = update_url.replace("replace_counters", "get_counters")
-    requests.get(get_url)
+    resp: requests.models.Response = requests.get(get_url)
+    #current_status: Dict[str, Union[str, int, float]] = {d["key"]: d["value"] for d in resp.json()["value"]}
+    print(resp.json())
+    current_status = {}
+    return current_status
 
 
 def post_elog_run_status(
@@ -359,18 +363,18 @@ def post_elog_run_status(
             function searches for the corresponding environment variable. If
             neither is found, the function aborts
     """
-    post_list: List[Dict[str, str]] = [
-        {"key": f"{key}", "value": f"{value}"} for key, value in data.items()
-    ]
-
     if update_url is None:
         update_url = os.environ.get("JID_UPDATE_COUNTERS")
         if update_url is None:
             logger.info("eLog Update Failed! JID_UPDATE_COUNTERS is not defined!")
             return
-
+    current_status: Dict[str, Union[str, int, float]] = _get_current_run_status(update_url)
+    current_status.update(data)
+    post_list: List[Dict[str, str]] = [
+        {"key": f"{key}", "value": f"{value}"} for key, value in current_status.items()
+    ]
     params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
-    requests.post(update_url, **params)
+    resp: requests.models.Response = requests.post(update_url, **params)
 
 
 def post_elog_message(

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -344,7 +344,6 @@ def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]
     exp: str = replace_counters_parts[-2]
     get_url: str = "/".join(replace_counters_parts[:-3])
     get_url = f"{get_url}/{exp}/get_counters"
-    print(get_url, flush=True)
     job_doc: Dict[str, str] = {
         "_id": os.environ.get("ARP_ROOT_JOB_ID"),
         "experiment": exp,

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -323,6 +323,23 @@ def format_file_for_post(
     return out_file
 
 
+def _get_current_run_status(update_url: str) -> Dict[str, str]:
+    """Retrieve the current 'counters' or status for a workflow.
+
+    This function is intended to be called from the posting function to allow
+    for incremental updates to the status. It will only work for currently
+    running workflows, as it does not go back to the database, only the JID/ARP.
+
+    Args:
+        update_url (str): The JID_UPDATE_COUNTERS url.
+
+    Returns:
+        data (Dict[str, str]): A dictionary of key:value pairs of currently
+            displayed data.
+    """
+    get_url: str = update_url.replace("replace_counters", "get_counters")
+    requests.get(get_url)
+
 def post_elog_run_status(
     data: Dict[str, Union[str, int, float]], update_url: Optional[str] = None
 ) -> None:

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -3,31 +3,48 @@
 Make use of various eLog API endpoint to retrieve information or post results.
 
 Functions:
-    get_elog_auth(exp: str): Return an authorization object to interact with
+    get_elog_opr_auth(exp: str): Return an authorization object to interact with
         eLog API as an opr account for the hutch where `exp` was conducted.
-    get_elog_http_request(url: str, request_type: str, **params): Make an HTTP
+
+    get_kerberos_auth(): Return the authorization headers for the user account
+        submitting the job.
+
+    elog_http_request(url: str, request_type: str, **params): Make an HTTP
         request to the API endpoint at `url`.
+
     format_file_for_post(in_file: Union[str, tuple, list]): Prepare files
         according to the specification needed to add them as attachments to eLog
         posts.
+
     post_elog_message(exp: str, msg: str, tag: Optional[str],
                       title: Optional[str],
                       in_files: List[Union[str, tuple, list]],
                       auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
         Post a message to the eLog.
-    post_elog_runtable(exp: str, run: int, data: Dict[str, Any],
+
+    post_elog_run_status(data: Dict[str, Union[str, int, float]],
+                         update_url: Optional[str] = None)
+        Post a run status to the summary section on the Workflows>Control tab.
+
+    post_elog_run_table(exp: str, run: int, data: Dict[str, Any],
                        auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
         Update run table in the eLog.
+
     get_elog_runs_by_tag(exp: str, tag: str,
                          auth: Optional[Union[HTTPBasicAuth, Dict]] = None)
         Return a list of runs with a specific tag.
+
+    get_elog_params_by_run(exp: str, params: List[str], runs: Optional[List[int]])
+        Retrieve the requested parameters by run. If no run is provided, retrieve
+        the requested parameters for all runs.
 """
 
 __all__ = [
     "post_elog_message",
-    "post_elog_runtable",
+    "post_elog_run_table",
     "get_elog_runs_by_tag",
-    "post_run_status",
+    "post_elog_run_status",
+    "get_elog_params_by_run",
 ]
 __author__ = "Gabriel Dorlhiac"
 
@@ -40,39 +57,149 @@ import os
 from typing import Any, Dict, Optional, List, Union, Tuple
 from io import BufferedReader
 
-BASE_URL: str = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
+from krtc import KerberosTicket
 
 
-def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict]:
+def get_elog_workflows(exp: str) -> Dict[str, str]:
+    """Get the current workflow definitions for an experiment.
+
+    Returns:
+        defns (Dict[str, str]): A dictionary of workflow definitions.
+    """
+    raise NotImplementedError
+
+
+def post_elog_workflow(
+    exp: str,
+    name: str,
+    executable: str,
+    wf_params: str,
+    *,
+    trigger: str = "run_end",
+    location: str = "S3DF",
+    **trig_args: str,
+) -> None:
+    """Create a new eLog workflow, or update an existing one.
+
+    The workflow will run a specific executable as a batch job when the
+    specified trigger occurs. The precise arguments may vary depending on the
+    selected trigger type.
+
+    Args:
+        name (str): An identifying name for the workflow. E.g. "process data"
+
+        executable (str): Full path to the executable to be run.
+
+        wf_params (str): All command-line parameters for the executable as a string.
+
+        trigger (str): When to trigger execution of the specified executable.
+            One of:
+                - 'manual': Must be manually triggered. No automatic processing.
+                - 'run_start': Execute immediately if a new run begins.
+                - 'run_end': As soon as a run ends.
+                - 'param_is': As soon as a parameter has a specific value for a run.
+
+        location (str): Where to submit the job. S3DF or NERSC.
+
+        **trig_args (str): Arguments required for a specific trigger type.
+            trigger='param_is' - 2 Arguments
+                trig_param (str): Name of the parameter to watch for.
+                trig_param_val (str): Value the parameter should have to trigger.
+    """
+    endpoint: str = f"{exp}/ws/create_update_workflow_def"
+    trig_map: Dict[str, str] = {
+        "manual": "MANUAL",
+        "run_start": "START_OF_RUN",
+        "run_end": "END_OF_RUN",
+        "param_is": "RUN_PARAM_IS_VALUE",
+    }
+    if trigger not in trig_map.keys():
+        raise NotImplementedError(
+            f"Cannot create workflow with trigger type: {trigger}"
+        )
+    wf_defn: Dict[str, str] = {
+        "name": name,
+        "executable": executable,
+        "parameters": wf_params,
+        "trigger": trig_map[trigger],
+        "location": location,
+    }
+    if trigger == "param_is":
+        if "trig_param" not in trig_args or "trig_param_val" not in trig_args:
+            raise RuntimeError(
+                "Trigger type 'param_is' requires: 'trig_param' and 'trig_param_val' arguments"
+            )
+        wf_defn.update(
+            {
+                "run_param_name": trig_args["trig_param"],
+                "run_param_val": trig_args["trig_param_val"],
+            }
+        )
+    post_params: Dict[str, Dict[str, str]] = {"json": wf_defn}
+    status_code, resp_msg, _ = elog_http_request(
+        exp, endpoint=endpoint, request_type="POST", **post_params
+    )
+
+
+def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
+    """Determine the appropriate auth method depending on experiment state.
+
+    Returns:
+        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
+            is active/live, returns authorization for the hutch operator account
+            or the current user submitting a job.
+    """
+    return get_elog_opr_auth(exp)
+
+
+def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
     """Produce authentication for the "opr" user associated to an experiment.
 
-    Will return different authentication methods depending on whether the
-    requested experiment is active or not.
+    This method uses basic authentication using username and password.
 
     Args:
         exp (str): Name of the experiment to produce authentication for.
 
     Returns:
-        auth (HTTPBasicAuth | Dict): HTTPBasicAuth for an active experiment
-            based on username and password, or Kerberos headers for an inactive
-            experiment.
+        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
+            username and password for the associated operator account.
     """
     # NEED TO FILL IN
     return HTTPBasicAuth("fake", "fake") or {}
 
 
+def get_kerberos_auth() -> Dict[str, str]:
+    """Returns Kerberos authorization key.
+
+    This functions returns authorization for the USER account submitting jobs.
+    It assumes that `kinit` has been run.
+
+    Returns:
+        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
+    """
+    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
+
+
 def elog_http_request(
-    url: str, request_type: str, **params
+    exp: str, endpoint: str, request_type: str, **params
 ) -> Tuple[int, str, Optional[Any]]:
     """Make an HTTP request to the eLog.
 
+    This method will determine the proper authorization method and update the
+    passed parameters appropriately. Functions implementing specific endpoint
+    functionality and calling this function should only pass the necessary
+    endpoint-specific parameters and not include the authorization objects.
+
     Args:
-        url (str): eLog API endpoint.
+        exp (str): Experiment.
+
+        endpoint (str): eLog API endpoint.
 
         request_type (str): Type of request to make. Recognized options: POST or
             GET.
-        **params (Dict): ALL parameters to pass with the HTTP request! Differs
-            depending on the API endpoint.
+
+        **params (Dict): Endpoint parameters to pass with the HTTP request!
+            Differs depending on the API endpoint. Do not include auth objects.
 
     Returns:
         status_code (int): Response status code. Can be checked for errors.
@@ -82,6 +209,17 @@ def elog_http_request(
         value (Optional[Any]): For GET requests ONLY, return the requested
             information.
     """
+    auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(exp)
+    base_url: str
+    if isinstance(auth, HTTPBasicAuth):
+        params.update({"auth": auth})
+        base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
+    elif isinstance(auth, dict):
+        params.update({"headers": auth})
+        base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
+
+    url: str = f"{base_url}/{endpoint}"
+
     if request_type.upper() == "POST":
         resp: requests.models.Response = requests.post(url, **params)
     elif request_type.upper() == "GET":
@@ -126,7 +264,7 @@ def format_file_for_post(
     return out_file
 
 
-def post_run_status(
+def post_elog_run_status(
     data: Dict[str, Union[str, int, float]], update_url: Optional[str] = None
 ) -> None:
     """Post a summary to the status/report section of a specific run.
@@ -200,8 +338,9 @@ def post_elog_message(
     if title:
         post["log_title"] = title
 
-    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_auth(exp)
+    auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_opr_auth(exp)
     post_url: str = f"{BASE_URL}/{exp}/ws/new_elog_entry"
+    # post_endpoint: str = f"{exp}/ws/new_elog_entry"
 
     params: Dict[str, Any] = {"data": post}
 
@@ -222,7 +361,7 @@ def post_elog_message(
     # NEED to handle/propagate errors...
 
 
-def post_elog_runtable(
+def post_elog_run_table(
     exp: str,
     run: int,
     data: Dict[str, Any],
@@ -247,6 +386,7 @@ def post_elog_runtable(
             return an error message.
     """
     table_url: str = f"{BASE_URL}/run_control/{exp}/ws/add_run_params"
+    # endpoint: str = f"run_control/{exp}/ws/add_run_params"
     auth: Union[HTTPBasicAuth, Dict] = auth or get_elog_auth(exp)
 
     params: Dict[str, Any] = {"params": {"run_num": run}, "json": data}
@@ -256,7 +396,9 @@ def post_elog_runtable(
     elif isinstance(auth, dict):
         params.update({"headers": auth})
 
-    status_code, resp_msg, _ = elog_http_request(url=table_url, request_type="POST")
+    status_code, resp_msg, _ = elog_http_request(
+        exp, url=table_url, request_type="POST", **params
+    )
 
     if resp_msg != "SUCCESS":
         return resp_msg
@@ -292,3 +434,18 @@ def get_elog_runs_by_tag(
         tagged_runs = []
 
     return tagged_runs
+
+
+def get_elog_params_by_run(
+    exp: str, params: List[str], runs: Optional[List[int]] = None
+) -> Dict[str, str]:
+    """Retrieve requested parameters by run or for all runs.
+
+    Args:
+        exp (str): Experiment to retrieve parameters for.
+
+        params (List[str]): A list of parameters to retrieve. These can be any
+            parameter recorded in the eLog (PVs, parameters posted by other
+            Tasks, etc.)
+    """
+    ...

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -340,6 +340,7 @@ def _get_current_run_status(update_url: str) -> Dict[str, str]:
     get_url: str = update_url.replace("replace_counters", "get_counters")
     requests.get(get_url)
 
+
 def post_elog_run_status(
     data: Dict[str, Union[str, int, float]], update_url: Optional[str] = None
 ) -> None:

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -323,7 +323,7 @@ def format_file_for_post(
     return out_file
 
 
-def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]]:
+def _get_current_run_status(update_url: str) -> Dict[str, str]:
     """Retrieve the current 'counters' or status for a workflow.
 
     This function is intended to be called from the posting function to allow
@@ -338,11 +338,7 @@ def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]
             displayed data.
     """
     get_url: str = update_url.replace("replace_counters", "get_counters")
-    resp: requests.models.Response = requests.get(get_url)
-    #current_status: Dict[str, Union[str, int, float]] = {d["key"]: d["value"] for d in resp.json()["value"]}
-    print(resp.json())
-    current_status = {}
-    return current_status
+    requests.get(get_url)
 
 
 def post_elog_run_status(
@@ -363,18 +359,18 @@ def post_elog_run_status(
             function searches for the corresponding environment variable. If
             neither is found, the function aborts
     """
+    post_list: List[Dict[str, str]] = [
+        {"key": f"{key}", "value": f"{value}"} for key, value in data.items()
+    ]
+
     if update_url is None:
         update_url = os.environ.get("JID_UPDATE_COUNTERS")
         if update_url is None:
             logger.info("eLog Update Failed! JID_UPDATE_COUNTERS is not defined!")
             return
-    current_status: Dict[str, Union[str, int, float]] = _get_current_run_status(update_url)
-    current_status.update(data)
-    post_list: List[Dict[str, str]] = [
-        {"key": f"{key}", "value": f"{value}"} for key, value in current_status.items()
-    ]
+
     params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
-    resp: requests.models.Response = requests.post(update_url, **params)
+    requests.post(update_url, **params)
 
 
 def post_elog_message(

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -153,7 +153,7 @@ def post_elog_workflow(
 def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
     """Get the current active experiment for a hutch.
 
-    This function is the only function to manage the HTTP request independently.
+    This function is one of two functions to manage the HTTP request independently.
     This is because it does not require an authorization object, and its result
     is needed for the generic function `elog_http_request` to work properly.
 
@@ -329,7 +329,7 @@ def post_elog_run_status(
     """Post a summary to the status/report section of a specific run.
 
     In contrast to most eLog update/post mechanisms, this function searches
-    for a specific environment variable which contains a temporary URL for
+    for a specific environment variable which contains a specific URL for
     posting. This is updated every job/run as jobs are submitted by the JID.
     The URL can optionally be passed to this function if it is known.
 
@@ -352,10 +352,7 @@ def post_elog_run_status(
             return
 
     params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
-    if update_url:
-        status_code, resp_msg, _ = elog_http_request(
-            url=update_url, request_type="POST", **params
-        )
+    requests.post(update_url, **params)
 
 
 def post_elog_message(

--- a/lute/io/exceptions.py
+++ b/lute/io/exceptions.py
@@ -1,0 +1,15 @@
+"""Specifies custom exceptions defined for IO problems.
+
+Exceptions:
+    ElogFileFormatError: Raised if an attachment is specified in an incorrect
+        format.
+"""
+
+__all__ = ["ElogFileFormatError"]
+__author__ = "Gabriel Dorlhiac"
+
+
+class ElogFileFormatError(Exception):
+    """Raised when an eLog attachment is specified in an invalid format."""
+
+    ...


### PR DESCRIPTION
# Description

This PR introduces basic utility functions which can be used to communicate with the eLog via various API endpoints to perform actions such as:
- Post messages
- Retrieve run information (tags, etc.)
- Post run tables
- and more...
 
It also uses the Airflow API to retrieve more information from logfiles to display through the eLog interface.

It simplifies the `Executor` subclassing process by separating the submission command out from the rest of `execute_task`. In this way subclasses (like `MPIExecutor`) do not need to recreate cleanup and communication code.

## Checklist
- [ ] Public utility functions:
  - [ ] `post_elog_message` : Posts a message in the eLog proper. Can include HTML formatting. Supports attachments (e.g. images).
  - [ ] `post_elog_run_table` : Posts a run table with requested columns.
  - [x] `get_elog_runs_by_tag` : Returns a list of runs with a specified tag.
  - [x] `post_elog_run_status` : Posts a message which appears in the `Workflow/Control` tab next to the run number.
  - [ ] `get_elog_params_by_run` : Retrieves a run parameter, or list of parameters, for a single run, or list of runs.
- [x] Private/lesser used helper functions and behind-the-scenes utilities.  
  - [x] `get_elog_auth` function for retrieving appropriate authorization to use API endpoints. Should use different objects and set endpoints depending on whether an experiment as active (e.g. Kerberos vs basic http authentication)
  - [x]  `elog_http_request` wrapper function to perform any GET/POST request.
  - [x]  `format_file_for_post` to help format files into the correct specification for attachment to eLog posts.
- [x] Improve the ability to view aspects of Airflow-submitted Task log files through the eLog interface 
  - [x] Wrapper script which submits `launch_airflow.py` so it can run for more than 30 seconds
  - [x] Improvements to `launch_airflow.py` so it displays information from the logs of the submitted `Task` jobs.
- [x] Separate `_submit_cmd` from `execute_task` in `BaseExecutor` (and `MPIExecutor`) 

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- NA

# Testing

# Screenshots
**Task status updating from RUNNING to FAILED**
![Task_RUNNING](https://github.com/slac-lcls/lute/assets/18701604/8e8d5e22-8b4f-4d0a-b6bd-d2969481965c)

![Task_FAILED](https://github.com/slac-lcls/lute/assets/18701604/7e780508-e0ff-45b7-b1fe-9d67f1e661b1)

**Task logs available in `launch_airflow.py` eLog output**
![logs_1](https://github.com/slac-lcls/lute/assets/18701604/44d667de-a244-468f-b352-ef1f7cdd561c)
![logs_2](https://github.com/slac-lcls/lute/assets/18701604/3eca54e8-69e2-4cb2-b49c-09a2326d7bb5)


