### PR TITLE
MNT IndexCrystFEL checks for Psocake output as well

### DIFF
--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -392,10 +392,20 @@ class IndexCrystFELParameters(BaseBinaryParameters):
                 f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "out_file"
             )
             if filename is None:
-                filename = read_latest_db_entry(
-                    f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "out_file"
+                exp: str = values["lute_config"].experiment
+                run: int = int(values["lute_config"].run)
+                tag: Optional[str] = read_latest_db_entry(
+                    f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "tag"
                 )
-            if filename is not None:
+                out_dir: Optional[str] = read_latest_db_entry(
+                    f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "outDir"
+                )
+                if out_dir is not None:
+                    fname: str = f"{out_dir}/{exp}_{run:04d}"
+                    if tag is not None:
+                        fname = f"{fname}_{tag}"
+                    return f"{fname}.lst"
+            else:
                 return filename
         return in_file
 

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -391,6 +391,10 @@ class IndexCrystFELParameters(BaseBinaryParameters):
             filename: Optional[str] = read_latest_db_entry(
                 f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "out_file"
             )
+            if filename is None:
+                filename = read_latest_db_entry(
+                    f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "out_file"
+                )
             if filename is not None:
                 return filename
         return in_file


### PR DESCRIPTION
# Description

This PR adds `FindPeaksPsocake` as a search path for the input file validator of `IndexCrystFEL`. This is a fallback option used only to run a workflow for a specific set of data.
 
## Checklist
- [x] Add `FindPeaksPsocake` database check to `IndexCrystFEL` `in_file` validator.

## PR Type:
- [x] Style/Maintenance

## Address issues:
- NA

# Testing

# Screenshots
NA
