### PR TITLE
UTL GitHub Action for Versioned Documentation Building

### DIFF
--- a/.github/workflows/build_versioned_mkdocs.yml
+++ b/.github/workflows/build_versioned_mkdocs.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: 3.10.14
       - name: Install dependencies
-        run: pip install mkdocs mkdocs-material mkdocstrings mike
+        run: pip install mkdocs mkdocs-material mkdocstrings "mkdocstrings[python]" mike
       - name: Build dev version
         if: steps.branch-names.outputs.current_branch == 'dev'
         run: mike deploy --push dev

--- a/.github/workflows/build_versioned_mkdocs.yml
+++ b/.github/workflows/build_versioned_mkdocs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: 3.10.14
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material mkdocstrings mike
       - name: Build dev version

--- a/.github/workflows/build_versioned_mkdocs.yml
+++ b/.github/workflows/build_versioned_mkdocs.yml
@@ -30,6 +30,10 @@ jobs:
           python-version: 3.10.14
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material mkdocstrings "mkdocstrings[python]" mike
+      - name: Git Config
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "<>"
       - name: Build dev version
         if: steps.branch-names.outputs.current_branch == 'dev'
         run: mike deploy --push dev

--- a/.github/workflows/build_versioned_mkdocs.yml
+++ b/.github/workflows/build_versioned_mkdocs.yml
@@ -1,0 +1,39 @@
+name: Build Documentation
+on:
+  push:
+    branches:
+      - dev
+    tags:
+      - '*'
+    #paths:
+    #  - 'docs/**'
+  workflow_dispatch:
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  mkdocs_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        id: branch-names
+        uses: tj-actions/branch-names@v8
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material mkdocstrings mike
+      - name: Build dev version
+        if: steps.branch-names.outputs.current_branch == 'dev'
+        run: mike deploy --push dev
+      - name: Build release
+        #if: steps.branch-names.outputs.current_branch == 'main'
+        if: steps.branch-names.outputs.is_tag == 'true'
+        run: mike deploy --push --update-aliases ${{ steps.branch-names.outputs.tag }} latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,5 +49,15 @@ plugins:
         paths: [lute]
         options:
           show_source: true
+- mike:
+    # These fields are all optional; the defaults are as below...
+    alias_type: symlink
+    redirect_template: null
+    deploy_prefix: ''
+    canonical_version: dev
+    version_selector: true
+    css_dir: css
+    javascript_dir: js
 theme:
-  name: readthedocs
+  #name: readthedocs
+  name: material


### PR DESCRIPTION
# Description

This PR provides a GitHub action to build versioned documentation to be deployed to the website using `mike` and `MkDocs`. The website theme is updated to `material`.

## Checklist
- [x] GitHub Action for versioned documentation building.
- [x] Switch to `Material` theme for documentation

## PR Type:
- [x] CI/CD

## Address issues:
- NA

# Testing
Tested action by deploying to local fork. (https://gadorlhiac.github.io/lute_dorlhiac/0.1/)

# Screenshots

![image](https://github.com/user-attachments/assets/b1088ab1-940d-410c-91a1-1b3c702b02ea)

![image](https://github.com/user-attachments/assets/654d7b1b-1400-4c7e-b6dd-61584497a58b)

