### PR TITLE
BUG Account for other Possible unpickling errors

### DIFF
--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -183,7 +183,7 @@ class PipeCommunicator(Communicator):
                     contents = raw_contents.decode()
                 except UnicodeDecodeError as err:
                     logger.debug("PipeCommunicator (Executor) - Set _use_pickle=True")
-                    #                    self._use_pickle = True
+                    self._use_pickle = True
                     contents = self._safe_unpickle_decode(raw_contents)
         else:
             contents = None

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -174,7 +174,7 @@ class PipeCommunicator(Communicator):
             if self._use_pickle:
                 try:
                     contents = pickle.loads(raw_contents)
-                except pickle.UnpicklingError as err:
+                except (pickle.UnpicklingError, ValueError, EOFError) as err:
                     logger.debug("PipeCommunicator (Executor) - Set _use_pickle=False")
                     self._use_pickle = False
                     contents = self._safe_unpickle_decode(raw_contents)
@@ -237,9 +237,18 @@ class PipeCommunicator(Communicator):
             repickled: bytes = pickle.dumps(contents)
             if len(repickled) < len(maybe_mixed):
                 # Successful unpickling, but pickle stops even if there are more bytes
-                additional_data: str = maybe_mixed[len(repickled) :].decode()
-                contents = f"{contents}{additional_data}"
-        except pickle.UnpicklingError as err:
+                try:
+                    additional_data: str = maybe_mixed[len(repickled) :].decode()
+                    contents = f"{contents}{additional_data}"
+                except UnicodeDecodeError:
+                    # Can't decode the bytes left by pickle, so they are lost
+                    missing_bytes: int = len(maybe_mixed) - len(repickled)
+                    logger.debug(
+                        f"PipeCommunicator has truncated message. Unable to retrieve {missing_bytes} bytes."
+                    )
+        except (pickle.UnpicklingError, ValueError, EOFError) as err:
+            # Pickle may also throw a ValueError, e.g. this bytes: b"Found! \n"
+            # Pickle may also throw an EOFError, eg. this bytes: b"F0\n"
             try:
                 contents = maybe_mixed.decode()
             except UnicodeDecodeError as err2:
@@ -251,11 +260,6 @@ class PipeCommunicator(Communicator):
                         f"PipeCommunicator unable to decode/parse data! {err3}"
                     )
                     contents = None
-        except UnicodeDecodeError as err3:
-            missing_bytes: int = len(maybe_mixed) - len(repickled)
-            logger.debug(
-                f"PipeCommunicator has truncated message. Unable to retrieve {missing_bytes} bytes."
-            )
         return contents
 
     def write(self, msg: Message) -> None:


### PR DESCRIPTION
# Description

This PR provides additional error handling in the `PipeCommunicator.read` method to account for other types of exceptions that can arise during unpickling.
 
## Checklist
- [x] Catch `ValueError` and `EOFError` when attempting to unpickle a potentially encoded, or mixed pickle/encoded, bytes object.
- [x] Allow the `PipeCommunicator` to re-enable using pickle by default.

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- NA

# Testing
Tested against the `psocake` peak finding `Task` (merged earlier today) where this potential failure mode was discovered. The `Task` printed the message: `b'Found an event with image:  0\nfindPeaks:  exp=cxic0515:run=0009:idx\n'` which produced an uncaught `ValueError` and caused failure. The temporary fix was to comment out the line of code allowing the `PipeCommunicator` to set `_use_pickle` back to `True`.

The fixes introduced in this PR address the issue. The `Task` runs without error even with the temporary fix removed by uncommenting.

The PR can be tested by running: `/sdf/scratch/users/d/dorlhiac/script_psocake.sh` which points to an installation of LUTE checked out to this branch.
# Screenshots
NA
