### PR TITLE
ENH Task definitions and backend changes for full SFX processing

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,8 +4,9 @@ on: [push, pull_request]
 jobs:
   format:
     runs-on: ubuntu-latest
-    options: "--check --verbose"
-    src: "./lute"
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./lute"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   format:
     runs-on: ubuntu-latest
+    options: "--check --verbose"
+    src: "./lute"
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,9 @@
+name: Black-format
+on: [push, pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      uses: actions/checkout@v3
+      uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--check --verbose"
+          options: "--verbose"
           src: "./lute"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,5 +5,5 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      uses: actions/checkout@v3
-      uses: psf/black@stable
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -121,4 +121,15 @@ TestBinary:
 TestSocket:
   array_size: 8000 # Size of arrays to send. 8000 floats ~ 6.4e4
   num_arrays: 10 # Number of arrays to send.
+
+IndexCrystFEL:
+  #in_file: ""            # Location of a CXI file
+  #out_file: ""           # Where to write the output stream file
+  geometry: ""            # Location of a geometry file
+  indexing: "mosflm"      # Indexing methods
+  int_radius: "4,5,7"     # Integration radii
+  tolerance: "5,5,5,1.5"  # Tolerances
+  multi: True
+  profile: True
+  no_revalidate: True
 ...

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -123,7 +123,7 @@ TestSocket:
   num_arrays: 10 # Number of arrays to send.
 
 IndexCrystFEL:
-  #in_file: ""            # Location of a CXI file
+  #in_file: ""            # Location of a `.lst` file listing CXI files
   #out_file: ""           # Where to write the output stream file
   geometry: ""            # Location of a geometry file
   indexing: "mosflm"      # Indexing methods

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -132,4 +132,11 @@ IndexCrystFEL:
   multi: True
   profile: True
   no_revalidate: True
+
+MergePartialator:
+  #in_file: ""
+  #out_file: ""
+  #model: "unity"
+  #niter: 1
+  symmetry: "mmm"
 ...

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -139,4 +139,12 @@ MergePartialator:
   #model: "unity"
   #niter: 1
   symmetry: "mmm"
+
+CompareHKL:
+  #in_files: ""
+  #fom: "Rsplit"
+  #nshells: 10
+  #shell_file: ""
+  #cell_file: ""
+  symmetry: "mmm"
 ...

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -122,6 +122,32 @@ TestSocket:
   array_size: 8000 # Size of arrays to send. 8000 floats ~ 6.4e4
   num_arrays: 10 # Number of arrays to send.
 
++FindPeaksPyAlgos:
++    outdir: ""
++    n_events: 100
++    det_name: "Rayonix"
++    event_receiver: "evr0"
++    tag: "red"
++    event_logic: false
++    psana_mask: false
++    mask_file: null
++    min_peaks: 10
++    max_peaks: 2048
++    npix_min: 2
++    npix_max: 30
++    amax_thr: 40
++    atot_thr: 180
++    son_min: 3.0
++    peak_rank: 3
++    r0: 3.0
++    dr: 2.0
++    nsigm: 10.0
++    compression:
++        compressor: "sz3"
++        abs_error: 10.0
++        bin_size: 2
++        roi_window_size: 9
+
 IndexCrystFEL:
   #in_file: ""            # Location of a `.lst` file listing CXI files
   #out_file: ""           # Where to write the output stream file

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -147,4 +147,11 @@ CompareHKL:
   #shell_file: ""
   #cell_file: ""
   symmetry: "mmm"
+
+#ManipulateHKL:
+  #output_format: "mtz"
+  #out_file: "..."
+
+DimpleSolve:
+  pdb: "/path/to/pdb"
 ...

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -52,7 +52,7 @@ The `Executor` table contains information on the environment provided to the `Ex
 | `communicator_desc` | Description of the Communicators used.                                                                                                                                            |
 |                     |                                                                                                                                                                                   |
 
-**NOTE**: The `env` column is currently being ignored while a method is decided on to choose appropriate environment variables to save.
+**NOTE**: The `env` column currently only stores variables related to `SLURM` or `LUTE` itself.
 
 ### `Task` tables
 For every `Task` a table of the following format will be created. The exact number of columns will depend on the specific `Task`, as the number of parameters can vary between them, and each parameter gets its own column. Within a table, multiple experiments and runs can coexist. The experiment and run are not recorded directly. Instead the first two columns point to the id of entries in the general configuration and `Executor` tables respectively. The general configuration table entry will contain the experiment and run information.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -23,9 +23,11 @@ A brief overview of parameters objects will be provided below. The following inf
 
 All `Task`s have a corresponding `TaskParameters` object. These objects are linked **exclusively** by a named relationship. For a `Task` named `MyBinaryTask`, the parameters object **must** be named `MyBinaryTaskParameters`. For third-party `Task`s there are a number of additional requirements:
 - The model must inherit from a base class called `BaseBinaryParameters`.
-- The model must have one field specified called `executable`. The presence of this field indicates that the `Task` is a third-party `Task`. This allows all third-party `Task`s to be defined exclusively by their parameters model. A single `BinaryTask` class handles execution of **all** third-party `Task`s.
+- The model must have one field specified called `executable`. The presence of this field indicates that the `Task` is a third-party `Task` and the specified executable must be called. This allows all third-party `Task`s to be defined exclusively by their parameters model. A single `BinaryTask` class handles execution of **all** third-party `Task`s.
 
 All models are stored in `lute/io/models`. For any given `Task`, a new model can be added to an existing module contained in this directory or to a new module. If creating a new module, make sure to add an import statement to `lute.io.models.__init__`.
+
+**Defining `TaskParameter`s**
 
 When specifying parameters the default behaviour is to provide a one-to-one correspondance between the Python attribute specified in the parameter model, and the parameter specified on the command-line. Single-letter attributes are assumed to be passed using `-`, e.g. `n` will be passed as `-n` when the executable is launched. Longer attributes are passed using `--`, e.g. by default a model attribute named `my_arg` will be passed on the command-line as `--my_arg`. Positional arguments are specified using `p_argX` where `X` is a number. All parameters are passed in the order that they are specified in the model.
 
@@ -33,7 +35,9 @@ However, because the number of possible command-line combinations is large, rely
 
 ```py
 
-from pydantic import Field, validator # Also include any pydantic type specifications
+from pydantic import Field, validator
+# Also include any pydantic type specifications - Pydantic has many custom
+# validation types already, e.g. types for constrained numberic values, URL handling, etc.
 
 from .base import BaseBinaryParameters
 
@@ -51,23 +55,178 @@ class RunTaskParameters(BaseBinaryParameters):
     # param1: param1Type = Field("default", description="", ...)
 ```
 
+Under the class definition for `Config` in the model, we can modify global options for all the parameters. Currently, the available configuration options are:
 
 | **Config Parameter** | **Meaning**                                                       | **Default Value** |
 |:--------------------:|:-----------------------------------------------------------------:|:-----------------:|
 | `short_flags_use_eq` | Use equals sign instead of space for arguments of `-` parameters. | `False`           |
-| `long_flags_use_eq`  | Use equals sign instead of space for arguments of `-` parameters. |                   |
+| `long_flags_use_eq`  | Use equals sign instead of space for arguments of `-` parameters. | `False`           |
+|                      |                                                                   |                   |
 
+These configuration options modify how the parameter models are parsed and passed along on the command-line. The default behaviour is that parameters are assumed to be passed as `-p arg` and `--param arg`. Setting the above options to `True` will mean that all parameters are instead passed as `-p=arg` and `--param=arg`.
 
-| **Field Parameter** | **Meaning**                                                                       | **Default Value** | **Example**                                  |
-|:-------------------:|:---------------------------------------------------------------------------------:|:-----------------:|:--------------------------------------------:|
-| `flag_type`         | Specify the type of flag for passing this argument. One of `"-"`, `"--"`, or `""` | N/A               | `p_arg1 = Field(..., flag_type="")`          |
-| `rename_param`      | Change the name of the parameter as passed on the command-line.                   | N/A               | `my_arg = Field(..., rename_param="my-arg")` |
-|                     |                                                                                   |                   |                                              |
+In addition to the global configuration options there are a couple of ways to specify individual parameters. The following `Field` attributes are used when parsing the model:
+
+| **Field Attribute** | **Meaning**                                                                       | **Default Value** | **Example**                                       |
+|:-------------------:|:---------------------------------------------------------------------------------:|:-----------------:|:-------------------------------------------------:|
+| `flag_type`         | Specify the type of flag for passing this argument. One of `"-"`, `"--"`, or `""` | N/A               | `p_arg1 = Field(..., flag_type="")`               |
+| `rename_param`      | Change the name of the parameter as passed on the command-line.                   | N/A               | `my_arg = Field(..., rename_param="my-arg")`      |
+| `description`       | Documentation of the parameter's usage or purpose.                                | N/A               | `arg = Field(..., description="Argument for...")` |
+|                     |                                                                                   |                   |                                                   |
+
+The `flag_type` attribute allows us to specify whether the parameter corresponds to a positional (`""`) command line argument, requires a single hyphen (`"-"`), or a double hyphen (`"--"`). By default, the parameter name is passed as-is on the command-line. However, command-line arguments can have characters which would not be valid in Python variable names. In particular, hyphens are frequently used. To handle this case, the `rename_param` attribute can be used to specify an alternative spelling of the parameter when it is passed on the command-line. This also allows for using more descriptive variable names internally than those used on the command-line. A `description` can also be provided for each Field to document the usage and purpose of that particular parameter.
+
+As an example, we can again consider defining a model for a `RunTask` `Task`. Consider an executable which would normally be called from the command-line as follows:
+```bash
+/sdf/group/lcls/ds/tools/runtask -n <nthreads> --method=<algorithm> -p <algo_param> [--debug]
+```
+
+A model specification for this `Task` may look like:
+```py
+class RunTaskParameters(BaseBinaryParameters):
+    """Parameters for the runtask binary."
+
+    class Config(BaseBinaryParameters.Config):
+        long_flags_use_eq: bool = True  # For the --method parameter
+
+    # Prefer using full/absolute paths where possible.
+    # No flag_type needed for this field
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/runtask", description="Runtask Binary v1.0"
+    )
+
+    # We can provide a more descriptive name for -n
+    # Let's assume it's a number of threads, or processes, etc.
+    num_threads: int = Field(
+        1, description="Number of concurrent threads.", flag_type="-", rename_param="n"
+    )
+
+    # In this case we will use the Python variable name directly when passing
+    # the parameter on the command-line
+    method: str = Field("algo1", description="Algorithm to use.", flag_type="--")
+
+    # For an actual parameter we would probably have a better name. Lets assume
+    # This parameter (-p) modifies the behaviour of the method above.
+    method_param1: int = Field(
+        3, description="Modify method performance.", flag_type="-", rename_param="p"
+    )
+
+    # Boolean flags are only passed when True! `--debug` is an optional parameter
+    # which is not followed by any arguments.
+    debug: bool = Field(
+        False, description="Whether to run in debug mode.", flag_type="--"
+    )
+```
+
+**Additional Comments**
+1. Model parameters of type `bool` are not passed with an argument and are only passed when `True`. This is a common use-case for boolean flags which enable things like test or debug modes, verbosity or reporting features. E.g. `--debug`, `--test`, `--verbose`, etc.
+  - If you need to pass the literal words `"True"` or `"False"`, use a parameter of type `str`.
+2. You can use `pydantic` types to constrain parameters beyond the basic Python types. E.g. `conint` can be used to define lower and upper bounds for an integer. There are also types for common categories, positive/negative numbers, paths, URLs, IP addresses, etc.
+  - Even more custom behaviour can be achieved with `validator`s (see below).
+3. All `TaskParameters` objects and its subclasses have access to a `lute_config` parameter, which is of type `lute.io.models.base.AnalysisHeader`. This special parameter is ignored when constructing the call for a binary task, but it provides access to shared/common parameters between tasks. For example, the following parameters are available through the `lute_config` object, and may be of use when constructing validators. All fields can be accessed with `.` notation. E.g. `lute_config.experiment`.
+  - `title`: A user provided title/description of the analysis.
+  - `experiment`: The current experiment name
+  - `run`: The current acquisition run number
+  - `date`: The date of the experiment or the analysis.
+  - `lute_version`: The version of the software you are running.
+  - `task_timeout`: How long a `Task` can run before it is killed.
+  - `work_dir`: The main working directory for LUTE. Files and the database are created relative to this directory.
+
+**Validators**
+Pydantic uses `validators` to determine whether a value for a specific field is appropriate. There are default validators for all the standard library types and the types specified within the pydantic package; however, it is straightforward to define custom ones as well. In the template code-snippet above we imported the `validator` decorator. To create our own validator we define a method (with any name) with the following prototype, and decorate it with the `validator` decorator:
+```py
+@validator("name_of_field_to_decorate")
+def my_custom_validator(cls, field: Any, values: Dict[str, Any]) -> Any: ...
+```
+In this snippet, the `field` variable corresponds to the value for the specific field we want to validate. `values` is a dictionary of fields and their values which have been parsed prior to the current field. This means you can validate the value of a parameter based on the values provided for other parameters. Since pydantic always validates the fields in the order they are defined in the model, fields dependent on other fields should come later in the definition.
+
+For example, consider the `method_param1` field defined above for `RunTask`. We can provide a custom validator which changes the default value for this field depending on what type of algorithm is specified for the `--method` option. We will also constrain the options for `method` to two specific strings.
+
+```py
+from pydantic import Field, validator, ValidationError
+class RunTaskParameters(BaseBinaryParameters):
+    """Parameters for the runtask binary."""
+
+    # [...]
+
+    # In this case we will use the Python variable name directly when passing
+    # the parameter on the command-line
+    method: str = Field("algo1", description="Algorithm to use.", flag_type="--")
+
+    # For an actual parameter we would probably have a better name. Lets assume
+    # This parameter (-p) modifies the behaviour of the method above.
+    method_param1: Optional[int] = Field(
+        description="Modify method performance.", flag_type="-", rename_param="p"
+    )
+
+    # We will only allow method to take on one of two values
+    @validator("method")
+    def validate_method(cls, method: str, values: Dict[str, Any]) -> str:
+        """Method validator: --method can be algo1 or algo2."""
+
+        valid_methods: List[str] = ["algo1", "algo2"]
+        if method not in valid_methods:
+            raise ValueError("method must be algo1 or algo2")
+        return method
+
+    # Lets change the default value of `method_param1` depending on `method`
+    # NOTE: We didn't provide a default value to the Field above and made it
+    # optional. We can use this to test whether someone is purposefully
+    # overriding the value of it, and if not, set the default ourselves.
+    # We set `always=True` since pydantic will normally not use the validator
+    # if the default is not changed
+    @validator("method_param1", always=True)
+    def validate_method_param1(cls, param1: Optional[int], values: Dict[str, Any]) -> int:
+        """method param1 validator"""
+
+        # If someone actively defined it, lets just return that value
+        # We could instead do some additional validation to make sure that the
+        # value they provided is valid...
+        if param1 is not None:
+            return param1
+
+        # method_param1 comes after method, so this will be defined, or an error
+        # would have been raised.
+        method: str = values['method']
+        if method == "algo1":
+            return 3
+        elif method == "algo2":
+            return 5
+```
 
 #### FAQ
 1. How can I specify a default value which depends on another parameter?
-2. My new `Task` depends on the output of a previous `Task`, how can I specify this dependency?
 
+Use a custom validator. The example above shows how to do this. The parameter that depends on another parameter must come LATER in the model defintion than the independent parameter.
+
+2. My new `Task` depends on the output of a previous `Task`, how can I specify this dependency?
+Parameters used to run a `Task` are recorded in a database for every `Task`. It is also recorded whether or not the execution of that specific parameter set was successful. A utility function is provided to access the most recent values from the database for a specific parameter of a specific `Task`. It can also be used to specify whether unsuccessful `Task`s should be included in the query. This utility can be used within a validator to specify dependencies. For example, suppose the input of `RunTask2` (parameter `input`) depends on the output location of `RunTask1` (parameter `outfile`). A validator of the following type can be used to retrieve the output file and make it the default value of the input parameter.
+
+```py
+from pydantic import Field, validator
+
+from .base import BaseBinaryParameters
+from ..db import read_latest_db_entry
+
+class RunTask2Parameters(BaseBinaryParameters):
+    input: str = Field("", description="Input file.", flag_type="--")
+
+    @validator("input")
+    def validate_input(cls, input: str, values: Dict[str, Any]) -> str:
+        if input == "":
+            task1_out: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}",  # Working directory. We search for the database here.
+                "RunTask1",                           # Name of Task we want to look up
+                "outfile",                            # Name of parameter of the Task
+                valid_only=True,                      # We only want valid output files.
+            )
+            # read_latest_db_entry returns None if nothing is found
+            if task1_out is not None:
+                return task1_out
+        return input
+```
+
+There are more examples of this pattern spread throughout the various `Task` models.
 
 ## Creating a "First-Party" `Task`
 ### Specifying a `TaskParameters` Model for your `Task`.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -1,0 +1,69 @@
+# Integrating a New `Task`
+
+`Task`s can be broadly categorized into two types:
+- "First-party" - where the analysis or executed code is maintained within this library.
+- "Third-party" - where the analysis, code, or program is maintained elsewhere and is simply called by a wrapping `Task`.
+
+Creating a new `Task` of either type generally involves the same steps, although for first-party `Task`s, the analysis code must of course also be written. Due to this difference, as well as additional considerations for parameter handling when dealing with "third-party" `Task`s, the "first-party" and "third-party" `Task` integration cases will be considered separately.
+
+## Creating a "Third-party" `Task`
+
+There are two required steps for third-party `Task` integration, and one additional step which is optional, and may not be applicable to all possible third-party `Task`s. Generally, `Task` integration requires:
+1. Defining a `TaskParameters` (pydantic) model which fully parameterizes the `Task`. This involves specifying a path to a binary, and all the required command-line arguments to run the binary.
+2. Creating a **managed `Task`** by specifying an `Executor` for the new third-party `Task`. At this stage, any additional environment variables can be added which are required for the execution environment.
+3. **(Optional/Maybe applicable)** Create a template for a third-party configuration file. If the new `Task` has its own configuration file, specifying a template will allow that file to be parameterized from the singular LUTE yaml configuration file. A couple of minor additions to the `pydantic` model specified in 1. are required to support template usage.
+
+Each of these stages will be discussed in detail below. The vast majority of the work is completed in step 1.
+
+### Specifying a `TaskParameters` Model for your `Task`.
+
+A brief overview of parameters objects will be provided below. The following information goes into detail only about specifics related to LUTE configuration. An in depth description of pydantic is beyond the scope of this tutorial; please refer to the [official documentation](https://docs.pydantic.dev/1.10/) for more information. Please note that due to environment constraints pydantic is currently pinned to version 1.10! Make sure to read the appropriate documentation for this version as many things are different compared to the newer releases. At the end this document there will be an example highlighting some supported behaviour as well as a FAQ to address some common integration considerations.
+
+**`Task`s and `TaskParameter`s**
+
+All `Task`s have a corresponding `TaskParameters` object. These objects are linked **exclusively** by a named relationship. For a `Task` named `MyBinaryTask`, the parameters object **must** be named `MyBinaryTaskParameters`. For third-party `Task`s there are a number of additional requirements:
+- The model must inherit from a base class called `BaseBinaryParameters`.
+- The model must have one field specified called `executable`. The presence of this field indicates that the `Task` is a third-party `Task`. This allows all third-party `Task`s to be defined exclusively by their parameters model. A single `BinaryTask` class handles execution of **all** third-party `Task`s.
+
+All models are stored in `lute/io/models`. For any given `Task`, a new model can be added to an existing module contained in this directory or to a new module. If creating a new module, make sure to add an import statement to `lute.io.models.__init__`.
+
+When specifying parameters the default behaviour is to provide a one-to-one correspondance between the Python attribute specified in the parameter model, and the parameter specified on the command-line. Single-letter attributes are assumed to be passed using `-`, e.g. `n` will be passed as `-n` when the executable is launched. Longer attributes are passed using `--`, e.g. by default a model attribute named `my_arg` will be passed on the command-line as `--my_arg`. Positional arguments are specified using `p_argX` where `X` is a number. All parameters are passed in the order that they are specified in the model.
+
+However, because the number of possible command-line combinations is large, relying on the default behaviour above is **NOT recommended**. It is provided solely as a fallback. Instead, there are a number of configuration knobs which can be tuned to achieve the desired behaviour. The two main mechanisms for controlling behaviour are specification of model-wide configuration under the `Config` class within the model's definition, and parameter-by-parameter configuration using field attributes. For the latter, we define all parameters as `Field` objects. This allows parameters to have their own attributes, which are parsed by LUTE's task-layer. Given this, the preferred starting template for a `TaskParameters` model is the following - we assume we are integrating a new `Task` called `RunTask`:
+
+```py
+
+from pydantic import Field, validator # Also include any pydantic type specifications
+
+from .base import BaseBinaryParameters
+
+# Change class name as necessary
+class RunTaskParameters(BaseBinaryParameters):
+    """Parameters for RunTask..."""
+
+    class Config(BaseBinaryParameters.Config): # MUST be exactly as written here.
+        ...
+        # Model-wide configuration will go here
+
+    executable: str = Field("/path/to/executable", description="...")
+    ...
+    # Additional params.
+    # param1: param1Type = Field("default", description="", ...)
+```
+
+
+| **Config Parameter** | **Meaning**                                                       | **Default Value** |
+|:--------------------:|:-----------------------------------------------------------------:|:-----------------:|
+| `short_flags_use_eq` | Use equals sign instead of space for arguments of `-` parameters. | `False`           |
+| `long_flags_use_eq`  | Use equals sign instead of space for arguments of `-` parameters. |                   |
+
+
+| **Field Parameter** | **Meaning**                                                                       | **Default Value** | **Example**                                  |
+|:-------------------:|:---------------------------------------------------------------------------------:|:-----------------:|:--------------------------------------------:|
+| `flag_type`         | Specify the type of flag for passing this argument. One of `"-"`, `"--"`, or `""` | N/A               | `p_arg1 = Field(..., flag_type="")`          |
+| `rename_param`      | Change the name of the parameter as passed on the command-line.                   | N/A               | `my_arg = Field(..., rename_param="my-arg")` |
+|                     |                                                                                   |                   |                                              |
+
+#### FAQ
+1. How can I specify a default value which depends on another parameter?
+2. My new `Task` depends on the output of a previous `Task`, how can I specify this dependency?

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -67,3 +67,21 @@ class RunTaskParameters(BaseBinaryParameters):
 #### FAQ
 1. How can I specify a default value which depends on another parameter?
 2. My new `Task` depends on the output of a previous `Task`, how can I specify this dependency?
+
+
+## Creating a "First-Party" `Task`
+### Specifying a `TaskParameters` Model for your `Task`.
+Parameter models have a format that must be followed for "Third-Party" `Task`s, but "First-Party" `Task`s have a little more liberty in how parameters are dealt with, since the `Task` will do all the parsing itself.
+
+To create a model, the basic steps are:
+1. If necessary, create a new module (e.g. `new_task_category.py`) under `lute.io.models`, or find an appropriate pre-existing module in that directory.
+  - An `import` statement must be added to `lute.io.models._init_` if a new module is created, so it can be found.
+  - If defining the model in a pre-existing module, make sure to modify the `__all__` statement to include it.
+2. Create a new model that inherits from `TaskParameters`. You can look at `lute.models.io.tests.TestReadOutputParameters` for an example. **The model must be named** `<YourTaskName>Parameters`
+  - You should include **all** relevant parameters here, including input file, output file, and any potentially adjustable parameters. These parameters **must** be included even if there are some implicit dependencies between `Task`s and it would make sense for the parameter to be auto-populated based on some other output. Creating this dependency is done with validators (see step 3.). All parameters should be overridable, and all `Task`s should be fully-independently configurable, based solely on their model and the configuration YAML.
+  - To follow the preferred format, parameters should be defined as: `param_name: type = Field([default value], description="This parameter does X.")`
+3. Use validators to do more complex things for your parameters, including populating default values dynamically:
+  - E.g. create default values that depend on other parameters in the model - see for example: [SubmitSMDParameters](https://github.com/slac-lcls/lute/blob/57f2a0889ec9603e3b8642f485c27df7d1f6e96f/lute/io/models/smd.py#L139).
+  - E.g. create default values that depend on other `Task`s by reading from the database - see for example: [TestReadOutputParameters](https://github.com/slac-lcls/lute/blob/57f2a0889ec9603e3b8642f485c27df7d1f6e96f/lute/io/models/tests.py#L75).
+4. The model will have access to some general configuration values by inheriting from `TaskParameters`. These parameters are all stored in `lute_config` which is an instance of `AnalysisHeader` ([defined here](https://github.com/slac-lcls/lute/blob/57f2a0889ec9603e3b8642f485c27df7d1f6e96f/lute/io/models/base.py#L42)).
+  - For example, the experiment and run number can be obtained from this object and a validator could use these values to define the default input file for the `Task`.

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -497,7 +497,8 @@ class MPIExecutor(Executor):
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 
         py_cmd: str = ""
-        mpi_cmd: str = f"mpirun -np {int(os.environ.get('SLURM_NPROCS', len(os.sched_getaffinity(0)))) - 1}"
+        nprocs: int = max(int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1)
+        mpi_cmd: str = f"mpirun -np {nprocs}"
         if __debug__:
             py_cmd = f"python -B -u -m mpi4py.run {executable_path} {params}"
         else:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -215,6 +215,7 @@ class BaseExecutor(ABC):
                         " Options are: prepend, append, overwrite."
                     )
                 )
+        os.environ.update(env)
         self._analysis_desc.task_env.update(env)
 
     def source_env(self, env: str) -> None:
@@ -286,7 +287,7 @@ class BaseExecutor(ABC):
         if lute_path is None:
             logger.debug("Absolute path to subprocess.py not found.")
             lute_path = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
-            os.environ["LUTE_PATH"] = lute_path
+            self.update_environment({"LUTE_PATH": lute_path})
         executable_path: str = f"{lute_path}/subprocess_task.py"
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -259,7 +259,13 @@ class BaseExecutor(ABC):
 
     def execute_task(self) -> None:
         """Run the requested Task as a subprocess."""
-        executable_path: str = "subprocess_task.py"
+        lute_path: Optional[str] = os.getenv("LUTE_PATH")
+        executable_path: str
+        if lute_path is not None:
+            executable_path = f"{lute_path}/subprocess_task.py"
+        else:
+            logger.debug("Absolute path to subprocess.py not found.")
+            executable_path = "subprocess_task.py"
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 
@@ -450,7 +456,13 @@ class MPIExecutor(Executor):
 
     def execute_task(self) -> None:
         """Run the requested Task as a subprocess."""
-        executable_path: str = "subprocess_task.py"
+        lute_path: Optional[str] = os.getenv("LUTE_PATH")
+        executable_path: str
+        if lute_path is not None:
+            executable_path = f"{lute_path}/subprocess_task.py"
+        else:
+            logger.debug("Absolute path to subprocess.py not found.")
+            executable_path = "subprocess_task.py"
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -234,7 +234,7 @@ class BaseExecutor(ABC):
         script: str = (
             f"set -a\n"
             f'source "{env}" >/dev/null\n'
-            f'{sys.executable} -c "import os; print(os.environ)"\n'
+            f'{sys.executable} -c "import os; print(dict(os.environ))"\n'
         )
         logger.info(f"Sourcing file {env}")
         o, e = subprocess.Popen(

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -278,7 +278,7 @@ class BaseExecutor(ABC):
         """Run the requested Task as a subprocess."""
         lute_path: Optional[str] = os.getenv("LUTE_PATH")
         if lute_path is None:
-            logger.debug("Absolute path to subprocess.py not found.")
+            logger.debug("Absolute path to subprocess_task.py not found.")
             lute_path = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
             self.update_environment({"LUTE_PATH": lute_path})
         executable_path: str = f"{lute_path}/subprocess_task.py"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -211,7 +211,7 @@ class BaseExecutor(ABC):
         os.environ.update(env)
         self._analysis_desc.task_env.update(env)
 
-    def shell_source(self, env: str) -> None:
+    def source_env(self, env: str) -> None:
         """Source a script.
 
         Unlike `update_environment` this method sources a new file.

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -211,7 +211,7 @@ class BaseExecutor(ABC):
         os.environ.update(env)
         self._analysis_desc.task_env.update(env)
 
-    def source_env(self, env: str) -> None:
+    def shell_source(self, env: str) -> None:
         """Source a script.
 
         Unlike `update_environment` this method sources a new file.

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -89,26 +89,19 @@ class BaseExecutor(ABC):
         signal.
         """
 
-        def no_pickle_mode(self: Self, msg: Message):
-            ...
+        def no_pickle_mode(self: Self, msg: Message): ...
 
-        def task_started(self: Self, msg: Message):
-            ...
+        def task_started(self: Self, msg: Message): ...
 
-        def task_failed(self: Self, msg: Message):
-            ...
+        def task_failed(self: Self, msg: Message): ...
 
-        def task_stopped(self: Self, msg: Message):
-            ...
+        def task_stopped(self: Self, msg: Message): ...
 
-        def task_done(self: Self, msg: Message):
-            ...
+        def task_done(self: Self, msg: Message): ...
 
-        def task_cancelled(self: Self, msg: Message):
-            ...
+        def task_cancelled(self: Self, msg: Message): ...
 
-        def task_result(self: Self, msg: Message):
-            ...
+        def task_result(self: Self, msg: Message): ...
 
     def __init__(
         self,
@@ -199,13 +192,13 @@ class BaseExecutor(ABC):
         if "PATH" in env:
             sep: str = os.pathsep
             if update_path == "prepend":
-                env[
-                    "PATH"
-                ] = f"{env['PATH']}{sep}{self._analysis_desc.task_env['PATH']}"
+                env["PATH"] = (
+                    f"{env['PATH']}{sep}{self._analysis_desc.task_env['PATH']}"
+                )
             elif update_path == "append":
-                env[
-                    "PATH"
-                ] = f"{self._analysis_desc.task_env['PATH']}{sep}{env['PATH']}"
+                env["PATH"] = (
+                    f"{self._analysis_desc.task_env['PATH']}{sep}{env['PATH']}"
+                )
             elif update_path == "overwrite":
                 pass
             else:
@@ -411,23 +404,19 @@ class Executor(BaseExecutor):
 
         self.add_hook("task_started", task_started)
 
-        def task_failed(self: Executor, msg: Message):
-            ...
+        def task_failed(self: Executor, msg: Message): ...
 
         self.add_hook("task_failed", task_failed)
 
-        def task_stopped(self: Executor, msg: Message):
-            ...
+        def task_stopped(self: Executor, msg: Message): ...
 
         self.add_hook("task_stopped", task_stopped)
 
-        def task_done(self: Executor, msg: Message):
-            ...
+        def task_done(self: Executor, msg: Message): ...
 
         self.add_hook("task_done", task_done)
 
-        def task_cancelled(self: Executor, msg: Message):
-            ...
+        def task_cancelled(self: Executor, msg: Message): ...
 
         self.add_hook("task_cancelled", task_cancelled)
 
@@ -497,7 +486,9 @@ class MPIExecutor(Executor):
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 
         py_cmd: str = ""
-        nprocs: int = max(int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1)
+        nprocs: int = max(
+            int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1
+        )
         mpi_cmd: str = f"mpirun -np {nprocs}"
         if __debug__:
             py_cmd = f"python -B -u -m mpi4py.run {executable_path} {params}"

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -118,8 +118,7 @@ class Communicator(ABC):
     def __enter__(self) -> Self:
         return self
 
-    def __exit__(self) -> None:
-        ...
+    def __exit__(self) -> None: ...
 
     def stage_communicator(self):
         """Alternative method for staging outside of context manager."""

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -162,34 +162,31 @@ class PipeCommunicator(Communicator):
         Returns:
             msg (Message): The message read, containing contents and signal.
         """
-        if self._use_pickle:
-            signal: bytes = proc.stderr.read()
-            if signal is not None:
-                signal: str = signal.decode()
-            raw_contents: bytes = proc.stdout.read()
-            if raw_contents:
-                try:
-                    contents: Any = pickle.loads(raw_contents)
-                except pickle.UnpicklingError as err:
-                    # Can occur if Task switches to unpickled mode before the
-                    # Executor can
-                    self._use_pickle = False
-                    contents: str = raw_contents.decode()
-            else:
-                contents: str = ""
+        signal: Optional[str]
+        contents: Optional[str]
+        raw_signal: bytes = proc.stderr.read()
+        raw_contents: bytes = proc.stdout.read()
+        if raw_signal is not None:
+            signal = raw_signal.decode()
         else:
-            signal: bytes = proc.stderr.read()
-            if signal is not None:
+            signal = raw_signal
+        if raw_contents:
+            if self._use_pickle:
                 try:
-                    signal: str = signal.decode()
-                except UnicodeDecodeError as err:
-                    signal: str = pickle.loads(signal)
-            contents: bytes = proc.stdout.read()
-            if contents is not None:
+                    contents = pickle.loads(raw_contents)
+                except pickle.UnpicklingError as err:
+                    logger.debug("PipeCommunicator (Executor) - Set _use_pickle=False")
+                    self._use_pickle = False
+                    contents = self._safe_unpickle_decode(raw_contents)
+            else:
                 try:
-                    contents: str = contents.decode()
+                    contents = raw_contents.decode()
                 except UnicodeDecodeError as err:
-                    contents: str = pickle.loads(contents)
+                    logger.debug("PipeCommunicator (Executor) - Set _use_pickle=True")
+                    self._use_pickle = True
+                    contents = self._safe_unpickle_decode(raw_contents)
+        else:
+            contents = None
 
         if signal and signal not in LUTE_SIGNALS:
             # Some tasks write on stderr
@@ -199,8 +196,67 @@ class PipeCommunicator(Communicator):
                 contents = f"({signal})"
             else:
                 contents = f"{contents} ({signal})"
-            signal: str = ""
+            signal = None
         return Message(contents=contents, signal=signal)
+
+    def _safe_unpickle_decode(self, maybe_mixed: bytes) -> Optional[str]:
+        """This method is used to unpickle and/or decode a bytes object.
+
+        It attempts to handle cases where contents can be mixed, i.e., part of
+        the message must be decoded and the other part unpickled. It handles
+        only two-way splits. If there are more complex arrangements such as:
+        <pickled>:<unpickled>:<pickled> etc, it will give up.
+
+        The simpler two way splits are unlikely to occur in normal usage. They
+        may arise when debugging if, e.g., `print` statements are mixed with the
+        usage of the `_report_to_executor` method.
+
+        Note that this method works because ONLY text data is assumed to be
+        sent via the pipes. The method needs to be revised to handle non-text
+        data if the `Task` is modified to also send that via PipeCommunicator.
+        The use of pickle is supported to provide for this option if it is
+        necessary. It may be deprecated in the future.
+
+        Be careful when making changes. This method has seemingly redundant
+        checks because unpickling will not throw an error if a full object can
+        be retrieved. That is, the library will ignore extraneous bytes. This
+        method attempts to retrieve that information if the pickled data comes
+        first in the stream.
+
+        Args:
+            maybe_mixed (bytes): A bytes object which could require unpickling,
+                decoding, or both.
+
+        Returns:
+            contents (Optional[str]): The unpickled/decoded contents if possible.
+                Otherwise, None.
+        """
+        contents: Optional[str]
+        try:
+            contents = pickle.loads(maybe_mixed)
+            repickled: bytes = pickle.dumps(contents)
+            if len(repickled) < len(maybe_mixed):
+                # Successful unpickling, but pickle stops even if there are more bytes
+                additional_data: str = maybe_mixed[len(repickled) :].decode()
+                contents = f"{contents}{additional_data}"
+        except pickle.UnpicklingError as err:
+            try:
+                contents = maybe_mixed.decode()
+            except UnicodeDecodeError as err2:
+                try:
+                    contents = maybe_mixed[: err2.start].decode()
+                    contents = f"{contents}{pickle.loads(maybe_mixed[err2.start:])}"
+                except Exception as err3:
+                    logger.debug(
+                        f"PipeCommunicator unable to decode/parse data! {err3}"
+                    )
+                    contents = None
+        except UnicodeDecodeError as err3:
+            missing_bytes: int = len(maybe_mixed) - len(repickled)
+            logger.debug(
+                f"PipeCommunicator has truncated message. Unable to retrieve {missing_bytes} bytes."
+            )
+        return contents
 
     def write(self, msg: Message) -> None:
         """Write to stdout and stderr.

--- a/lute/io/_sqlite.py
+++ b/lute/io/_sqlite.py
@@ -284,8 +284,12 @@ def _add_row_no_duplicate(
 def _select_from_db(
     con: sqlite3.Connection, table_name: str, col_name: str, condition: Dict[str, str]
 ) -> Optional[Any]:
-    param, val = next(iter(condition.items()))
-    sql: str = f"SELECT {col_name} FROM {table_name} WHERE {param} = {val}"
+    sql: str
+    if condition:
+        param, val = next(iter(condition.items()))
+        sql = f"SELECT {col_name} FROM {table_name} WHERE {param} = {val}"
+    else:
+        sql = f"SELECT {col_name} FROM {table_name}"
     with con:
         res: sqlite3.Cursor = con.execute(sql)
         entries: List[Any] = res.fetchall()

--- a/lute/io/_sqlite.py
+++ b/lute/io/_sqlite.py
@@ -283,10 +283,10 @@ def _add_row_no_duplicate(
 
 def _select_from_db(
     con: sqlite3.Connection, table_name: str, col_name: str, condition: Dict[str, str]
-) -> Any:
+) -> Optional[Any]:
     param, val = next(iter(condition.items()))
     sql: str = f"SELECT {col_name} FROM {table_name} WHERE {param} = {val}"
     with con:
         res: sqlite3.Cursor = con.execute(sql)
         entries: List[Any] = res.fetchall()
-    return entries[-1][0]
+    return entries[-1][0] if entries else None

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -20,7 +20,7 @@ __all__ = ["record_analysis_db", "read_latest_db_entry"]
 __author__ = "Gabriel Dorlhiac"
 
 import logging
-from typing import List, Dict, Dict, Any, Tuple
+from typing import List, Dict, Dict, Any, Tuple, Optional
 
 from .models.base import TaskParameters
 from ..tasks.dataclasses import TaskResult, TaskStatus, DescribedAnalysis
@@ -257,7 +257,7 @@ def record_analysis_db(cfg: DescribedAnalysis) -> None:
         _add_task_entry(con, task_name, full_task_entry)
 
 
-def read_latest_db_entry(db_dir: str, task_name: str, param: str) -> Any:
+def read_latest_db_entry(db_dir: str, task_name: str, param: str) -> Optional[Any]:
     """Read most recent value entered into the database for a Task parameter.
 
     (Will be updated for schema compliance as well as Task name.)
@@ -271,13 +271,16 @@ def read_latest_db_entry(db_dir: str, task_name: str, param: str) -> Any:
 
     Returns:
         val (Any): The most recently entered value for `param` of `task_name`
-            that can be found in the database.
+            that can be found in the database. Returns None if nothing found.
     """
     import sqlite3
     from ._sqlite import _select_from_db
 
     con: sqlite3.Connection = sqlite3.Connection(f"{db_dir}/lute.db")
     with con:
-        entry: Any = _select_from_db(con, task_name, param, {"valid_flag": "1"})
-
+        try:
+            entry: Any = _select_from_db(con, task_name, param, {"valid_flag": "1"})
+        except sqlite3.OperationalError as err:
+            logger.debug(f"Cannot retrieve value {param} due to: {err}")
+            entry = None
     return entry

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -70,7 +70,12 @@ def _cfg_to_exec_entry_cols(
 
 def _params_to_entry_cols(
     params: TaskParameters,
-) -> Tuple[Dict[str, Any], Dict[str, str], Dict[str, Any], Dict[str, str],]:
+) -> Tuple[
+    Dict[str, Any],
+    Dict[str, str],
+    Dict[str, Any],
+    Dict[str, str],
+]:
     """Adapts a TaskParameters object to be entered into a table.
 
     Extracts the appropriate names and types from a TaskParameters object.

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -49,13 +49,18 @@ def _cfg_to_exec_entry_cols(
 
         columns (Dict[str, str]): Converted {name:type} dictionary.
     """
+    selected_env_vars: Dict[str, str] = {
+        key: cfg.task_env[key]
+        for key in cfg.task_env
+        if "LUTE_" in key or "SLURM_" in key
+    }
     entry: Dict[str, Any] = {
-        # "env": ";".join(f"{key}={value}" for key, value in cfg.task_env.items()),
+        "env": ";".join(f"{key}={value}" for key, value in selected_env_vars.items()),
         "poll_interval": cfg.poll_interval,
         "communicator_desc": ";".join(desc for desc in cfg.communicator_desc),
     }
     columns: Dict[str, str] = {
-        # "env": "TEXT",
+        "env": "TEXT",
         "poll_interval": "REAL",
         "communicator_desc": "TEXT",
     }

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -5,3 +5,4 @@ from .smd import *
 from .sfx_index import *
 from .sfx_merge import *
 from .sfx_solve import *
+from .sfx_find_peaks import *

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -1,4 +1,5 @@
 """Pydantic models for Task parameters and configuration."""
+
 from .base import *
 from .tests import *
 from .smd import *

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -2,3 +2,4 @@
 from .base import *
 from .tests import *
 from .smd import *
+from .sfx import *

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -2,4 +2,5 @@
 from .base import *
 from .tests import *
 from .smd import *
-from .sfx import *
+from .sfx_index import *
+from .sfx_merge import *

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -4,3 +4,4 @@ from .tests import *
 from .smd import *
 from .sfx_index import *
 from .sfx_merge import *
+from .sfx_solve import *

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -124,8 +124,11 @@ class BaseBinaryParameters(TaskParameters):
     used for filling in third party configuration files.
     """
 
-    class Config:
-        extra: str = "allow"
+    class Config(TaskParameters.Config):
+        short_flags_use_eq: bool = False
+        """Whether short command-line arguments are passed like `-x=arg`."""
+        long_flags_use_eq: bool = False
+        """Whether long command-line arguments are passed like `-long=arg`."""
 
     # lute_template_cfg: TemplateConfig
 

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -128,7 +128,7 @@ class BaseBinaryParameters(TaskParameters):
         short_flags_use_eq: bool = False
         """Whether short command-line arguments are passed like `-x=arg`."""
         long_flags_use_eq: bool = False
-        """Whether long command-line arguments are passed like `-long=arg`."""
+        """Whether long command-line arguments are passed like `--long=arg`."""
 
     # lute_template_cfg: TemplateConfig
 

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -90,7 +90,6 @@ class TaskParameters(BaseSettings):
 
     class Config:
         env_prefix = "LUTE_"
-        extra: str = "allow"
         underscore_attrs_are_private: bool = True
         copy_on_model_validation: str = "deep"
         allow_inf_nan: bool = False
@@ -125,6 +124,7 @@ class BaseBinaryParameters(TaskParameters):
     """
 
     class Config(TaskParameters.Config):
+        extra: str = "allow"
         short_flags_use_eq: bool = False
         """Whether short command-line arguments are passed like `-x=arg`."""
         long_flags_use_eq: bool = False

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -16,6 +16,7 @@ Classes:
     TemplateConfig(BaseModel): Class for holding information on where templates
         are stored in order to properly handle ThirdPartyParameter objects.
 """
+
 __all__ = [
     "TaskParameters",
     "AnalysisHeader",

--- a/lute/io/models/sfx.py
+++ b/lute/io/models/sfx.py
@@ -27,7 +27,11 @@ class IndexCrystFEL(BaseBinaryParameters):
         long_flags_use_eq: bool = True
         """Whether long command-line arguments are passed like `-long=arg`."""
 
-    executable: str = Field("", description="CrystFEL's indexing binary.", flag_type="")
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/indexamajig",
+        description="CrystFEL's indexing binary.",
+        flag_type="",
+    )
     # Basic options
     infile: Optional[str] = Field(
         "", description="Path to input file.", flag_type="-", rename_param="i"

--- a/lute/io/models/sfx.py
+++ b/lute/io/models/sfx.py
@@ -1,0 +1,287 @@
+"""Models for serial femtosecond crystallography Tasks.
+
+Classes:
+    IndexCrystFEL(BaseBinaryParameters): Perform indexing of hits/peaks using
+        CrystFEL's `indexamajig`.
+"""
+from typing import Union, List, Optional, Dict, Any
+
+from pydantic import (
+    BaseModel,
+    AnyUrl,
+    PositiveInt,
+    PositiveFloat,
+    NonNegativeInt,
+    Field,
+    conint,
+    validator,
+)
+
+from .base import TaskParameters, BaseBinaryParameters
+
+
+class IndexCrystFEL(BaseBinaryParameters):
+    """Parameters for CrystFEL's `indexamajig`."""
+
+    class Config(BaseBinaryParameters.Config):
+        long_flags_use_eq: bool = True
+        """Whether long command-line arguments are passed like `-long=arg`."""
+
+    executable: str = Field("", description="CrystFEL's indexing binary.", flag_type="")
+    # Basic options
+    infile: Optional[str] = Field(
+        "", description="Path to input file.", flag_type="-", rename_param="i"
+    )
+    outfile: str = Field(
+        description="Path to output file.", flag_type="-", rename_param="o"
+    )
+    geometry: str = Field(
+        description="Path to geometry file.", flag_type="-", rename_param="g"
+    )
+    zmq_input: Optional[str] = Field(
+        description="ZMQ address to receive data over. `input` and `zmq-input` are mutually exclusive",
+        flag_type="--",
+        rename_param="zmq-input",
+    )
+    zmq_subscribe: Optional[str] = Field(  # Can be used multiple times...
+        description="Subscribe to ZMQ message of type `tag`",
+        flag_type="--",
+        rename_param="zmq-subscribe",
+    )
+    zmq_request: Optional[AnyUrl] = Field(
+        description="Request new data over ZMQ by sending this value",
+        flag_type="--",
+        rename_param="zmq-request",
+    )
+    asapo_endpoint: Optional[str] = Field(
+        description="ASAP::O endpoint. zmq-input and this are mutually exclusive.",
+        flag_type="--",
+        rename_param="asapo-endpoint",
+    )
+    asapo_token: Optional[str] = Field(
+        description="ASAP::O authentication token.",
+        flag_type="--",
+        rename_param="asapo-token",
+    )
+    asapo_beamtime: Optional[str] = Field(
+        description="ASAP::O beatime.",
+        flag_type="--",
+        rename_param="asapo-beamtime",
+    )
+    asapo_source: Optional[str] = Field(
+        description="ASAP::O data source.",
+        flag_type="--",
+        rename_param="asapo-source",
+    )
+    asapo_group: Optional[str] = Field(
+        description="ASAP::O consumer group.",
+        flag_type="--",
+        rename_param="asapo-group",
+    )
+    asapo_stream: Optional[str] = Field(
+        description="ASAP::O stream.",
+        flag_type="--",
+        rename_param="asapo-stream",
+    )
+    asapo_wait_for_stream: Optional[str] = Field(
+        description="If ASAP::O stream does not exist, wait for it to appear.",
+        flag_type="--",
+        rename_param="asapo-wait-for-stream",
+    )
+    data_format: Optional[str] = Field(
+        description="Specify format for ZMQ or ASAP::O. `msgpack`, `hdf5` or `seedee`.",
+        flag_type="--",
+        rename_param="data-format",
+    )
+    basename: bool = Field(
+        False,
+        description="Remove directory parts of filenames. Acts before prefix if prefix also given.",
+        flag_type="--",
+    )
+    prefix: Optional[str] = Field(
+        description="Add a prefix to the filenames from the infile argument.",
+        flag_type="--",
+        rename_param="asapo-stream",
+    )
+    nthreads: PositiveInt = Field(
+        1,
+        description="Number of threads to use. See also `max_indexer_threads`.",
+        flag_type="-",
+        rename_param="j",
+    )
+    no_check_prefix: bool = Field(
+        bool,
+        description="Don't attempt to correct the prefix if it seems incorrect.",
+        flag_type="--",
+        rename_param="no-check-prefix",
+    )
+    highres: Optional[float] = Field(
+        description="Mark all pixels greater than `x` has bad.", flag_type="--"
+    )
+    profile: bool = Field(
+        False, description="Display timing data to monitor performance.", flag_type="--"
+    )
+    temp_dir: Optional[str] = Field(
+        description="Specify a path for the temp files folder.",
+        flag_type="--",
+        rename_param="temp-dir",
+    )
+    wait_for_file: conint(gt=-2) = Field(
+        0,
+        description="Wait at most `x` seconds for a file to be created. A value of -1 means wait forever.",
+        flag_type="--",
+        rename_param="wait-for-file",
+    )
+    no_image_data: bool = Field(
+        False,
+        description="Load only the metadata, no iamges. Can check indexability without high data requirements.",
+        flag_type="--",
+        rename_param="no-image-data",
+    )
+    # Peak-finding options
+    # ....
+    # Indexing options
+    indexing: Optional[str] = Field(
+        description="Comma-separated list of supported indexing algorithms to use. Default is to automatically detect.",
+        flag_type="--",
+    )
+    cell_file: Optional[str] = Field(
+        description="Path to a file containing unit cell information (PDB or CrystFEL format).",
+        flag_type="-",
+        rename_param="p",
+    )
+    tolerance: str = Field(
+        description=(
+            "Tolerances (in percent) for unit cell comparison. "
+            "Comma-separated list a,b,c,angle. Default=5,5,5,1.5"
+        ),
+        flag_type="--",
+    )
+    no_check_cell: bool = Field(
+        False,
+        description="Do not check cell parameters against unit cell. Replaces '-raw' method.",
+        flag_type="--",
+        rename_param="no-check-cell",
+    )
+    no_check_peaks: bool = Field(
+        False,
+        description="Do not verify peaks are accounted for by solution.",
+        flag_type="--",
+        rename_param="no-check-peaks",
+    )
+    multi: bool = Field(
+        False, description="Enable multi-lattice indexing.", flag_type="--"
+    )
+    wavelength_estimate: Optional[float] = Field(
+        description="Estimate for X-ray wavelength. Required for some methods.",
+        flag_type="--",
+        rename_param="wavelength-estimate",
+    )
+    camera_length_estimate: Optional[float] = Field(
+        description="Estimate for camera distance. Required for some methods.",
+        flag_type="--",
+        rename_param="camera-length-estimate",
+    )
+    max_indexer_threads: PositiveInt = Field(
+        1,
+        description="Some indexing algos can use multiple threads. In addition to image-based.",
+        flag_type="--",
+        rename_param="max-indexer-threads",
+    )
+    no_retry: bool = Field(
+        False,
+        description="Do not remove weak peaks and try again.",
+        flag_type="--",
+        rename_param="no-retry",
+    )
+    no_refine: bool = Field(
+        False,
+        description="Skip refinement step.",
+        flag_type="--",
+        rename_param="no-refine",
+    )
+    # TakeTwo specific parameters
+    taketwo_member_threshold: PositiveInt = Field(
+        20,
+        description="Minimum number of vectors to consider.",
+        flag_type="--",
+        rename_param="taketwo-member-threshold",
+    )
+    taketwo_len_tolerance: PositiveFloat = Field(
+        0.001,
+        description="TakeTwo length tolerance in Angstroms.",
+        flag_type="--",
+        rename_param="taketwo-len-tolerance",
+    )
+    taketwo_angle_tolerance: PositiveFloat = Field(
+        0.6,
+        description="TakeTwo angle tolerance in degrees.",
+        flag_type="--",
+        rename_param="taketwo-angle-tolerance",
+    )
+    taketwo_trace_tolerance: PositiveFloat = Field(
+        3,
+        description="Matrix trace tolerance in degrees.",
+        flag_type="--",
+        rename_param="taketwo-trace-tolerance",
+    )
+    # Felix-specific parameters
+    # felix_domega
+    # felix-fraction-max-visits
+    # felix-max-internal-angle
+    # felix-max-uniqueness
+    # felix-min-completeness
+    # felix-min-visits
+    # felix-num-voxels
+    # felix-sigma
+    # felix-tthrange-max
+    # felix-tthrange-min
+    # XGANDALF-specific parameters
+    xgandalf_sampling_pitch: NonNegativeInt = Field(
+        6,
+        description="Density of reciprocal space sampling.",
+        flag_type="--",
+        rename_param="xgandalf-sampling-pitch",
+    )
+    xgandalf_grad_desc_iterations: NonNegativeInt = Field(
+        4,
+        description="Number of gradient descent iterations.",
+        flag_type="--",
+        rename_param="xgandalf-grad-desc-iterations",
+    )
+    xgandalf_tolerance: PositiveFloat = Field(
+        0.02,
+        description="Relative tolerance of lattice vectors",
+        flag_type="--",
+        rename_param="xgandalf-tolerance",
+    )
+    xgandalf_no_deviation_from_provided_cell: Optional[bool] = Field(
+        description="Found unit cell must match provided.",
+        flag_type="--",
+        rename_param="xgandalf-no-deviation-from-provided-cell",
+    )
+    xgandalf_min_lattice_vector_length: PositiveFloat = Field(
+        30,
+        description="Minimum possible lattice length.",
+        flag_type="--",
+        rename_param="xgandalf-min-lattice-vector-length",
+    )
+    xgandalf_max_lattice_vector_length = Field(
+        250,
+        description="Minimum possible lattice length.",
+        flag_type="--",
+        rename_param="xgandalf-max-lattice-vector-length",
+    )
+    xgandalf_max_peaks: PositiveInt = Field(
+        250,
+        description="Maximum number of peaks to use for indexing.",
+        flag_type="--",
+        rename_param="xgandalf-max-peaks",
+    )
+    xgandalf_fast_execution: bool = Field(
+        False,
+        description="Shortcut to set sampling-pitch=2, and grad-desc-iterations=3.",
+        flag_type="--",
+        rename_param="xgandalf-fast-execution",
+    )
+    # pinkIndexer parameters

--- a/lute/io/models/sfx.py
+++ b/lute/io/models/sfx.py
@@ -4,6 +4,10 @@ Classes:
     IndexCrystFEL(BaseBinaryParameters): Perform indexing of hits/peaks using
         CrystFEL's `indexamajig`.
 """
+
+__all__ = ["IndexCrystFELParameters"]
+__author__ = "Gabriel Dorlhiac"
+
 from typing import Union, List, Optional, Dict, Any
 
 from pydantic import (
@@ -20,8 +24,13 @@ from pydantic import (
 from .base import TaskParameters, BaseBinaryParameters
 
 
-class IndexCrystFEL(BaseBinaryParameters):
-    """Parameters for CrystFEL's `indexamajig`."""
+class IndexCrystFELParameters(BaseBinaryParameters):
+    """Parameters for CrystFEL's `indexamajig`.
+
+    There are many parameters, and many combinations. For more information on
+    usage, please refer to the CrystFEL documentation, here:
+    https://www.desy.de/~twhite/crystfel/manual-indexamajig.html
+    """
 
     class Config(BaseBinaryParameters.Config):
         long_flags_use_eq: bool = True
@@ -289,3 +298,79 @@ class IndexCrystFEL(BaseBinaryParameters):
         rename_param="xgandalf-fast-execution",
     )
     # pinkIndexer parameters
+    # asdf_fast: bool = Field(False, description="Enable fast mode for asdf. 3x faster for 7% loss in accuracy.", flag_type="--", rename_param="asdf-fast")
+    # Integration parameters
+    integration: str = Field(
+        "rings-nocen", description="Method for integrating reflections.", flag_type="--"
+    )
+    fix_profile_radius: Optional[float] = Field(
+        description="Fix the profile radius (m^{-1})",
+        flag_type="--",
+        rename_param="fix-profile-radius",
+    )
+    fix_divergence: Optional[float] = Field(
+        0,
+        description="Fix the divergence (rad, full angle).",
+        flag_type="--",
+        rename_param="fix-divergence",
+    )
+    int_radius: str = Field(
+        "4,5,7",
+        description="Inner, middle, and outer radii for 3-ring integration.",
+        flag_type="--",
+        rename_param="int-radius",
+    )
+    int_diag: str = Field(
+        "none",
+        description="Show detailed information on integration when condition is met.",
+        flag_type="--",
+        rename_param="int-diag",
+    )
+    push_res: str = Field(
+        "infinity",
+        description="Integrate `x` higher than apparent resolution limit (nm-1).",
+        flag_type="--",
+        rename_param="push-res",
+    )
+    overpredict: bool = Field(
+        False,
+        description="Over-predict reflections. Maybe useful with post-refinement.",
+        flag_type="--",
+    )
+    cell_parameters_only: bool = Field(
+        False, description="Do not predict refletions at all", flag_type="--"
+    )
+    # Output parameters
+    no_non_hits_in_stream: bool = Field(
+        False,
+        description="Exclude non-hits from the stream file.",
+        flag_type="--",
+        rename_param="no-non-hits-in-stream",
+    )
+    copy_hheader: Optional[str] = Field(
+        description="Copy information from header in the image to output stream.",
+        flag_type="--",
+        rename_param="copy-hheader",
+    )
+    no_peaks_in_stream: bool = Field(
+        False,
+        description="Do not record peaks in stream file.",
+        flag_type="--",
+        rename_param="no-peaks-in-stream",
+    )
+    no_refls_in_stream: bool = Field(
+        False,
+        description="Do not record reflections in stream.",
+        flag_type="--",
+        rename_param="no-refls-in-stream",
+    )
+    serial_offset: Optional[PositiveInt] = Field(
+        description="Start numbering at `x` instead of 1.",
+        flag_type="--",
+        rename_param="serial-offset",
+    )
+    harvest_file: Optional[str] = Field(
+        description="Write parameters to file in JSON format.",
+        flag_type="--",
+        rename_param="harvest-file",
+    )

--- a/lute/io/models/sfx.py
+++ b/lute/io/models/sfx.py
@@ -34,7 +34,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
 
     class Config(BaseBinaryParameters.Config):
         long_flags_use_eq: bool = True
-        """Whether long command-line arguments are passed like `-long=arg`."""
+        """Whether long command-line arguments are passed like `--long=arg`."""
 
     executable: str = Field(
         "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/indexamajig",
@@ -298,6 +298,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="xgandalf-fast-execution",
     )
     # pinkIndexer parameters
+    # ...
     # asdf_fast: bool = Field(False, description="Enable fast mode for asdf. 3x faster for 7% loss in accuracy.", flag_type="--", rename_param="asdf-fast")
     # Integration parameters
     integration: str = Field(

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -1,0 +1,87 @@
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field
+
+from .base import BaseBinaryParameters, TaskParameters
+
+
+class FindPeaksPyAlgosParameters(TaskParameters):
+    n_events: int = Field(
+        0,
+        description="Number of events to process (0 to process all events)",
+    )
+    det_name: str = Field(
+        description="Psana name of the detector storing the image data",
+    )
+    event_receiver: Literal["evr0", "evr1"] = Field(
+        description="Event Receiver to be used: evr0 or evr1",
+    )
+    tag: str = Field(
+        "",
+        description="Tag to add to the output file names",
+    )
+    pv_camera_length: Union[str, float] = Field(
+        "",
+        description="PV associated with camera length "
+        "(if a number, camera length directly)",
+    )
+    event_logic: bool = Field(
+        False,
+        description="True if only events with a specific event code should be "
+        "processed. False if the event code should be ignored",
+    )
+    event_code: int = Field(
+        0,
+        description="Required events code for events to be processed if event logic "
+        "is True",
+    )
+    psana_mask: bool = Field(
+        False,
+        description="If True, apply mask from psana Detector object",
+    )
+    mask_file: Union[str, None] = Field(
+        None,
+        description="File with a custom mask to apply. If None, no custom mask is "
+        "applied",
+    )
+    min_peaks: int = Field(2, description="Minimum number of peaks per image")
+    max_peaks: int = Field(
+        2048,
+        description="Maximum number of peaks per image",
+    )
+    npix_min: int = Field(
+        2,
+        description="Minimum number of pixels per peak",
+    )
+    npix_max: int = Field(
+        30,
+        description="Maximum number of pixels per peak",
+    )
+    amax_thr: float = Field(
+        80.0,
+        description="Minimum intensity threshold for starting a peak",
+    )
+    atot_thr: float = Field(
+        120.0,
+        description="Minimum summed intensity threshold for pixel collection",
+    )
+    son_min: float = Field(
+        7.0,
+        description="Minimum signal-to-noise ratio to be considered a peak",
+    )
+    peak_rank: int = Field(
+        3,
+        description="Radius in which central peak pixel is a local maximum",
+    )
+    r0: float = Field(
+        3.0,
+        description="Radius of ring for background evaluation in pixels",
+    )
+    dr: float = Field(
+        2.0,
+        description="Width of ring for background evaluation in pixels",
+    )
+    nsigm: float = Field(
+        7.0,
+        description="Intensity threshold to include pixel in connected group",
+    )

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -120,4 +120,4 @@ class FindPeaksPyAlgosParameters(TaskParameters):
                 / f"{values['lute_config'].experiment}_{values['lute_config'].run}_"
                 f"{values['tag']}.list"
             )
-        return out_file
+        return fname

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -120,4 +120,5 @@ class FindPeaksPyAlgosParameters(TaskParameters):
                 / f"{values['lute_config'].experiment}_{values['lute_config'].run}_"
                 f"{values['tag']}.list"
             )
-        return fname
+            return str(fname)
+        return out_file

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -8,6 +8,7 @@ Classes:
 __all__ = ["IndexCrystFELParameters"]
 __author__ = "Gabriel Dorlhiac"
 
+import os
 from typing import Union, List, Optional, Dict, Any
 
 from pydantic import (
@@ -117,7 +118,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="asapo-stream",
     )
     nthreads: PositiveInt = Field(
-        1,
+        int(os.environ.get('SLURM_NPROCS', len(os.sched_getaffinity(0)))) - 1,
         description="Number of threads to use. See also `max_indexer_threads`.",
         flag_type="-",
         rename_param="j",

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -118,7 +118,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="asapo-stream",
     )
     nthreads: PositiveInt = Field(
-        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
+        max(int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1),
         description="Number of threads to use. See also `max_indexer_threads`.",
         flag_type="-",
         rename_param="j",

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -164,6 +164,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="p",
     )
     tolerance: str = Field(
+        "5,5,5,1.5",
         description=(
             "Tolerances (in percent) for unit cell comparison. "
             "Comma-separated list a,b,c,angle. Default=5,5,5,1.5"
@@ -212,6 +213,12 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         description="Skip refinement step.",
         flag_type="--",
         rename_param="no-refine",
+    )
+    no_revalidate: bool = Field(
+        False,
+        description="Skip revalidation step.",
+        flag_type="--",
+        rename_param="no-revalidate",
     )
     # TakeTwo specific parameters
     taketwo_member_threshold: PositiveInt = Field(

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -118,7 +118,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="asapo-stream",
     )
     nthreads: PositiveInt = Field(
-        int(os.environ.get('SLURM_NPROCS', len(os.sched_getaffinity(0)))) - 1,
+        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
         description="Number of threads to use. See also `max_indexer_threads`.",
         flag_type="-",
         rename_param="j",
@@ -197,8 +197,8 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         flag_type="--",
         rename_param="camera-length-estimate",
     )
-    max_indexer_threads: PositiveInt = Field(
-        1,
+    max_indexer_threads: Optional[PositiveInt] = Field(
+        # 1,
         description="Some indexing algos can use multiple threads. In addition to image-based.",
         flag_type="--",
         rename_param="max-indexer-threads",
@@ -222,26 +222,26 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="no-revalidate",
     )
     # TakeTwo specific parameters
-    taketwo_member_threshold: PositiveInt = Field(
-        20,
+    taketwo_member_threshold: Optional[PositiveInt] = Field(
+        # 20,
         description="Minimum number of vectors to consider.",
         flag_type="--",
         rename_param="taketwo-member-threshold",
     )
-    taketwo_len_tolerance: PositiveFloat = Field(
-        0.001,
+    taketwo_len_tolerance: Optional[PositiveFloat] = Field(
+        # 0.001,
         description="TakeTwo length tolerance in Angstroms.",
         flag_type="--",
         rename_param="taketwo-len-tolerance",
     )
-    taketwo_angle_tolerance: PositiveFloat = Field(
-        0.6,
+    taketwo_angle_tolerance: Optional[PositiveFloat] = Field(
+        # 0.6,
         description="TakeTwo angle tolerance in degrees.",
         flag_type="--",
         rename_param="taketwo-angle-tolerance",
     )
-    taketwo_trace_tolerance: PositiveFloat = Field(
-        3,
+    taketwo_trace_tolerance: Optional[PositiveFloat] = Field(
+        # 3,
         description="Matrix trace tolerance in degrees.",
         flag_type="--",
         rename_param="taketwo-trace-tolerance",
@@ -258,20 +258,20 @@ class IndexCrystFELParameters(BaseBinaryParameters):
     # felix-tthrange-max
     # felix-tthrange-min
     # XGANDALF-specific parameters
-    xgandalf_sampling_pitch: NonNegativeInt = Field(
-        6,
+    xgandalf_sampling_pitch: Optional[NonNegativeInt] = Field(
+        # 6,
         description="Density of reciprocal space sampling.",
         flag_type="--",
         rename_param="xgandalf-sampling-pitch",
     )
-    xgandalf_grad_desc_iterations: NonNegativeInt = Field(
-        4,
+    xgandalf_grad_desc_iterations: Optional[NonNegativeInt] = Field(
+        # 4,
         description="Number of gradient descent iterations.",
         flag_type="--",
         rename_param="xgandalf-grad-desc-iterations",
     )
-    xgandalf_tolerance: PositiveFloat = Field(
-        0.02,
+    xgandalf_tolerance: Optional[PositiveFloat] = Field(
+        # 0.02,
         description="Relative tolerance of lattice vectors",
         flag_type="--",
         rename_param="xgandalf-tolerance",
@@ -281,20 +281,20 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         flag_type="--",
         rename_param="xgandalf-no-deviation-from-provided-cell",
     )
-    xgandalf_min_lattice_vector_length: PositiveFloat = Field(
-        30,
+    xgandalf_min_lattice_vector_length: Optional[PositiveFloat] = Field(
+        # 30,
         description="Minimum possible lattice length.",
         flag_type="--",
         rename_param="xgandalf-min-lattice-vector-length",
     )
-    xgandalf_max_lattice_vector_length = Field(
-        250,
+    xgandalf_max_lattice_vector_length: Optional[PositiveFloat] = Field(
+        # 250,
         description="Minimum possible lattice length.",
         flag_type="--",
         rename_param="xgandalf-max-lattice-vector-length",
     )
-    xgandalf_max_peaks: PositiveInt = Field(
-        250,
+    xgandalf_max_peaks: Optional[PositiveInt] = Field(
+        # 250,
         description="Maximum number of peaks to use for indexing.",
         flag_type="--",
         rename_param="xgandalf-max-peaks",
@@ -402,3 +402,13 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         # )
         # in_file: str = f"{values['lute_config'].work_dir}/{filename}"
         return geometry
+
+    @validator("cell_file", always=True)
+    def validate_cell_file(cls, cell_file: str, values: Dict[str, Any]) -> str:
+        if cell_file == "":
+            ...
+        # filename: str = read_latest_db_entry(
+        #    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "outfile"
+        # )
+        # in_file: str = f"{values['lute_config'].work_dir}/{filename}"
+        return cell_file

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -1,7 +1,7 @@
 """Models for serial femtosecond crystallography indexing.
 
 Classes:
-    IndexCrystFEL(BaseBinaryParameters): Perform indexing of hits/peaks using
+    IndexCrystFELParameters(BaseBinaryParameters): Perform indexing of hits/peaks using
         CrystFEL's `indexamajig`.
 """
 

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -387,28 +387,9 @@ class IndexCrystFELParameters(BaseBinaryParameters):
     @validator("in_file", always=True)
     def validate_in_file(cls, in_file: str, values: Dict[str, Any]) -> str:
         if in_file == "":
-            filename: str = read_latest_db_entry(
-                f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "outfile"
+            filename: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "out_file"
             )
-            in_file: str = f"{values['lute_config'].work_dir}/{filename}"
+            if filename is not None:
+                return filename
         return in_file
-
-    @validator("geometry", always=True)
-    def validate_geometry(cls, geometry: str, values: Dict[str, Any]) -> str:
-        if geometry == "":
-            ...
-        # filename: str = read_latest_db_entry(
-        #    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "outfile"
-        # )
-        # in_file: str = f"{values['lute_config'].work_dir}/{filename}"
-        return geometry
-
-    @validator("cell_file", always=True)
-    def validate_cell_file(cls, cell_file: str, values: Dict[str, Any]) -> str:
-        if cell_file == "":
-            ...
-        # filename: str = read_latest_db_entry(
-        #    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "outfile"
-        # )
-        # in_file: str = f"{values['lute_config'].work_dir}/{filename}"
-        return cell_file

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -49,7 +49,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         description="Path to output file.", flag_type="-", rename_param="o"
     )
     geometry: str = Field(
-        description="Path to geometry file.", flag_type="-", rename_param="g"
+        "", description="Path to geometry file.", flag_type="-", rename_param="g"
     )
     zmq_input: Optional[str] = Field(
         description="ZMQ address to receive data over. `input` and `zmq-input` are mutually exclusive",
@@ -123,7 +123,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
         rename_param="j",
     )
     no_check_prefix: bool = Field(
-        bool,
+        False,
         description="Don't attempt to correct the prefix if it seems incorrect.",
         flag_type="--",
         rename_param="no-check-prefix",
@@ -391,3 +391,13 @@ class IndexCrystFELParameters(BaseBinaryParameters):
             )
             in_file: str = f"{values['lute_config'].work_dir}/{filename}"
         return in_file
+
+    @validator("geometry", always=True)
+    def validate_geometry(cls, geometry: str, values: Dict[str, Any]) -> str:
+        if geometry == "":
+            ...
+        # filename: str = read_latest_db_entry(
+        #    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "outfile"
+        # )
+        # in_file: str = f"{values['lute_config'].work_dir}/{filename}"
+        return geometry

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -81,7 +81,7 @@ class MergePartialatorParameters(BaseBinaryParameters):
         flag_type="--",
     )
     nthreads: int = Field(
-        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
+        max(int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1),
         description="Number of parallel analyses.",
         flag_type="-",
         rename_param="j",

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -1,0 +1,363 @@
+"""Models for merging reflections in serial femtosecond crystallography.
+
+Classes:
+    IndexCrystFEL(BaseBinaryParameters): Perform indexing of hits/peaks using
+        CrystFEL's `indexamajig`.
+"""
+
+__all__ = ["MergePartialatorParameters"]
+__author__ = "Gabriel Dorlhiac"
+
+from typing import Union, List, Optional, Dict, Any
+
+from pydantic import (
+    AnyUrl,
+    PositiveInt,
+    PositiveFloat,
+    NonNegativeInt,
+    Field,
+    conint,
+    validator,
+)
+
+from .base import BaseBinaryParameters
+from ..db import read_latest_db_entry
+
+
+class MergePartialatorParameters(BaseBinaryParameters):
+    """Parameters for CrystFEL's `partialator`.
+
+    There are many parameters, and many combinations. For more information on
+    usage, please refer to the CrystFEL documentation, here:
+    https://www.desy.de/~twhite/crystfel/manual-partialator.html
+    """
+
+    class Config(BaseBinaryParameters.Config):
+        long_flags_use_eq: bool = True
+        """Whether long command-line arguments are passed like `--long=arg`."""
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/partialator",
+        description="CrystFEL's Partialator binary.",
+        flag_type="",
+    )
+    in_file: Optional[str] = Field(
+        "", description="Path to input stream.", flag_type="-", rename_param="i"
+    )
+    out_file: str = Field(
+        "partialator.hkl",
+        description="Path to output file.",
+        flag_type="-",
+        rename_param="o",
+    )
+    symmetry: str = Field(description="Point group symmetry.", flag_type="--")
+    niter: Optional[int] = Field(
+        description="Number of cycles of scaling and post-refinement.",
+        flag_type="-",
+        rename_param="n",
+    )
+    no_scale: Optional[bool] = Field(
+        description="Disable scaling.", flag_type="--", rename_param="no-scale"
+    )
+    no_Bscale: Optional[bool] = Field(
+        description="Disable Debye-Waller part of scaling.",
+        flag_type="--",
+        rename_param="no-Bscale",
+    )
+    no_pr: Optional[bool] = Field(
+        description="Disable orientation model.", flag_type="--", rename_param="no-pr"
+    )
+    no_deltacchalf: Optional[bool] = Field(
+        description="Disable rejection based on deltaCC1/2.",
+        flag_type="--",
+        rename_param="no-deltacchalf",
+    )
+    model: str = Field(
+        "unity",
+        description="Partiality model. Options: xsphere, unity, offset, ggpm.",
+        flag_type="--",
+    )
+    nthreads: int = Field(
+        1, description="Number of parallel analyses.", flag_type="-", rename_param="j"
+    )
+    polarisation: Optional[str] = Field(
+        description="Specification of incident polarisation. Refer to CrystFEL docs for more info.",
+        flag_type="--",
+    )
+    no_polarisation: Optional[bool] = Field(
+        description="Synonym for --polarisation=none",
+        flag_type="--",
+        rename_param="no-polarisation",
+    )
+    max_adu: Optional[float] = Field(
+        description="Maximum intensity of reflection to include.",
+        flag_type="--",
+        rename_param="max-adu",
+    )
+    min_res: Optional[float] = Field(
+        description="Only include crystals diffracting to a minimum resolution.",
+        flag_type="--",
+        rename_param="min-res",
+    )
+    min_measurements: int = Field(
+        2,
+        description="Include a reflection only if it appears a minimum number of times.",
+        flag_type="--",
+        rename_param="min-measurements",
+    )
+    push_res: Optional[float] = Field(
+        description="Merge reflections up to higher than the apparent resolution limit.",
+        flag_type="--",
+        rename_param="push-res",
+    )
+    start_after: int = Field(
+        0,
+        description="Ignore the first n crystals.",
+        flag_type="--",
+        rename_param="start-after",
+    )
+    stop_after: int = Field(
+        0,
+        description="Stop after processing n crystals. 0 means process all.",
+        flag_type="--",
+        rename_param="stop-after",
+    )
+    no_free: Optional[bool] = Field(
+        description="Disable cross-validation. Testing ONLY.",
+        flag_type="--",
+        rename_param="no-free",
+    )
+    custom_split: Optional[str] = Field(
+        description="Read a set of filenames, event and dataset IDs from a filename.",
+        flag_type="--",
+        rename_param="custom-split",
+    )
+    max_rel_B: float = Field(
+        100,
+        description="Reject crystals if |relB| > n sq Angstroms.",
+        flag_type="--",
+        rename_param="max-rel-B",
+    )
+    output_every_cycle: bool = Field(
+        False,
+        description="Write per-crystal params after every refinement cycle.",
+        flag_type="--",
+        rename_param="output-every-cycle",
+    )
+    no_logs: bool = Field(
+        False,
+        description="Do not write logs needed for plots, maps and graphs.",
+        flag_type="--",
+        rename_param="no-logs",
+    )
+    set_symmetry: Optional[str] = Field(
+        description="Set the apparent symmetry of the crystals to a point group.",
+        flag_type="-",
+        rename_param="w",
+    )
+    operator: Optional[str] = Field(
+        description="Specify an ambiguity operator. E.g. k,h,-l.", flag_type="--"
+    )
+    force_bandwidth: Optional[float] = Field(
+        description="Set X-ray bandwidth. As percent, e.g. 0.0013 (0.13%).",
+        flag_type="--",
+        rename_param="force-bandwidth",
+    )
+    force_radius: Optional[float] = Field(
+        description="Set the initial profile radius (nm-1).",
+        flag_type="--",
+        rename_param="force-radius",
+    )
+    force_lambda: Optional[float] = Field(
+        description="Set the wavelength. In Angstroms.",
+        flag_type="--",
+        rename_param="force-lambda",
+    )
+    harvest_file: Optional[str] = Field(
+        description="Write parameters to file in JSON format.",
+        flag_type="--",
+        rename_param="harvest-file",
+    )
+
+
+class CompareHKLParameters(BaseBinaryParameters):
+    """Parameters for CrystFEL's `compare_hkl` for calculating figures of merit.
+
+    There are many parameters, and many combinations. For more information on
+    usage, please refer to the CrystFEL documentation, here:
+    https://www.desy.de/~twhite/crystfel/manual-partialator.html
+    """
+
+    class Config(BaseBinaryParameters.Config):
+        long_flags_use_eq: bool = True
+        """Whether long command-line arguments are passed like `--long=arg`."""
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/compare_hkl",
+        description="CrystFEL's reflection comparison binary.",
+        flag_type="",
+    )
+    in_files: Optional[str] = Field(
+        "out.hkl1 out.hkl2", description="Path to input stream.", flag_type=""
+    )
+    symmetry: str = Field(description="Point group symmetry.", flag_type="--")
+    cell_file: Optional[str] = Field(
+        description="Path to a file containing unit cell information (PDB or CrystFEL format).",
+        flag_type="-",
+        rename_param="p",
+    )
+    fom: str = Field(
+        "Rsplit", description="Specify figure of merit to calculate.", flag_type="--"
+    )
+    nshells: int = Field(10, description="Use n resolution shells.", flag_type="--")
+    fix_unity: bool = Field(
+        False,
+        description="Fix scale factors to unity.",
+        flag_type="-",
+        rename_param="u",
+    )
+    shell_file: str = Field(
+        description="Write the statistics in resolution shells to a file.",
+        flag_type="--",
+        rename_param="shell-file",
+    )
+    ignore_negs: bool = Field(
+        False,
+        description="Ignore reflections with negative reflections.",
+        flag_type="--",
+        rename_param="ignore-negs",
+    )
+    zero_negs: bool = Field(
+        False,
+        description="Set negative intensities to 0.",
+        flag_type="--",
+        rename_param="zero-negs",
+    )
+    sigma_cutoff: Optional[Union[float, int, str]] = Field(
+        "-infinity",
+        description="Discard reflections with I/sigma(I) < n. -infinity means no cutoff.",
+        flag_type="--",
+        rename_param="sigma-cutoff",
+    )
+    rmin: Optional[float] = Field(
+        description="Low resolution cutoff of 1/d (m-1). Use this or --lowres NOT both.",
+        flag_type="--",
+    )
+    lowres: Optional[float] = Field(
+        descirption="Low resolution cutoff in Angstroms. Use this or --rmin NOT both.",
+        flag_type="--",
+    )
+    rmax: Optional[float] = Field(
+        description="High resolution cutoff in 1/d (m-1). Use this or --highres NOT both.",
+        flag_type="--",
+    )
+    highres: Optional[float] = Field(
+        description="High resolution cutoff in Angstroms. Use this or --rmax NOT both.",
+        flag_type="--",
+    )
+
+
+class ManipulateHKLParameters(BaseBinaryParameters):
+    """Parameters for CrystFEL's `get_hkl` for manipulating lists of reflections.
+
+    This Task is predominantly used internally to convert `hkl` to `mtz` files.
+    Note that performing multiple manipulations is undefined behaviour. Run
+    the Task with multiple configurations in explicit separate steps. For more
+    information on usage, please refer to the CrystFEL documentation, here:
+    https://www.desy.de/~twhite/crystfel/manual-partialator.html
+    """
+
+    class Config(BaseBinaryParameters.Config):
+        long_flags_use_eq: bool = True
+        """Whether long command-line arguments are passed like `--long=arg`."""
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/get_hkl",
+        description="CrystFEL's reflection manipulation binary.",
+        flag_type="",
+    )
+    in_file: Optional[str] = Field(
+        "reflections.hkl",
+        description="Path to input stream.",
+        flag_type="-",
+        rename_param="i",
+    )
+    out_file: str = Field(
+        "output.hkl",
+        description="Path to output file.",
+        flag_type="-",
+        rename_param="o",
+    )
+    cell_file: Optional[str] = Field(
+        description="Path to a file containing unit cell information (PDB or CrystFEL format).",
+        flag_type="-",
+        rename_param="p",
+    )
+    output_format: Optional[str] = Field(
+        description="Output format. One of mtz, mtz-bij, or xds. Otherwise CrystFEL format.",
+        flag_type="--",
+        rename_param="output-format",
+    )
+    expand: Optional[str] = Field(
+        description="Reflections will be expanded to fill asymmetric unit of specified point group.",
+        flag_type="--",
+    )
+    # Reducing reflections to higher symmetry
+    twin: Optional[str] = Field(
+        description="Reflections equivalent to specified point group will have intensities summed.",
+        flag_type="--",
+    )
+    no_need_all_parts: Optional[bool] = Field(
+        description="Use with --twin to allow reflections missing a 'twin mate' to be written out.",
+        flag_type="--",
+        rename_param="no-need-all-parts",
+    )
+    # Noise - Add to data
+    noise: Optional[bool] = Field(
+        description="Generate 10% uniform noise.", flag_type="--"
+    )
+    poisson: Optional[bool] = Field(
+        description="Generate Poisson noise. Intensities assumed to be A.U.",
+        flag_type="--",
+    )
+    adu_per_photon: Optional[int] = Field(
+        description="Use with --poisson to convert A.U. to photons.",
+        flag_type="--",
+        rename_param="adu-per-photon",
+    )
+    # Remove duplicate reflections
+    trim_centrics: Optional[bool] = Field(
+        description="Duplicated reflections (according to symmetry) are removed.",
+        flag_type="--",
+    )
+    # Restrict to template file
+    template: Optional[str] = Field(
+        description="Only reflections which also appear in specified file are written out.",
+        flag_type="--",
+    )
+    # Multiplicity
+    multiplicity: Optional[bool] = Field(
+        description="Reflections are multiplied by their symmetric multiplicites.",
+        flag_type="--",
+    )
+    # Resolution cutoffs
+    cutoff_angstroms: Union[str, int, float] = Field(
+        description="Either n, or n1,n2,n3. For n, reflections < n are removed. For n1,n2,n3 anisotropic trunction performed at separate resolution limits for a*, b*, c*.",
+        flag_type="--",
+        rename_param="cutoff-angstroms",
+    )
+    lowres: Optional[float] = Field(
+        description="Remove reflections with d > n", flag_type="--"
+    )
+    highres: Optional[float] = Field(
+        description="Synonym for first form of --cutoff-angstroms"
+    )
+    reindex: Optional[str] = Field(
+        description="Reindex according to specified operator. E.g. k,h,-l.",
+        flag_type="--",
+    )
+    # Override input symmetry
+    symmetry: Optional[str] = Field(
+        description="Point group symmetry to use to override. Almost always OMIT this option.",
+        flag_type="--",
+    )

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -1,8 +1,14 @@
 """Models for merging reflections in serial femtosecond crystallography.
 
 Classes:
-    IndexCrystFEL(BaseBinaryParameters): Perform indexing of hits/peaks using
-        CrystFEL's `indexamajig`.
+    MergePartialatorParameters(BaseBinaryParameters): Perform merging using
+        CrystFEL's `partialator`.
+
+    CompareHKLParameters(BaseBinaryParameters): Calculate figures of merit using
+        CrystFEL's `compare_hkl`.
+
+    ManipulateHKLParameters(BaseBinaryParameters): Perform transformations on
+        lists of reflections using CrystFEL's `get_hkl`.
 """
 
 __all__ = [
@@ -12,6 +18,7 @@ __all__ = [
 ]
 __author__ = "Gabriel Dorlhiac"
 
+import os
 from typing import Union, List, Optional, Dict, Any
 
 from pydantic import Field
@@ -74,7 +81,10 @@ class MergePartialatorParameters(BaseBinaryParameters):
         flag_type="--",
     )
     nthreads: int = Field(
-        1, description="Number of parallel analyses.", flag_type="-", rename_param="j"
+        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
+        description="Number of parallel analyses.",
+        flag_type="-",
+        rename_param="j",
     )
     polarisation: Optional[str] = Field(
         description="Specification of incident polarisation. Refer to CrystFEL docs for more info.",

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -5,20 +5,12 @@ Classes:
         CrystFEL's `indexamajig`.
 """
 
-__all__ = ["MergePartialatorParameters"]
+__all__ = ["MergePartialatorParameters", "CompareHKLParameters", "ManipulateHKLParameters"]
 __author__ = "Gabriel Dorlhiac"
 
 from typing import Union, List, Optional, Dict, Any
 
-from pydantic import (
-    AnyUrl,
-    PositiveInt,
-    PositiveFloat,
-    NonNegativeInt,
-    Field,
-    conint,
-    validator,
-)
+from pydantic import Field
 
 from .base import BaseBinaryParameters
 from ..db import read_latest_db_entry

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -5,7 +5,11 @@ Classes:
         CrystFEL's `indexamajig`.
 """
 
-__all__ = ["MergePartialatorParameters", "CompareHKLParameters", "ManipulateHKLParameters"]
+__all__ = [
+    "MergePartialatorParameters",
+    "CompareHKLParameters",
+    "ManipulateHKLParameters",
+]
 __author__ = "Gabriel Dorlhiac"
 
 from typing import Union, List, Optional, Dict, Any

--- a/lute/io/models/sfx_solve.py
+++ b/lute/io/models/sfx_solve.py
@@ -1,0 +1,236 @@
+"""Models for structure solution in serial femtosecond crystallography.
+
+Classes:
+    DimpleSolveParameters(BaseBinaryParameters): Perform structure solution
+        using CCP4's dimple (molecular replacement).
+"""
+
+__all__ = ["DimpleSolveParameters", "RunSHELXCParameters"]
+__author__ = "Gabriel Dorlhiac"
+
+import os
+from typing import Union, List, Optional, Dict, Any
+
+from pydantic import Field, validator, PositiveFloat, PositiveInt
+
+from .base import BaseBinaryParameters
+from ..db import read_latest_db_entry
+
+
+class DimpleSolveParameters(BaseBinaryParameters):
+    """Parameters for CCP4's dimple program.
+
+    There are many parameters. For more information on
+    usage, please refer to the CCP4 documentation, here:
+    https://ccp4.github.io/dimple/
+    """
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/ccp4-8.0/bin/dimple",
+        description="CCP4 Dimple for solving structures with MR.",
+        flag_type="",
+    )
+    # Positional requirements - all required.
+    in_file: str = Field(
+        "",
+        description="Path to input mtz.",
+        flag_type="",
+    )
+    pdb: str = Field("", description="Path to a PDB.", flag_type="")
+    out_dir: str = Field("", description="Output DIRECTORY.", flag_type="")
+    # Most used options
+    mr_thresh: PositiveFloat = Field(
+        0.4,
+        description="Threshold for molecular replacement.",
+        flag_type="--",
+        rename_param="mr-when-r",
+    )
+    slow: Optional[bool] = Field(
+        False, description="Perform more refinement.", flag_type="--"
+    )
+    # Other options (IO)
+    hklout: str = Field(
+        "final.mtz", description="Output mtz file name.", flag_type="--"
+    )
+    xyzout: str = Field(
+        "final.pdb", description="Output PDB file name.", flag_type="--"
+    )
+    icolumn: Optional[str] = Field(
+        # "IMEAN",
+        description="Name for the I column.",
+        flag_type="--",
+    )
+    sigicolumn: Optional[str] = Field(
+        # "SIG<ICOL>",
+        description="Name for the Sig<I> column.",
+        flag_type="--",
+    )
+    fcolumn: Optional[str] = Field(
+        # "F",
+        description="Name for the F column.",
+        flag_type="--",
+    )
+    sigfcolumn: Optional[str] = Field(
+        # "F",
+        description="Name for the Sig<F> column.",
+        flag_type="--",
+    )
+    libin: Optional[str] = Field(
+        description="Ligand descriptions for refmac (LIBIN).", flag_type="--"
+    )
+    refmac_key: Optional[str] = Field(
+        description="Extra Refmac keywords to use in refinement.",
+        flag_type="--",
+        rename_param="refmac-key",
+    )
+    free_r_flags: Optional[str] = Field(
+        description="Path to a mtz file with freeR flags.",
+        flag_type="--",
+        rename_param="free-r-flags",
+    )
+    freecolumn: Optional[Union[int, float]] = Field(
+        # 0,
+        description="Refree column with an optional value.",
+        flag_type="--",
+    )
+    img_format: Optional[str] = Field(
+        description="Format of generated images. (png, jpeg, none).",
+        flag_type="-",
+        rename_param="f",
+    )
+    white_bg: bool = Field(
+        False,
+        description="Use a white background in Coot and in images.",
+        flag_type="--",
+        rename_param="white-bg",
+    )
+    no_cleanup: bool = Field(
+        False,
+        description="Retain intermediate files.",
+        flag_type="--",
+        rename_param="no-cleanup",
+    )
+    # Calculations
+    no_blob_search: bool = Field(
+        False,
+        description="Do not search for unmodelled blobs.",
+        flag_type="--",
+        rename_param="no-blob-search",
+    )
+    anode: bool = Field(
+        False, description="Use SHELX/AnoDe to find peaks in the anomalous map."
+    )
+    # Run customization
+    no_hetatm: bool = Field(
+        False,
+        description="Remove heteroatoms from the given model.",
+        flag_type="--",
+        rename_param="no-hetatm",
+    )
+    rigid_cycles: Optional[PositiveInt] = Field(
+        # 10,
+        description="Number of cycles of rigid-body refinement to perform.",
+        flag_type="--",
+        rename_param="rigid-cycles",
+    )
+    jelly: Optional[PositiveInt] = Field(
+        # 4,
+        description="Number of cycles of jelly-body refinement to perform.",
+        flag_type="--",
+    )
+    restr_cycles: Optional[PositiveInt] = Field(
+        # 8,
+        description="Number of cycles of refmac final refinement to perform.",
+        flag_type="--",
+        rename_param="restr-cycles",
+    )
+    lim_resolution: Optional[PositiveFloat] = Field(
+        description="Limit the final resolution.", flag_type="--", rename_param="reso"
+    )
+    weight: Optional[str] = Field(
+        # "auto-weight",
+        description="The refmac matrix weight.",
+        flag_type="--",
+    )
+    mr_prog: Optional[str] = Field(
+        # "phaser",
+        description="Molecular replacement program. phaser or molrep.",
+        flag_type="--",
+        rename_param="mr-prog",
+    )
+    mr_num: Optional[Union[str, int]] = Field(
+        # "auto",
+        description="Number of molecules to use for molecular replacement.",
+        flag_type="--",
+        rename_param="mr-num",
+    )
+    mr_reso: Optional[PositiveFloat] = Field(
+        # 3.25,
+        description="High resolution for molecular replacement. If >10 interpreted as eLLG.",
+        flag_type="--",
+        rename_param="mr-reso",
+    )
+    itof_prog: Optional[str] = Field(
+        description="Program to calculate amplitudes. truncate, or ctruncate.",
+        flag_type="--",
+        rename_param="ItoF-prog",
+    )
+
+    @validator("in_file")
+    def validate_in_file(cls, in_file: str, values: Dict[str, Any]) -> str:
+        if in_file == "":
+            get_hkl_file: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "ManipulateHKL", "out_file"
+            )
+            if get_hkl_file:
+                return get_hkl_file
+        return in_file
+
+    @validator("out_dir")
+    def validate_out_dir(cls, out_dir: str, values: Dict[str, Any]) -> str:
+        if out_dir == "":
+            get_hkl_file: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "ManipulateHKL", "out_file"
+            )
+            if get_hkl_file:
+                return os.path.dirname(get_hkl_file)
+        return out_dir
+
+
+class RunSHELXCParameters(BaseBinaryParameters):
+    """Parameters for CCP4's SHELXC program.
+
+    SHELXC prepares files for SHELXD and SHELXE.
+
+    For more information please refer to the official documentation:
+    https://www.ccp4.ac.uk/html/crank.html
+    """
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/ccp4-8.0/bin/shelxc",
+        description="CCP4 SHELXC. Generates input files for SHELXD/SHELXE.",
+        flag_type="",
+    )
+    placeholder: str = Field(
+        "xx", description="Placeholder filename stem.", flag_type=""
+    )
+    in_file: str = Field(
+        "",
+        description="Input file for SHELXC with reflections AND proper records.",
+        flag_type="",
+    )
+
+    @validator("in_file")
+    def validate_in_file(cls, in_file: str, values: Dict[str, Any]) -> str:
+        if in_file == "":
+            # get_hkl needed to be run to produce an XDS format file...
+            xds_format_file: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "ManipulateHKL", "out_file"
+            )
+            if xds_format_file:
+                in_file = xds_format_file
+        if in_file[0] != "<":
+            # Need to add a redirection for this program
+            # Runs like `shelxc xx <input_file.xds`
+            in_file = f"<{in_file}"
+        return in_file

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -21,7 +21,6 @@ from pydantic import (
     PositiveInt,
     NonNegativeInt,
     Field,
-    conint,
     validator,
 )
 
@@ -32,8 +31,10 @@ class SubmitSMDParameters(BaseBinaryParameters):
     """Parameters for running smalldata to produce reduced HDF5 files."""
 
     executable: str = Field("mpirun", description="MPI executable.", flag_type="")
-    np: conint(gt=2, le=120) = Field(
-        120, description="Number of processes", flag_type="-"
+    np: PositiveInt = Field(
+        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
+        description="Number of processes",
+        flag_type="-",
     )
     p_arg1: str = Field(
         "python", description="Executable to run with mpi (i.e. python).", flag_type=""

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -32,7 +32,7 @@ class SubmitSMDParameters(BaseBinaryParameters):
 
     executable: str = Field("mpirun", description="MPI executable.", flag_type="")
     np: PositiveInt = Field(
-        int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1,
+        max(int(os.environ.get("SLURM_NPROCS", len(os.sched_getaffinity(0)))) - 1, 1),
         description="Number of processes",
         flag_type="-",
     )

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -31,7 +31,7 @@ PartialatorMerger: Executor = Executor("MergePartialator")
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
 DimpleSolver: Executor = Executor("DimpleSolve")
-DimpleSolver.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+DimpleSolver.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
 PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
 SHELXCRunner: Executor = Executor("RunSHELXC")
-SHELXCRunner.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+SHELXCRunner.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -5,19 +5,22 @@ from .execution.executor import *
 
 # Tests
 #######
-Tester = Executor("Test")
-BinaryTester = Executor("TestBinary")
-SocketTester = Executor("TestSocket")
-WriteTester = Executor("TestWriteOutput")
-ReadTester = Executor("TestReadOutput")
+Tester: Executor = Executor("Test")
+BinaryTester: Executor = Executor("TestBinary")
+SocketTester: Executor = Executor("TestSocket")
+WriteTester: Executor = Executor("TestWriteOutput")
+ReadTester: Executor = Executor("TestReadOutput")
 
 # SmallData-related
 ###################
-SmallDataProducer = Executor("SubmitSMD")
+SmallDataProducer: Executor = Executor("SubmitSMD")
 
 # SFX
 #####
-CrystFELIndexer = Executor("IndexCrystFEL")
+CrystFELIndexer: Executor = Executor("IndexCrystFEL")
 CrystFELIndexer.update_environment(
     {"PATH": "/sdf/group/lcls/ds/tools/XDS-INTEL64_Linux_x86_64"}
 )
+PartialtorMerger: Executor = Executor("MergePartialator")
+HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
+HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -31,7 +31,7 @@ PartialatorMerger: Executor = Executor("MergePartialator")
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
 DimpleSolver: Executor = Executor("DimpleSolve")
-DimpleSolver.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+DimpleSolver.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
 PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
 SHELXCRunner: Executor = Executor("RunSHELXC")
-SHELXCRunner.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+SHELXCRunner.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -32,4 +32,6 @@ HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
 DimpleSolver: Executor = Executor("DimpleSolve")
 DimpleSolver.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
-PeakFinderPyAlgos = MPIExecutor("FindPeaksPyAlgos")
+PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
+SHELXCRunner: Executor = Executor("RunSHELXC")
+SHELXCRunner.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from .io.config import *
 from .execution.executor import *
 
@@ -12,3 +14,10 @@ ReadTester = Executor("TestReadOutput")
 # SmallData-related
 ###################
 SmallDataProducer = Executor("SubmitSMD")
+
+# SFX
+#####
+CrystFELIndexer = Executor("IndexCrystFEL")
+CrystFELIndexer.update_environment(
+    {"PATH": "/sdf/group/lcls/ds/tools/XDS-INTEL64_Linux_x86_64"}
+)

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -32,3 +32,4 @@ HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
 DimpleSolver: Executor = Executor("DimpleSolve")
 DimpleSolver.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+PeakFinderPyAlgos = MPIExecutor("FindPeaksPyAlgos")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -19,7 +19,13 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 #####
 CrystFELIndexer: Executor = Executor("IndexCrystFEL")
 CrystFELIndexer.update_environment(
-    {"PATH": "/sdf/group/lcls/ds/tools/XDS-INTEL64_Linux_x86_64"}
+    {
+        "PATH": (
+            "/sdf/group/lcls/ds/tools/XDS-INTEL64_Linux_x86_64:"
+            "/sdf/group/lcls/ds/tools:"
+            "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin"
+        )
+    }
 )
 PartialtorMerger: Executor = Executor("MergePartialator")
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -30,3 +30,5 @@ CrystFELIndexer.update_environment(
 PartialatorMerger: Executor = Executor("MergePartialator")
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
+DimpleSolver: Executor = Executor("DimpleSolve")
+DimpleSolver.source_env("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -27,6 +27,6 @@ CrystFELIndexer.update_environment(
         )
     }
 )
-PartialtorMerger: Executor = Executor("MergePartialator")
+PartialatorMerger: Executor = Executor("MergePartialator")
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -1,3 +1,0 @@
-from .task import *
-from .test import *
-from .peakfinders import *

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -1,2 +1,3 @@
 from .task import *
 from .test import *
+from .peakfinders import *

--- a/lute/tasks/peakfinders.py
+++ b/lute/tasks/peakfinders.py
@@ -10,9 +10,9 @@ from numpy.typing import NDArray
 from psalgos.pypsalgos import PyAlgos
 from psana import Detector, EventId, MPIDataSource
 
-from ..execution.ipc import Message
-from ..io.models.base import *
-from .task import *
+from lute.tasks.task import *
+from lute.io.models.base import *
+from lute.execution.ipc import Message
 
 
 class CxiWriter:
@@ -699,8 +699,12 @@ class FindPeaksPyAlgos(Task):
 
                 if self._task_parameters.compression is not None:
 
-                    libpressio_config_with_peaks = add_peaks_to_libpressio_configuration(libpressio_config, peaks)
-                    compressor = PressioCompressor.from_config(libpressio_config_with_peaks)
+                    libpressio_config_with_peaks = (
+                        add_peaks_to_libpressio_configuration(libpressio_config, peaks)
+                    )
+                    compressor = PressioCompressor.from_config(
+                        libpressio_config_with_peaks
+                    )
                     compressed_img = compressor.encode(img)
                     decompressed_img = numpy.zeros_like(img)
                     decompressed = compressor.decode(compressed_img, decompressed_img)

--- a/lute/tasks/peakfinders.py
+++ b/lute/tasks/peakfinders.py
@@ -1,0 +1,654 @@
+import sys
+from pathlib import Path
+from typing import Any, List, Tuple, Union
+
+import h5py
+import numpy
+from mpi4py.MPI import COMM_WORLD, SUM
+from numpy.typing import NDArray
+from psalgos.pypsalgos import PyAlgos
+from psana import Detector, EventId, MPIDataSource
+
+from ..execution.ipc import Message
+from ..io.models.base import *
+from .task import *
+
+
+class CxiWriter:
+
+    def __init__(
+        self,
+        outdir: str,
+        rank: int,
+        exp: str,
+        run: int,
+        n_events: int,
+        det_shape: Tuple[int, ...],
+        min_peaks: int,
+        max_peaks: int,
+        i_x: Any,  # Not typed becomes it comes from psana
+        i_y: Any,  # Not typed becomes it comes from psana
+        ipx: Any,  # Not typed becomes it comes from psana
+        ipy: Any,  # Not typed becomes it comes from psana
+        tag: str,
+    ):
+        """
+        Set up the CXI files to which peak finding results will be saved.
+
+        Parameters:
+
+            outdir (str): Output directory for cxi file.
+
+            rank (int): MPI rank of the caller.
+
+            exp (str): Experiment string.
+
+            run (int): Experimental run.
+
+            n_events (int): Number of events to process.
+
+            det_shape (Tuple[int, int]): Shape of the numpy array storing the detector
+                data. This must be aCheetah-stile 2D array.
+
+            min_peaks (int): Minimum number of peaks per image.
+
+            max_peaks (int): Maximum number of peaks per image.
+
+            i_x (Any): Array of pixel indexes along x
+
+            i_y (Any): Array of pixel indexes along y
+
+            ipx (Any): Pixel indexes with respect to detector origin (x component)
+
+            ipy (Any): Pixel indexes with respect to detector origin (y component)
+
+            tag (str): Tag to append to cxi file names.
+        """
+        self._det_shape: Tuple[int, ...] = det_shape
+        self._i_x: Any = i_x
+        self._i_y: Any = i_y
+        self._ipx: Any = ipx
+        self._ipy: Any = ipy
+        self._index: int = 0
+
+        # Create and open the HDF5 file
+        fname: str = f"{exp}_r{run:0>4}_{rank}{tag}.cxi"
+        Path(outdir).mkdir(exist_ok=True)
+        self._outh5: Any = h5py.File(Path(outdir) / fname, "w")
+
+        # Entry_1 entry for processing with CrystFEL
+        entry_1: Any = self._outh5.create_group("entry_1")
+        keys: List[str] = [
+            "nPeaks",
+            "peakXPosRaw",
+            "peakYPosRaw",
+            "rcent",
+            "ccent",
+            "rmin",
+            "rmax",
+            "cmin",
+            "cmax",
+            "peakTotalIntensity",
+            "peakMaxIntensity",
+            "peakRadius",
+        ]
+        ds_expId: Any = entry_1.create_dataset(
+            "experimental_identifier", (n_events,), maxshape=(None,), dtype=int
+        )
+        ds_expId.attrs["axes"] = "experiment_identifier"
+        data_1: Any = entry_1.create_dataset(
+            "/entry_1/data_1/data",
+            (n_events, det_shape[0], det_shape[1]),
+            chunks=(1, det_shape[0], det_shape[1]),
+            maxshape=(None, det_shape[0], det_shape[1]),
+            dtype=numpy.float32,
+        )
+        data_1.attrs["axes"] = "experiment_identifier"
+        key: str
+        for key in ["powderHits", "powderMisses", "mask"]:
+            entry_1.create_dataset(
+                f"/entry_1/data_1/{key}",
+                (det_shape[0], det_shape[1]),
+                chunks=(det_shape[0], det_shape[1]),
+                maxshape=(det_shape[0], det_shape[1]),
+                dtype=float,
+            )
+
+        # Peak-related entries
+        for key in keys:
+            if key == "nPeaks":
+                ds_x: Any = self._outh5.create_dataset(
+                    f"/entry_1/result_1/{key}",
+                    (n_events,),
+                    maxshape=(None,),
+                    dtype=int,
+                )
+                ds_x.attrs["minPeaks"] = min_peaks
+                ds_x.attrs["maxPeaks"] = max_peaks
+            else:
+                ds_x: Any = self._outh5.create_dataset(
+                    f"/entry_1/result_1/{key}",
+                    (n_events, max_peaks),
+                    maxshape=(None, max_peaks),
+                    chunks=(1, max_peaks),
+                    dtype=float,
+                )
+            ds_x.attrs["axes"] = "experiment_identifier:peaks"
+
+        # Timestamp entries
+        lcls_1: Any = self._outh5.create_group("LCLS")
+        keys: List[str] = [
+            "eventNumber",
+            "machineTime",
+            "machineTimeNanoSeconds",
+            "fiducial",
+            "photon_energy_eV",
+        ]
+        key: str
+        for key in keys:
+            if key == "photon_energy_eV":
+                ds_x: Any = lcls_1.create_dataset(
+                    f"{key}", (n_events,), maxshape=(None,), dtype=float
+                )
+            else:
+                ds_x = lcls_1.create_dataset(
+                    f"{key}", (n_events,), maxshape=(None,), dtype=int
+                )
+            ds_x.attrs["axes"] = "experiment_identifier"
+
+        ds_x = self._outh5.create_dataset(
+            "/LCLS/detector_1/EncoderValue", (n_events,), maxshape=(None,), dtype=float
+        )
+        ds_x.attrs["axes"] = "experiment_identifier"
+
+    def write_event(
+        self,
+        img: NDArray[numpy.float_],
+        peaks: Any,  # Not typed becomes it comes from psana
+        timestamp_seconds: int,
+        timestamp_nanoseconds: int,
+        timestamp_fiducials: int,
+        photon_energy: float,
+    ):
+        """
+        Write peak finding results for an event into the HDF5 file.
+
+        Parameters:
+
+            img (NDArray[numpy.float_]): Detector data for the event
+
+            peaks: (Any): Peak information for the event, as recovered from the PyAlgos
+                algorithm
+
+            timestamp_seconds (int): Second part of the event's timestamp information
+
+            timestamp_nanoseconds (int): Nanosecond part of the event's timestamp
+                information
+
+            timestamp_fiducials (int): Fiducials part of the event's timestamp
+                information
+
+            photon_energy (float): Photon energy for the event
+        """
+        ch_rows: NDArray[numpy.float_] = peaks[:, 0] * self._det_shape[1] + peaks[:, 1]
+        ch_cols: NDArray[numpy.float_] = peaks[:, 2]
+
+        # Entry_1 entry for processing with CrystFEL
+        self._outh5["/entry_1/data_1/data"][self._index, :, :] = img.reshape(
+            -1, img.shape[-1]
+        )
+        self._outh5["/entry_1/result_1/nPeaks"][self._index] = peaks.shape[0]
+        self._outh5["/entry_1/result_1/peakXPosRaw"][self._index, : peaks.shape[0]] = (
+            ch_cols.astype("int")
+        )
+        self._outh5["/entry_1/result_1/peakYPosRaw"][self._index, : peaks.shape[0]] = (
+            ch_rows.astype("int")
+        )
+        self._outh5["/entry_1/result_1/rcent"][self._index, : peaks.shape[0]] = peaks[
+            :, 6
+        ]
+        self._outh5["/entry_1/result_1/ccent"][self._index, : peaks.shape[0]] = peaks[
+            :, 7
+        ]
+        self._outh5["/entry_1/result_1/rmin"][self._index, : peaks.shape[0]] = peaks[
+            :, 10
+        ]
+        self._outh5["/entry_1/result_1/rmax"][self._index, : peaks.shape[0]] = peaks[
+            :, 11
+        ]
+        self._outh5["/entry_1/result_1/cmin"][self._index, : peaks.shape[0]] = peaks[
+            :, 12
+        ]
+        self._outh5["/entry_1/result_1/cmax"][self._index, : peaks.shape[0]] = peaks[
+            :, 13
+        ]
+        self._outh5["/entry_1/result_1/peakTotalIntensity"][
+            self._index, : peaks.shape[0]
+        ] = peaks[:, 5]
+        self._outh5["/entry_1/result_1/peakMaxIntensity"][
+            self._index, : peaks.shape[0]
+        ] = peaks[:, 4]
+
+        # Calculate and write pixel radius
+        peaks_cenx: NDArray[numpy.float_] = (
+            self._i_x[
+                numpy.array(peaks[:, 0], dtype=numpy.int64),
+                numpy.array(peaks[:, 1], dtype=numpy.int64),
+                numpy.array(peaks[:, 2], dtype=numpy.int64),
+            ]
+            + 0.5
+            - self._ipx
+        )
+        peaks_ceny: NDArray[numpy.float_] = (
+            self._i_y[
+                numpy.array(peaks[:, 0], dtype=numpy.int64),
+                numpy.array(peaks[:, 1], dtype=numpy.int64),
+                numpy.array(peaks[:, 2], dtype=numpy.int64),
+            ]
+            + 0.5
+            - self._ipy
+        )
+        peak_radius: NDArray[numpy.float_] = numpy.sqrt(
+            (peaks_cenx**2) + (peaks_ceny**2)
+        )
+        self._outh5["/entry_1/result_1/peakRadius"][
+            self._index, : peaks.shape[0]
+        ] = peak_radius
+
+        # LCLS entry dataset
+        self._outh5["/LCLS/machineTime"][self._index] = timestamp_seconds
+        self._outh5["/LCLS/machineTimeNanoSeconds"][self._index] = timestamp_nanoseconds
+        self._outh5["/LCLS/fiducial"][self._index] = timestamp_fiducials
+        self._outh5["/LCLS/photon_energy_eV"][self._index] = photon_energy
+
+        self._index += 1
+
+    def write_non_event_data(
+        self,
+        powder_hits: NDArray[numpy.float_],
+        powder_misses: NDArray[numpy.float_],
+        mask: NDArray[numpy.uint16],
+        clen: float,
+    ):
+        """
+        Write to the file data that is not related to a specific event (masks, powders)
+
+        Parameters:
+
+            powder_hits (NDArray[numpy.float_]): Virtual powder pattern from hits
+
+            powder_misses (NDArray[numpy.float_]): Virtual powder pattern from hits
+
+            mask: (NDArray[numpy.uint16]): Pixel ask to write into the file
+
+        """
+        # Add powders and mask to files, reshaping them to match the crystfel
+        # convention
+        self._outh5["/entry_1/data_1/powderHits"][:] = powder_hits.reshape(
+            -1, powder_hits.shape[-1]
+        )
+        self._outh5["/entry_1/data_1/powderMisses"][:] = powder_misses.reshape(
+            -1, powder_misses.shape[-1]
+        )
+        self._outh5["/entry_1/data_1/mask"][:] = (1 - mask).reshape(
+            -1, mask.shape[-1]
+        )  # Crystfel expects inverted values
+
+        # Add clen distance
+        self._outh5["/LCLS/detector_1/EncoderValue"][:] = clen
+
+    def optimize_and_close_file(
+        self,
+        num_hits: int,
+        max_peaks: int,
+    ):
+        """
+        Resize data blocks and write additional information to the file
+
+        Parameters:
+
+            num_hits (int): Number of hits for which information has been saved to the
+                file
+
+            max_peaks (int): Maximum number of peaks (per event) for which information
+                can be written into the file
+        """
+
+        # Resize the entry_1 entry
+        data_shape: Tuple[int, ...] = self._outh5["/entry_1/data_1/data"].shape
+        self._outh5["/entry_1/data_1/data"].resize(
+            (num_hits, data_shape[1], data_shape[2])
+        )
+        self._outh5[f"/entry_1/result_1/nPeaks"].resize((num_hits,))
+        key: str
+        for key in [
+            "peakXPosRaw",
+            "peakYPosRaw",
+            "rcent",
+            "ccent",
+            "rmin",
+            "rmax",
+            "cmin",
+            "cmax",
+            "peakTotalIntensity",
+            "peakMaxIntensity",
+            "peakRadius",
+        ]:
+            self._outh5[f"/entry_1/result_1/{key}"].resize((num_hits, max_peaks))
+
+        # Resize LCLS entry
+        for key in [
+            "eventNumber",
+            "machineTime",
+            "machineTimeNanoSeconds",
+            "fiducial",
+            "detector_1/EncoderValue",
+            "photon_energy_eV",
+        ]:
+            self._outh5[f"/LCLS/{key}"].resize((num_hits,))
+        self._outh5.close()
+
+
+def write_master_file(
+    mpi_size: int,
+    outdir: str,
+    exp: str,
+    run: int,
+    tag: str,
+    n_hits_per_rank: List[int],
+    n_hits_total: int,
+):
+    """
+    Generate a virtual dataset to map all individual files for this run.
+
+    Parameters:
+
+        mpi_size (int): Number of ranks in the MPI pool
+
+        outdir (str): Output directory for cxi file.
+
+        exp (str): Experiment string.
+
+        run (int): Experimental run.
+
+        tag (str): Tag to append to cxi file names.
+
+        n_hits_per_rank (List[int]): Array containing the number of hits found on each
+            node processing data.
+
+        n_hits_total (int): Total number of hits found across all nodes.
+    """
+    # Retrieve paths to the files containing data
+    fnames: List[Path] = []
+    fi: int
+    for fi in range(mpi_size):
+        if n_hits_per_rank[fi] > 0:
+            fnames.append(Path(outdir) / f"{exp}_r{run:0>4}_{fi}{tag}.cxi")
+    if len(fnames) == 0:
+        sys.exit("No hits found")
+
+    # Retrieve list of entries to populate in the virtual hdf5 file
+    dname_list, key_list, shape_list, dtype_list = [], [], [], []
+    datasets = ["/entry_1/result_1", "/LCLS/detector_1", "/LCLS", "/entry_1/data_1"]
+    f = h5py.File(fnames[0], "r")
+    for dname in datasets:
+        dset = f[dname]
+        for key in dset.keys():
+            if f"{dname}/{key}" not in datasets:
+                dname_list.append(dname)
+                key_list.append(key)
+                shape_list.append(dset[key].shape)
+                dtype_list.append(dset[key].dtype)
+    f.close()
+
+    # Compute cumulative powder hits and misses for all files
+    powder_hits, powder_misses = None, None
+    for fn in fnames:
+        f = h5py.File(fn, "r")
+        if powder_hits is None:
+            powder_hits = f["entry_1/data_1/powderHits"][:].copy()
+            powder_misses = f["entry_1/data_1/powderMisses"][:].copy()
+        else:
+            powder_hits = numpy.maximum(
+                powder_hits, f["entry_1/data_1/powderHits"][:].copy()
+            )
+            powder_misses = numpy.maximum(
+                powder_misses, f["entry_1/data_1/powderMisses"][:].copy()
+            )
+        f.close()
+
+    vfname: Path = Path(outdir) / f"{exp}_r{run:0>4}{tag}.cxi"
+    with h5py.File(vfname, "w") as vdf:
+
+        # Write the virtual hdf5 file
+        for dnum in range(len(dname_list)):
+            dname = f"{dname_list[dnum]}/{key_list[dnum]}"
+            if key_list[dnum] not in ["mask", "powderHits", "powderMisses"]:
+                layout = h5py.VirtualLayout(
+                    shape=(n_hits_total,) + shape_list[dnum][1:], dtype=dtype_list[dnum]
+                )
+                cursor = 0
+                for i, fn in enumerate(fnames):
+                    vsrc = h5py.VirtualSource(
+                        fn, dname, shape=(n_hits_per_rank[i],) + shape_list[dnum][1:]
+                    )
+                    if len(shape_list[dnum]) == 1:
+                        layout[cursor : cursor + n_hits_per_rank[i]] = vsrc
+                    else:
+                        layout[cursor : cursor + n_hits_per_rank[i], :] = vsrc
+                    cursor += n_hits_per_rank[i]
+                vdf.create_virtual_dataset(dname, layout, fillvalue=-1)
+
+        vdf["entry_1/data_1/powderHits"] = powder_hits
+        vdf["entry_1/data_1/powderMisses"] = powder_misses
+
+
+class FindPeaksPyAlgos(Task):
+    """
+    Task that performs peak finding using the PyAlgos peak finding algorithms and
+    writes the peak information to CXI files.
+    """
+
+    def __init__(self, *, params: TaskParameters) -> None:
+        super().__init__(params=params)
+
+    def _run(self) -> None:
+        ds: Any = MPIDataSource(
+            f"exp={self._task_parameters.lute_config.experiment}:"
+            f"run={self._task_parameters.lute_config.run}:smd"
+        )
+        if self._task_parameters.n_events != 0:
+            ds.break_after(self._task_parameters.n_events)
+
+        det: Any = Detector(self._task_parameters.det_name)
+        det.do_reshape_2d_to_3d(flag=True)
+        evr: Any = Detector(self._task_parameters.event_receiver)
+
+        i_x: Any = det.indexes_x(self._task_parameters.lute_config.run).astype(
+            numpy.int64
+        )
+        i_y: Any = det.indexes_y(self._task_parameters.lute_config.run).astype(
+            numpy.int64
+        )
+        ipx: Any
+        ipy: Any
+        ipx, ipy = det.point_indexes(
+            self._task_parameters.lute_config.run, pxy_um=(0, 0)
+        )
+
+        alg: Any = None
+        num_hits: int = 0
+        num_events: int = 0
+        num_empty_images: int = 0
+        tag: str = self._task_parameters.tag
+        if (tag != "") and (tag[0] != "_"):
+            tag = "_" + tag
+
+        evt: Any
+        for evt in ds.events():
+
+            evt_id: Any = evt.get(EventId)
+            timestamp_seconds: int = evt_id.time()[0]
+            timestamp_nanoseconds: int = evt_id.time()[1]
+            timestamp_fiducials: int = evt_id.fiducials()
+            event_codes: Any = evr.eventCodes(evt)
+
+            if isinstance(self._task_parameters.pv_camera_length, float):
+                clen: float = self._task_parameters.pv_camera_length
+            else:
+                clen = (
+                    ds.env().epicsStore().value(self._task_parameters.pv_camera_length)
+                )
+
+            if self._task_parameters.event_logic:
+                if not self._task_parameters.event_code in event_codes:
+                    continue
+
+            img: Any = det.calib(evt)
+
+            if img is None:
+                num_empty_images += 1
+                continue
+
+            if alg is None:
+                det_shape: Tuple[int, ...] = img.shape
+                if len(det_shape) == 3:
+                    det_shape = (det_shape[0] * det_shape[1], det_shape[2])
+                else:
+                    det_shape = img.shape
+
+                mask: NDArray[numpy.uint16] = numpy.ones(det_shape).astype(numpy.uint16)
+
+                if self._task_parameters.psana_mask:
+                    mask = det.mask(
+                        self.task_parameters.run,
+                        calib=False,
+                        status=True,
+                        edges=False,
+                        centra=False,
+                        unbond=False,
+                        unbondnbrs=False,
+                    ).astype(numpy.uint16)
+
+                if self._task_parameters.mask_file is not None:
+                    mask *= numpy.load(self._task_parameters.mask_file).astype(
+                        numpy.uint16
+                    )
+
+                self._file_writer: CxiWriter = CxiWriter(
+                    outdir=self._task_parameters.outdir,
+                    rank=ds.rank,
+                    exp=self._task_parameters.lute_config.experiment,
+                    run=self._task_parameters.lute_config.run,
+                    n_events=self._task_parameters.n_events,
+                    det_shape=det_shape,
+                    i_x=i_x,
+                    i_y=i_y,
+                    ipx=ipx,
+                    ipy=ipy,
+                    min_peaks=self._task_parameters.min_peaks,
+                    max_peaks=self._task_parameters.max_peaks,
+                    tag=tag,
+                )
+                alg: Any = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
+                alg.set_peak_selection_pars(
+                    npix_min=self._task_parameters.npix_min,
+                    npix_max=self._task_parameters.npix_max,
+                    amax_thr=self._task_parameters.amax_thr,
+                    atot_thr=self._task_parameters.atot_thr,
+                    son_min=self._task_parameters.son_min,
+                )
+
+                powder_hits: NDArray[numpy.float_] = numpy.zeros(det_shape)
+                powder_misses: NDArray[numpy.float_] = numpy.zeros(det_shape)
+
+            peaks: Any = alg.peak_finder_v3r3(
+                img,
+                rank=self._task_parameters.peak_rank,
+                r0=self._task_parameters.r0,
+                dr=self._task_parameters.dr,
+                #      nsigm=self._task_parameters.nsigm,
+            )
+
+            num_events += 1
+
+            if (peaks.shape[0] >= self._task_parameters.min_peaks) and (
+                peaks.shape[0] <= self._task_parameters.max_peaks
+            ):
+
+                try:
+                    photon_energy: float = (
+                        Detector("EBeam").get(evt).ebeamPhotonEnergy()
+                    )
+                except AttributeError:
+                    photon_energy = (
+                        1.23984197386209e-06
+                        / ds.env().epicsStore().value("SIOC:SYS0:ML00:AO192")
+                        / 1.0e9
+                    )
+
+                self._file_writer.write_event(
+                    img=img,
+                    peaks=peaks,
+                    timestamp_seconds=timestamp_seconds,
+                    timestamp_nanoseconds=timestamp_nanoseconds,
+                    timestamp_fiducials=timestamp_fiducials,
+                    photon_energy=photon_energy,
+                )
+                num_hits += 1
+
+            # TODO: Fix bug here
+            # generate / update powders
+            if peaks.shape[0] >= self._task_parameters.min_peaks:
+                powder_hits = numpy.maximum(powder_hits, img)
+            else:
+                powder_misses = numpy.maximum(powder_misses, img)
+
+        if num_empty_images != 0:
+            msg: Message = Message(
+                contents=f"Rank {ds.rank} encountered {num_empty_images} empty images."
+            )
+            self._report_to_executor(msg)
+
+        self._file_writer.write_non_event_data(
+            powder_hits=powder_hits,
+            powder_misses=powder_misses,
+            mask=mask,
+            clen=clen,
+        )
+
+        self._file_writer.optimize_and_close_file(
+            num_hits=num_hits, max_peaks=self._task_parameters.max_peaks
+        )
+
+        COMM_WORLD.Barrier()
+
+        num_hits_per_rank: List[int] = COMM_WORLD.gather(num_hits, root=0)
+        num_hits_total: int = COMM_WORLD.reduce(num_hits, SUM)
+        num_events_per_rank: List[int] = COMM_WORLD.gather(num_events, root=0)
+
+        if ds.rank == 0:
+            write_master_file(
+                mpi_size=ds.size,
+                outdir=self._task_parameters.outdir,
+                exp=self._task_parameters.lute_config.experiment,
+                run=self._task_parameters.lute_config.run,
+                tag=tag,
+                n_hits_per_rank=num_hits_per_rank,
+                n_hits_total=num_hits_total,
+            )
+
+            # Write final summary file
+            with open(
+                Path(self._task_parameters.outdir) / f"peakfinding{tag}.summary", "w"
+            ) as f:
+                f.write(f"Number of events processed: {num_events_per_rank[-1]}\n")
+                f.write(f"Number of hits found: {num_hits_total}\n")
+                f.write(
+                    f"Fractional hit rate: {(num_hits_total/num_events_per_rank[-1]):.2f}\n"
+                )
+                f.write(f"No. hits per rank: {num_hits_per_rank}")
+
+    def _post_run(self) -> None:
+        super()._post_run()
+        self._result.task_status = TaskStatus.COMPLETED

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -251,9 +251,9 @@ class BinaryTask(Task):
         identified.
         """
         super()._pre_run()
-        full_schema: Dict[
-            str, Union[str, Dict[str, Any]]
-        ] = self._task_parameters.schema()
+        full_schema: Dict[str, Union[str, Dict[str, Any]]] = (
+            self._task_parameters.schema()
+        )
         short_flags_use_eq: bool
         long_flags_use_eq: bool
         if hasattr(self._task_parameters.Config, "short_flags_use_eq"):

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -11,7 +11,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import time
 from abc import ABC, abstractmethod
-from typing import Any, List, Dict, Union, Type, TextIO
+from typing import Any, List, Dict, Union, Type, TextIO, Optional
 import os
 import warnings
 import signal
@@ -216,9 +216,17 @@ class BinaryTask(Task):
         out_file: str = self._task_parameters.lute_template_cfg.output_dir
         template_file: str = self._task_parameters.lute_template_cfg.template_dir
 
-        environment: Environment = Environment(
-            loader=FileSystemLoader("../../config/templates")
-        )
+        lute_path: Optional[str] = os.getenv("LUTE_PATH")
+        template_dir: str
+        if lute_path is None:
+            warnings.warn(
+                "LUTE_PATH is None in Task process! Using relative path for templates!",
+                category=UserWarning,
+            )
+            template_dir: str = "../../config/templates"
+        else:
+            template_dir = f"{lute_path}/config/templates"
+        environment: Environment = Environment(loader=FileSystemLoader(template_dir))
         template: Template = environment.get_template(template_file)
 
         with open(out_file, "w", encoding="utf-8") as cfg_out:

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -282,17 +282,18 @@ class BinaryTask(Task):
                     if flag == "--" and isinstance(value, bool) and not value:
                         continue
                     constructed_flag: str = f"{flag}{param_repr}"
-                    if flag == "-" and short_flags_use_eq:
-                        constructed_flag = f"{constructed_flag}={value}"
-                        continue
-                    elif flag == "--" and long_flags_use_eq:
-                        constructed_flag = f"{constructed_flag}={value}"
-                        continue
-                    self._args_list.append(f"{constructed_flag}")
-                    # self._args_list.append(f"{flag}{param_repr}")
                     if flag == "--" and isinstance(value, bool) and value:
                         # On/off flag, e.g. something like --verbose: No Arg
+                        self._args_list.append(f"{constructed_flag}")
                         continue
+                    if (flag == "-" and short_flags_use_eq) or (
+                        flag == "--" and long_flags_use_eq
+                    ):  # Must come after above check! Otherwise you get --param=True
+                        # Flags following --param=value or -param=value
+                        constructed_flag = f"{constructed_flag}={value}"
+                        self._args_list.append(f"{constructed_flag}")
+                        continue
+                    self._args_list.append(f"{constructed_flag}")
             else:
                 warnings.warn(
                     "Model parameters should be defined using Field(...,flag_type='') in the future.",

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -259,7 +259,8 @@ class BinaryTask(Task):
             # converted to `dict`. E.g. type(value) = dict not AnalysisHeader
             if (
                 param == "executable"
-                or value is None
+                or value is None  # Cannot have empty values in argument list for execvp
+                or value == ""  # But do want to include, e.g. 0
                 or isinstance(self._task_parameters.__dict__[param], TemplateConfig)
                 or isinstance(self._task_parameters.__dict__[param], AnalysisHeader)
             ):
@@ -315,14 +316,11 @@ class BinaryTask(Task):
                     self._args_list.append(f"--{param_repr}")
                     if isinstance(value, bool) and value:
                         continue
-            if value != "":
-                # Cannot have empty values in argument list for execvp
-                # So far this only comes for '', but do want to include, e.g. 0
-                if isinstance(value, str) and " " in value:
-                    for val in value.split():
-                        self._args_list.append(f"{val}")
-                else:
-                    self._args_list.append(f"{value}")
+            if isinstance(value, str) and " " in value:
+                for val in value.split():
+                    self._args_list.append(f"{val}")
+            else:
+                self._args_list.append(f"{value}")
         if (
             hasattr(self._task_parameters, "lute_template_cfg")
             and self._template_context

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -11,7 +11,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import time
 from abc import ABC, abstractmethod
-from typing import Any, List, Dict, Union, Type, TextIO, Optional
+from typing import Any, List, Dict, Union, Type, TextIO
 import os
 import warnings
 import signal
@@ -344,25 +344,3 @@ class BinaryTask(Task):
         signal: str = "NO_PICKLE_MODE"
         msg: Message = Message(signal=signal)
         self._report_to_executor(msg)
-
-
-def get_task(where: str) -> Optional[Task]:
-    """Return the current Task."""
-    objects: Dict[str, Any] = globals()
-    for _, obj in objects.items():
-        if isinstance(obj, Task):
-            return obj
-    return None
-
-
-def timeout_handler(signum: int, frame: types.FrameType) -> None:
-    """Log and exit gracefully on Task timeout."""
-    task: Optional[Task] = get_task(__name__)
-    if task:
-        msg: Message = Message(contents="Timed out.", signal="TASK_FAILED")
-        task._report_to_executor(msg)
-        task.clean_up_timeout()
-        sys.exit(-1)
-
-
-signal.signal(signal.SIGALRM, timeout_handler)

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -259,6 +259,7 @@ class BinaryTask(Task):
             # converted to `dict`. E.g. type(value) = dict not AnalysisHeader
             if (
                 param == "executable"
+                or value is None
                 or isinstance(self._task_parameters.__dict__[param], TemplateConfig)
                 or isinstance(self._task_parameters.__dict__[param], AnalysisHeader)
             ):
@@ -313,7 +314,7 @@ class BinaryTask(Task):
                     self._args_list.append(f"--{param_repr}")
                     if isinstance(value, bool) and value:
                         continue
-            if value != "" and value is not None:
+            if value != "":
                 # Cannot have empty values in argument list for execvp
                 # So far this only comes for '', but do want to include, e.g. 0
                 self._args_list.append(f"{value}")

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -318,7 +318,11 @@ class BinaryTask(Task):
             if value != "":
                 # Cannot have empty values in argument list for execvp
                 # So far this only comes for '', but do want to include, e.g. 0
-                self._args_list.append(f"{value}")
+                if isinstance(value, str) and " " in value:
+                    for val in value.split():
+                        self._args_list.append(f"{val}")
+                else:
+                    self._args_list.append(f"{value}")
         if (
             hasattr(self._task_parameters, "lute_template_cfg")
             and self._template_context

--- a/lute/tasks/test.py
+++ b/lute/tasks/test.py
@@ -19,9 +19,9 @@ import time
 
 import numpy as np
 
-from .task import *
-from ..io.models.base import *
-from ..execution.ipc import Message
+from lute.tasks.task import *
+from lute.io.models.base import *
+from lute.execution.ipc import Message
 
 
 class Test(Task):

--- a/run_task.py
+++ b/run_task.py
@@ -3,7 +3,6 @@ import argparse
 import logging
 import os
 
-import lute.tasks as tasks
 from lute.io.config import *
 from lute.execution.executor import *
 

--- a/run_task.py
+++ b/run_task.py
@@ -15,7 +15,7 @@ else:
 logger: logging.Logger = logging.getLogger(__name__)
 
 parser: argparse.ArgumentParser = argparse.ArgumentParser(
-    prog="LUTE Managed Task",
+    prog="run_managed_task",
     description="Run a LUTE managed task.",
     epilog="Refer to https://github.com/slac-lcls/lute for more information.",
 )

--- a/subprocess_task.py
+++ b/subprocess_task.py
@@ -1,11 +1,37 @@
 import sys
 import argparse
 import logging
-from typing import Type
+import signal
+import types
+from typing import Type, Optional, Dict, Any
 
+from lute.tasks.task import Task
+from lute.execution.ipc import Message
 from lute.io.config import *
 from lute.io.models.base import TaskParameters
 from lute import tasks
+
+
+def get_task() -> Optional[Task]:
+    """Return the current Task."""
+    objects: Dict[str, Any] = globals()
+    for _, obj in objects.items():
+        if isinstance(obj, Task):
+            return obj
+    return None
+
+
+def timeout_handler(signum: int, frame: types.FrameType) -> None:
+    """Log and exit gracefully on Task timeout."""
+    task: Optional[Task] = get_task()
+    if task:
+        msg: Message = Message(contents="Timed out.", signal="TASK_FAILED")
+        task._report_to_executor(msg)
+        task.clean_up_timeout()
+        sys.exit(-1)
+
+
+signal.signal(signal.SIGALRM, timeout_handler)
 
 if __debug__:
     logging.basicConfig(level=logging.DEBUG)
@@ -15,7 +41,7 @@ else:
 logger: logging.Logger = logging.getLogger(__name__)
 
 parser: argparse.ArgumentParser = argparse.ArgumentParser(
-    prog="LUTE Task",
+    prog="run_subprocess_task",
     description="Analysis Task run as a subprocess managed by a LUTE Executor.",
     epilog="Refer to https://github.com/slac-lcls/lute for more information.",
 )


### PR DESCRIPTION
# Description

This PR introduces:
- Additional case handling for possible Binary Task parameter configurations. I.e. command-line arguments that are passed in different ways.
- Binary tasks used for serial femtosecond crystallography (SFX): indexing, merging, and structure solution.
- Improved documentation for new Task integration.
- Support for MPI with first-party Tasks. (Third party Tasks can already use MPI, if, e.g., `mpirun` is treated as the executable)

## Checklist
- [x] Change pydantic model `Config` inheritance pattern for `TaskParameters`
- [x] Support new flag types for Binary Tasks
  - [x] Renaming parameters to allow unsupported Python characters (e.g. `-`)
  - [x] Parameters whose arguments are specified using `=`. E.g. `--flag=arg` instead of `--flag arg`.
- [x] Tasks
  - [x] `FindPeaksPyAlgos` - Peak finding based on pyalgos peakfinder algorithm.  (@valmar )
    - [x] Include  Sz Compression and decompression option (@valmar )
  - [x] `IndexCrystFEL` - Use `indexamajig` for indexing
  - [x] `MergePartialator` - Use CrystFEL's `partialator` for merging.
  - [x] `CompareHKL` - Use CrystFEL's `compare_hkl` to compare reflection data. Used internally predominantly for calculating figures of merit.
  - [x] `ManipulateHKL` - Use CrystFEL's `get_hkl` for performing manipulations on lists of reflections. Used internally predominantly to convert `hkl` files to `mtz` files.
  - [x]  `DimpleSolve` - Use `dimple` (CCP4) to solve a structure using molecular replacement.
  - [x] `RunSHELXC` - Use `SHELXC` (CCP4) to prepare input files for `SHELXD` and `SHELXE` (used with experimental phasing) 
- [x] `MPIExecutor` for "first-party" Tasks requiring MPI support. The `MPIExecutor` determines the number of ranks from SLURM environment variables or the number of available cores.
- [x] Determine default number of cores based on SLURM environment variables or number of cores for the third party smalldata_tools `Task`, `SubmitSMD`.
- [x] Database updates:
  - [x] Ability to save selective environment variables. `LUTE` and `SLURM` related variables are stored in the database.
  - [x] Can choose to retrieve parameters from the database for tasks that are marked as failed. E.g. no tasks may have achieved but you may still be interested in one of the parameters that is stored because it is an input parameter for both the failed task and some other task.
- [x] `Executor.source_env` method for sourcing bash files from the `Executor` (in addition to the `update_environment` method).
- [x] Documentation for integrating a new Task.
- [x] Updates to `PipeCommunicator` to improve error handling.
  - Simplify the `read` method.
  - Can handle cases where a single read contains both `pickled` and `unpickled` data. This should not occur during normal usage; however, it can occur during debugging if `print` statements are mixed with `_report_to_executor` calls from within the `Task`.
- [x] GitHub action for `Black`
- [x] Workaround to only `import` the `Task` to be run. This prevents errors due to trying to import libraries from `Task`s that need to be run in a different environment. 

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- NA

# Testing

# Screenshots
NA
# Screenshots
NA