### PR TITLE
BUG Airflow/ARP bugs

### DIFF
--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         "dag_run_id": str(uuid.uuid4()),
         "conf": {
             "experiment": os.environ.get("EXPERIMENT"),
-            "run_id": f"{os.environ.get('RUN_NUM')}{datetime.datetime.utcnow().isoformat()}",
+            "run_id": f"{os.environ.get('RUN_NUM')}_{datetime.datetime.utcnow().isoformat()}",
             "JID_UPDATE_COUNTERS": os.environ.get("JID_UPDATE_COUNTERS"),
             "ARP_ROOT_JOB_ID": os.environ.get("ARP_JOB_ID"),
             "ARP_LOCATION": os.environ.get("ARP_LOCATION", "S3DF"),

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -30,7 +30,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def _retrieve_pw(instance: str = "prod") -> str:
     path: str = "/sdf/group/lcls/ds/tools/lute/airflow_{instance}.txt"
     if instance == "prod" or instance == "test":
-        path = path.format(instance)
+        path = path.format(instance=instance)
     else:
         raise ValueError('`instance` must be either "test" or "prod"!')
 

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -60,7 +60,10 @@ fi
 # Assume all other arguments are for SLURM
 SLURM_ARGS=$@
 
-# Setup logfile names - $EXPERIMENT and $RUN will be available if ARP submitted
+# Setup logfile names - $EXPERIMENT and $RUN_NUM will be available if ARP submitted
+# RUN_NUM is actually in format RUN_DATETIME
+RUN_TIME_ARR=(${RUN_NUM//_/ })
+RUN="${RUN_TIME_ARR[0]}"
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
 SLURM_ARGS+=" --output=${LOG_FILE}.out"

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -399,7 +399,7 @@ class IndexCrystFELParameters(BaseBinaryParameters):
     def validate_out_file(cls, out_file: str, values: Dict[str, Any]) -> str:
         if out_file == "":
             expmt: str = values["lute_config"].experiment
-            run: int = values["lute_config"].run
+            run: int = int(values["lute_config"].run)
             work_dir: str = values["lute_config"].work_dir
             fname: str = f"{expmt}_r{run:04d}.stream"
             return f"{work_dir}/{fname}"


### PR DESCRIPTION
# Description

Bug fix es for running jobs via Airflow using the ARP.
 
## Checklist
- [x] Fix string formatting issue in `launch_airflow.py` preventing credential retrieval.
- [x] Add delimiter between run number and datetime in `run_id` from `launch_airflow.py`
- [x] Correctly parse `RUN_NUM` in `submit_slurm.sh`

## PR Type:
- [x] Bug fix

## Address issues:
- NA

# Testing
Confirmed by launching Airflow on `test` instance for `cxic0515`.


# Screenshots
NA
