### PR TITLE
MNT/BUG Rename TemplateConfig attributes + bug fix

### DIFF
--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -143,7 +143,15 @@ class BaseBinaryParameters(TaskParameters):
 
 
 class TemplateConfig(BaseModel):
-    """Parameters used for templating of third party configuration files."""
+    """Parameters used for templating of third party configuration files.
 
-    template_dir: str
-    output_dir: str
+    Attributes:
+        template_name (str): The name of the template to use. This template must
+            live in `config/templates`.
+
+        output_path (str): The FULL path, including filename to write the
+            rendered template to.
+    """
+
+    template_name: str
+    output_path: str

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -130,7 +130,7 @@ class SubmitSMDParameters(BaseBinaryParameters):
         False, description="Whether to not use archiver data.", flag_type="--"
     )
 
-    lute_template_cfg: TemplateConfig = TemplateConfig(template_dir="", output_dir="")
+    lute_template_cfg: TemplateConfig = TemplateConfig(template_name="", output_path="")
 
     @validator("producer", always=True)
     def validate_producer_path(cls, producer: str) -> str:
@@ -140,8 +140,8 @@ class SubmitSMDParameters(BaseBinaryParameters):
     def use_producer(
         cls, lute_template_cfg: TemplateConfig, values: Dict[str, Any]
     ) -> TemplateConfig:
-        if not lute_template_cfg.output_dir:
-            lute_template_cfg.output_dir = values["producer"]
+        if not lute_template_cfg.output_path:
+            lute_template_cfg.output_path = values["producer"]
         return lute_template_cfg
 
     # detnames: ThirdPartyParameters = ThirdPartyParameters({})

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -213,8 +213,8 @@ class BinaryTask(Task):
         """
         from jinja2 import Environment, FileSystemLoader, Template
 
-        out_file: str = self._task_parameters.lute_template_cfg.output_dir
-        template_file: str = self._task_parameters.lute_template_cfg.template_dir
+        out_file: str = self._task_parameters.lute_template_cfg.output_path
+        template_name: str = self._task_parameters.lute_template_cfg.template_name
 
         lute_path: Optional[str] = os.getenv("LUTE_PATH")
         template_dir: str
@@ -227,7 +227,7 @@ class BinaryTask(Task):
         else:
             template_dir = f"{lute_path}/config/templates"
         environment: Environment = Environment(loader=FileSystemLoader(template_dir))
-        template: Template = environment.get_template(template_file)
+        template: Template = environment.get_template(template_name)
 
         with open(out_file, "w", encoding="utf-8") as cfg_out:
             cfg_out.write(template.render(self._template_context))

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -276,6 +276,7 @@ class BinaryTask(Task):
             if isinstance(self._task_parameters.__dict__[param], ThirdPartyParameters):
                 # ThirdPartyParameters objects have a single parameter `params`
                 self._add_to_jinja_context(param_name=param, value=value.params)
+                continue
 
             param_attributes: Dict[str, Any] = full_schema["properties"][param]
             # Some model params do not match the commnad-line parameter names


### PR DESCRIPTION
# Description

This PR renames the `TemplateConfig` attributes to more accurately reflect their use and purpose.
 
## Checklist
- [x] Rename `TemplateConfig` attributes.
- [x] Appropriately fix uses of the above attributes in `BinaryTask` code and affected pydantic models.
- [x] Fix bug where the `BinaryTask` continued processing `ThirdPartyParameters` even after adding them to the jinja context.
 
## PR Type:
- [x] Style/Maintenance
- [x] Bug Fix 

## Address issues:
- NA

# Testing
- Tested with actual `BinaryTask` execution disabled. The output rendering of the template at `/sdf/scratch/users/d/dorlhiac/lute_valerio/config/templates/sz.json` can be found here: `/sdf/scratch/users/d/dorlhiac/testsz.json` .

# Screenshots
NA
