### PR TITLE
ENH IPC Improvements - Support TCP, ZMQ and Better multi-node handling

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -133,7 +133,7 @@ TestSocket:
 
 TestMultiNodeCommunication:
   send_obj: "plot" # Either "plot" or "array". Type of object to send
-  arr_size: 5  	   # Size of the array if sending array
+  arr_size: 5      # Size of the array if sending array
 
 FindPeaksPyAlgos:
     outdir: ""

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -131,6 +131,10 @@ TestSocket:
   array_size: 8000 # Size of arrays to send. 8000 floats ~ 6.4e4
   num_arrays: 10 # Number of arrays to send.
 
+TestMultiNodeCommunication:
+  send_obj: "plot" # Either "plot" or "array". Type of object to send
+  arr_size: 5  	   # Size of the array if sending array
+
 FindPeaksPyAlgos:
     outdir: ""
     n_events: 100

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -324,13 +324,17 @@ There are more examples of this pattern spread throughout the various `Task` mod
 
 **Overview**
 
-After a pydantic model has been created, the next required step is to define a **managed `Task`**. In the context of this library, a **managed `Task`** refers to the combination of an `Executor` and a `Task` to run. The `Executor` manages the process of `Task` submission and the execution environment, as well as performing an logging, eLog communication, etc. There are currently two types of `Executor` to choose from. For most cases you will use the first option for third-party `Task`s.
+After a pydantic model has been created, the next required step is to define a **managed `Task`**. In the context of this library, a **managed `Task`** refers to the combination of an `Executor` and a `Task` to run. The `Executor` manages the process of `Task` submission and the execution environment, as well as performing any logging, eLog communication, etc. There are currently two types of `Executor` to choose from, **but only one is applicable to third-party code.** The second `Executor` is listed below for completeness only. If you need MPI see the note below.
 
-1. `Executor`: This is the standard `Executor` and sufficient for most third-party uses cases.
+1. `Executor`: This is the standard `Executor`. It should be used for third-party uses cases.
 2. `MPIExecutor`: This performs all the same types of operations as the option above; however, it will submit your `Task` using MPI.
   - The `MPIExecutor` will submit the `Task` using the number of available cores - 1. The number of cores is determined from the physical core/thread count on your local machine, or the number of cores allocated by SLURM when submitting on the batch nodes.
 
-As mentioned, for most cases you can setup a third-party `Task` to use the first type of `Executor`. If, however, your third-party `Task` uses MPI, you can use either. When using the standard `Executor` for a `Task` requiring MPI, the `executable` in the pydantic model must be set to `mpirun`. For example, a third-party `Task` model, that uses MPI but can be run with the `Executor` may look like the following. We assume this `Task` runs a Python script using MPI.
+**Using MPI with third-party `Task`s**
+
+As mentioned, you should setup a third-party `Task` to use the first type of `Executor`. If, however, your third-party `Task` uses MPI this may seem non-intuitive. When using the `MPIExecutor` LUTE code is submitted with MPI. This includes the code that performs signalling to the `Executor` and `exec`s the third-party code you are interested in running. While it is possible to set this code up to run with MPI, it is more challenging in the case of third-party `Task`s because there is no `Task` code to modify directly! The `MPIExecutor` is provided mostly for first-party code. This is not an issue, however, since the standard `Executor` is easily configured to run with MPI in the case of third-party code.
+
+When using the standard `Executor` for a `Task` requiring MPI, the `executable` in the pydantic model must be set to `mpirun`. For example, a third-party `Task` model, that uses MPI but is intended to be run with the `Executor` may look like the following. We assume this `Task` runs a Python script using MPI.
 
 ```py
 class RunMPITaskParameters(ThirdPartyParameters):
@@ -603,8 +607,9 @@ In addition to the global configuration options there are a couple of ways to sp
 
 ### Writing the `Task`
 You can write your analysis code (or whatever code to be executed) as long as it adheres to the limited rules below. You can create a new module for your `Task` in `lute.tasks` or add it to any existing module, if it makes sense for it to belong there. The `Task` itself is a single class constructed as:
+
 1. Your analysis `Task` is a class named in a way that matches its Pydantic model. E.g. `RunTask` is the `Task`, and `RunTaskParameters` is the Pydantic model.
-2. The class must inherit from the `Task` class (see template below).
+2. The class must inherit from the `Task` class (see template below). **If you intend to use MPI see the following section.**
 3. You must provide an implementation of a `_run` method. This is the method that will be executed when the `Task` is run. You can in addition write as many methods as you need. For fine-grained execution control you can also provide `_pre_run()` and `_post_run()` methods, but this is optional.
 4. For all communication (including print statements) you should use the `_report_to_executor(msg: Message)` method. Since the `Task` is run as a subprocess this method will pass information to the controlling `Executor`. You can pass **any** type of object using this method, strings, plots, arrays, etc.
 5. If you did not use the `set_result` configuration option in your parameters model, make sure to provide a result when finished. This is done by setting `self._result.payload = ...`. You can set the result to be any object. If you have written the result to a file, for example, please provide a path.
@@ -652,6 +657,34 @@ class RunTask(Task): # Inherit from Task
         self._result.task_status = TaskStatus.COMPLETED
 ```
 
+#### Using MPI for your `Task`
+
+In the case your `Task` is written to use `MPI` a slight modification to the template above is needed. Specifically, an additional keyword argument should be passed to the base class initializer: `use_mpi=True`. This tells the base class to adjust signalling/communication behaviour appropriately for a multi-rank MPI program. Doing this prevents tricky-to-track-dow problems due to ranks starting, completing and sending messages at different times. The rest of your code can, as before, be written as you see fit. The use of this keyword argument will also synchronize the start of all ranks and wait until all ranks have finished to exit.
+
+```py
+"""Task which needs to run with MPI"""
+
+__all__ = ["RunTask"]
+__author__ = "" # Please include so we know who the SME is
+
+# Include any imports you need here
+
+from lute.execution.ipc import Message # Message for communication
+from lute.io.models.base import *      # For TaskParameters
+from lute.tasks.task import *          # For Task
+
+# Only the init is shown
+class RunMPITask(Task): # Inherit from Task
+    """Task description goes here, or in __init__"""
+
+    # Signal the use of MPI!
+    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+        super().__init__(params=params, use_mpi=use_mpi) # Sets up Task, parameters, etc.
+        # That's it.
+```
+
+#### Message signals
+
 Signals in `Message` objects are strings and can be one of the following:
 
 ```py
@@ -684,4 +717,4 @@ def import_task(task_name: str) -> Type[Task]:
 ```
 
 ### Defining an `Executor`
-The process of `Executor` definition is identical to the process as described for `ThirdPartyTask`s above.
+The process of `Executor` definition is identical to the process as described for `ThirdPartyTask`s above. The one exception is if you defined the `Task` to use MPI as described in the section above (Using MPI for your `Task`), you will likely consider using the `MPIExecutor`.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -659,7 +659,7 @@ class RunTask(Task): # Inherit from Task
 
 #### Using MPI for your `Task`
 
-In the case your `Task` is written to use `MPI` a slight modification to the template above is needed. Specifically, an additional keyword argument should be passed to the base class initializer: `use_mpi=True`. This tells the base class to adjust signalling/communication behaviour appropriately for a multi-rank MPI program. Doing this prevents tricky-to-track-dow problems due to ranks starting, completing and sending messages at different times. The rest of your code can, as before, be written as you see fit. The use of this keyword argument will also synchronize the start of all ranks and wait until all ranks have finished to exit.
+In the case your `Task` is written to use `MPI` a slight modification to the template above is needed. Specifically, an additional keyword argument should be passed to the base class initializer: `use_mpi=True`. This tells the base class to adjust signalling/communication behaviour appropriately for a multi-rank MPI program. Doing this prevents tricky-to-track-down problems due to ranks starting, completing and sending messages at different times. The rest of your code can, as before, be written as you see fit. The use of this keyword argument will also synchronize the start of all ranks and wait until all ranks have finished to exit.
 
 ```py
 """Task which needs to run with MPI"""

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -78,6 +78,7 @@ if [[ -z ${LUTE_USE_TCP} || ${LUTE_USE_TCP} != 0 ]]; then
     export LUTE_USE_TCP=1
 else
     echo "Using Unix sockets"
+    unset LUTE_USE_TCP
     export LUTE_SOCKET="/tmp/lute_${RANDOM}.sock"
 fi
 

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -74,8 +74,10 @@ SLURM_ARGS+=" --error=${LOG_FILE}.out"
 
 # If LUTE_USE_TCP is unset use TCP
 if [[ -z ${LUTE_USE_TCP} || ${LUTE_USE_TCP} != 0 ]]; then
+    echo "Using TCP"
     export LUTE_USE_TCP=1
 else
+    echo "Using Unix sockets"
     export LUTE_SOCKET="/tmp/lute_${RANDOM}.sock"
 fi
 

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -72,7 +72,12 @@ LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S'
 SLURM_ARGS+=" --output=${LOG_FILE}.out"
 SLURM_ARGS+=" --error=${LOG_FILE}.out"
 
-export LUTE_SOCKET="/tmp/lute_${RANDOM}.sock"
+# If LUTE_USE_TCP is unset use TCP
+if [[ -z ${LUTE_USE_TCP} || ${LUTE_USE_TCP} != 0 ]]; then
+    export LUTE_USE_TCP=1
+else
+    export LUTE_SOCKET="/tmp/lute_${RANDOM}.sock"
+fi
 
 # By default source the psana environment since most Tasks will use it.
 source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -252,8 +252,9 @@ class BaseExecutor(ABC):
             # Not great, but experience shows we need a bit of time to setup
             # network.
             time.sleep(0.1)
-        # Propagate any env vars setup by Communicators
-        self._analysis_desc.task_env.update(os.environ)
+        # Propagate any env vars setup by Communicators - only update LUTE_ vars
+        tmp: Dict[str, str] = {key: os.environ[key] for key in os.environ if "LUTE_" in key}
+        self._analysis_desc.task_env.update(tmp)
 
     def _submit_task(self, cmd: str) -> subprocess.Popen:
         proc: subprocess.Popen = subprocess.Popen(

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -596,17 +596,20 @@ class Executor(BaseExecutor):
         that its finished.
         """
         for communicator in self._communicators:
-            msg: Message = communicator.read(proc)
-            if msg.signal is not None and msg.signal.upper() in LUTE_SIGNALS:
-                hook: Callable[[Executor, Message], None] = getattr(
-                    self.Hooks, msg.signal.lower()
-                )
-                hook(self, msg)
-            if msg.contents is not None:
-                if isinstance(msg.contents, str) and msg.contents != "":
-                    logger.info(msg.contents)
-                elif not isinstance(msg.contents, str):
-                    logger.info(msg.contents)
+            while True:
+                msg: Message = communicator.read(proc)
+                if msg.signal is not None and msg.signal.upper() in LUTE_SIGNALS:
+                    hook: Callable[[Executor, Message], None] = getattr(
+                        self.Hooks, msg.signal.lower()
+                    )
+                    hook(self, msg)
+                if msg.contents is not None:
+                    if isinstance(msg.contents, str) and msg.contents != "":
+                        logger.info(msg.contents)
+                    elif not isinstance(msg.contents, str):
+                        logger.info(msg.contents)
+                if not communicator.has_messages:
+                    break
 
     def _finalize_task(self, proc: subprocess.Popen) -> None:
         """Any actions to be performed after the Task has ended.

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -861,7 +861,14 @@ class SocketCommunicator(Communicator):
                 self._local_socket_path = self._setup_unix_ssh_tunnel(
                     socket_path, hostname, executor_hostname
                 )
-                data_socket.connect(self._local_socket_path)
+                while 1:
+                    # Keep trying reconnect until ssh tunnel works.
+                    try:
+                        data_socket.connect(self._local_socket_path)
+                        break
+                    except FileNotFoundError:
+                        continue
+
         return data_socket
 
     def _init_unix_socket_zmq(self, data_socket: zmq.sugar.socket.Socket) -> None:

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -18,7 +18,7 @@ __all__ = [
     "Communicator",
     "PipeCommunicator",
     "LUTE_SIGNALS",
-    "SocketCommunicator",
+    "SocketCommunicator",  # Points to one of two classes below. See bottom
 ]
 __author__ = "Gabriel Dorlhiac"
 
@@ -34,7 +34,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Set, List
+from typing import Any, Optional, Set, List, Literal, Union
 
 import _io
 from typing_extensions import Self
@@ -307,18 +307,33 @@ class PipeCommunicator(Communicator):
             sys.stdout.write(raw_contents)
 
 
-class SocketCommunicator(Communicator):
-    """Provides communication over Unix sockets.
+class RawSocketCommunicator(Communicator):
+    """Provides communication over raw Unix or TCP sockets.
 
+    Whether to use TCP or Unix sockets is controlled by the environment:
+                           `LUTE_USE_TCP=1`
+    If defined, TCP sockets will be used, otherwise Unix sockets will be used.
+
+    Regardless of socket type, the environment variable
+                      `LUTE_EXECUTOR_HOST=<hostname>`
+    will be defined by the Executor-side Communicator.
+
+
+    For TCP sockets:
+    The Executor-side Communicator should be run first and will bind to all
+    interfaces on the port determined by the environment variable:
+                            `LUTE_PORT=###`
+    If no port is defined, a port scan will be performed and the Executor-side
+    Communicator will bind the first one available from a random selection. It
+    will then define the environment variable so the Task-side can pick it up.
+
+    For Unix sockets:
     The path to the Unix socket is defined by the environment variable:
                       `LUTE_SOCKET=/path/to/socket`
     This class assumes proper permissions and that this above environment
     variable has been defined. The `Task` is configured as what would commonly
     be referred to as the `client`, while the `Executor` is configured as the
-    server. The Executor continuosly monitors for connections and appends any
-    Messages that are received to a queue. Read requests retrieve Messages from
-    the queue. Task-side Communicators are fleeting so they open a connection,
-    send data, and immediately close and clean up.
+    server.
 
     If the Task process is run on a different machine than the Executor, the
     Task-side Communicator will open a ssh-tunnel to forward traffic from a local
@@ -339,7 +354,7 @@ class SocketCommunicator(Communicator):
     """
 
     def __init__(self, party: Party = Party.TASK, use_pickle: bool = True) -> None:
-        """IPC over a Unix socket.
+        """IPC over a TCP or Unix socket.
 
         Unlike with the PipeCommunicator, pickle is always used to send data
         through the socket.
@@ -352,7 +367,7 @@ class SocketCommunicator(Communicator):
                 passing False does not change behaviour.
         """
         super().__init__(party=party, use_pickle=use_pickle)
-        self.desc: str = "Communicates through a Unix socket."
+        self.desc: str = "Communicates through a TCP or Unix socket."
         if self._party == Party.EXECUTOR:
             # Executor created first so we can define the hostname env variable
             os.environ["LUTE_EXECUTOR_HOST"] = socket.gethostname()
@@ -380,7 +395,7 @@ class SocketCommunicator(Communicator):
             [self._data_socket],
             [],
             [self._data_socket],
-            SocketCommunicator.READ_TIMEOUT,
+            RawSocketCommunicator.READ_TIMEOUT,
         )
 
         msg: Message
@@ -388,7 +403,7 @@ class SocketCommunicator(Communicator):
             connection, _ = has_data[0].accept()
             full_data: bytes = b""
             while True:
-                data: bytes = connection.recv(1024)
+                data: bytes = connection.recv(8192)
                 if data:
                     full_data += data
                 else:
@@ -411,18 +426,91 @@ class SocketCommunicator(Communicator):
         """
         self._write_socket(msg)
 
-    def _create_socket(self) -> socket.socket:
-        """Returns a socket object.
+    def _find_random_port(
+        self, min_port: int = 41923, max_port: int = 64324, max_tries: int = 100
+    ) -> Optional[int]:
+        """Find a random open port to bind to if using TCP."""
+        from random import choices
+
+        sock: socket.socket
+        ports: List[int] = choices(range(min_port, max_port), k=max_tries)
+        for port in ports:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                sock.bind(("", port))
+                sock.close()
+                del sock
+                return port
+            except:
+                continue
+        return None
+
+    def _init_tcp_socket(self) -> socket.socket:
+        """Initialize a TCP socket.
+
+        Executor-side code should always be run first. It checks to see if
+        the environment variable
+                                `LUTE_PORT=###`
+        is defined, if so binds it, otherwise find a free port from a selection
+        of random ports. If a port search is performed, the `LUTE_PORT` variable
+        will be defined so it can be picked up by the the Task-side Communicator.
+
+        In the event that no port can be bound on the Executor-side, or the port
+        and hostname information is unavailable to the Task-side, the program
+        will exit.
+
+        Returns:
+            data_socket (socket.socket): TCP socket object.
+        """
+        data_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        port: Optional[Union[str, int]] = os.getenv("LUTE_PORT")
+        if self._party == Party.EXECUTOR:
+            if port is None:
+                # If port is None find one
+                # Executor code executes first
+                port = self._find_random_port()
+                if port is None:
+                    # Failed to find a port to bind
+                    logger.info(
+                        "Executor failed to bind a port. "
+                        "Try providing a LUTE_PORT directly! Exiting!"
+                    )
+                    sys.exit(-1)
+                # Provide port env var for Task-side
+                os.environ["LUTE_PORT"] = str(port)
+            data_socket.bind(("", int(port)))
+            data_socket.listen()
+        else:
+            executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
+            if executor_hostname is None or port is None:
+                logger.info(
+                    "Task-side does not have host/port information!"
+                    " Check environment variables! Exiting!"
+                )
+                sys.exit(-1)
+            data_socket.connect((executor_hostname, int(port)))
+        return data_socket
+
+    def _init_unix_socket(self) -> socket.socket:
+        """Returns a Unix socket object.
+
+        Executor-side code should always be run first. It checks to see if
+        the environment variable
+                                `LUTE_SOCKET=XYZ`
+        is defined, if so binds it, otherwise it will create a new path and
+        define the environment variable for the Task-side to find.
 
         On the Task (client-side), this method will also open a SSH tunnel to
         forward a local Unix socket to an Executor Unix socket if the Task and
         Executor processes are on different machines.
 
-        The SSH tunnel is opened with `ssh -NTf -L <local>:<remote>`.
-        These options are for:
-        - `-N`: Do not execute remote command (useful for port forwarding).
-        - `-T`: Disable pseudo-terminal.
-        - `-f`: Go to background before command execution.
+        The SSH tunnel is opened with `ssh -L <local>:<remote> sleep 2`.
+        This method of communication is slightly slower and incurs additional
+        overhead - it should only be used as a backup. If communication across
+        multiple hosts is required consider using TCP.  The Task will use
+        the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
+        created. It is assumed that the user is identical on both the
+        Task machine and Executor machine.
 
         Returns:
             data_socket (socket.socket): Unix socket object.
@@ -438,15 +526,13 @@ class SocketCommunicator(Communicator):
             # Executor-side always created first, Task will use the same one
             socket_path = f"{tempfile.gettempdir()}/lute_{uuid.uuid4().hex}.sock"
             os.environ["LUTE_SOCKET"] = socket_path
-            logger.debug(f"SocketCommunicator defines socket_path: {socket_path}")
-
-        data_socket: socket.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
+            logger.debug(f"UnixSocketCommunicator defines socket_path: {socket_path}")
+        data_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         if self._party == Party.EXECUTOR:
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
             data_socket.bind(socket_path)
-            data_socket.listen(10)
+            data_socket.listen()
         elif self._party == Party.TASK:
             hostname: str = socket.gethostname()
             executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
@@ -463,35 +549,59 @@ class SocketCommunicator(Communicator):
                 self._use_ssh_tunnel = True
                 ssh_cmd: List[str] = [
                     "ssh",
-                    "-NTf",
+                    "-o",
+                    "LogLevel=quiet",
                     "-L",
                     f"{self._local_socket_path}:{socket_path}",
                     executor_hostname,
+                    "sleep",
+                    "2",
                 ]
                 logger.debug(f"Opening tunnel from {hostname} to {executor_hostname}")
                 self._ssh_proc = subprocess.Popen(ssh_cmd)
-                time.sleep(0.2)  # Need to wait... -> Use single Task comm at beginning?
+                time.sleep(0.4)  # Need to wait... -> Use single Task comm at beginning?
                 data_socket.connect(self._local_socket_path)
-
         return data_socket
 
-    def _write_socket(self, msg: Message) -> None:
-        """Sends data over a socket from the 'client' (Task) side.
+    def _create_socket(self) -> socket.socket:
+        """Create either a Unix or TCP socket.
 
-        Communicator objects on the Task-side are fleeting, so a socket is
-        opened, data is sent, and then the connection and socket are cleaned up.
+        If the environment variable:
+                              `LUTE_USE_TCP=1`
+        is defined, a TCP socket is returned, otherwise a Unix socket.
+
+        Refer to the individual initialization methods for additional environment
+        variables controlling the behaviour of these two communication types.
+
+        Returns:
+            data_socket (socket.socket): TCP or Unix socket.
         """
-        self._data_socket.sendall(pickle.dumps(msg))
+        import struct
 
-        self._clean_up()
+        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
+        sock: socket.socket
+        if use_tcp is not None:
+            sock = self._init_tcp_socket()
+        else:
+            sock = self._init_unix_socket()
+        sock.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 10000)
+        )
+        return sock
+
+    def _write_socket(self, msg: Message) -> None:
+        """Sends data over a socket from the 'client' (Task) side."""
+        self._data_socket.sendall(pickle.dumps(msg))
 
     def _clean_up(self) -> None:
         """Clean up connections."""
         # Check the object exists in case the Communicator is cleaned up before
         # opening any connections
-        if hasattr(self, "_data_socket"):
+        if hasattr(self, "_data_socket") and not self._data_socket._closed:
             socket_path: str = self.socket_path
             self._data_socket.close()
+            if os.getenv("LUTE_USE_TCP"):
+                return
             if self._party == Party.EXECUTOR or self._use_ssh_tunnel:
                 os.unlink(socket_path)
                 if self._ssh_proc is not None:
@@ -509,3 +619,284 @@ class SocketCommunicator(Communicator):
 
     def __exit__(self):
         self._clean_up()
+
+    def __del__(self):
+        self._clean_up()
+
+
+import zmq
+
+
+class ZMQCommunicator(Communicator):
+    """Provides communication over Unix or TCP sockets with ZMQ.
+
+    Whether to use TCP or Unix sockets is controlled by the environment:
+                           `LUTE_USE_TCP=1`
+    If defined, TCP sockets will be used, otherwise Unix sockets will be used.
+
+    Regardless of socket type, the environment variable
+                      `LUTE_EXECUTOR_HOST=<hostname>`
+    will be defined by the Executor-side Communicator.
+
+
+    For TCP sockets:
+    The Executor-side Communicator should be run first and will bind to all
+    interfaces on the port determined by the environment variable:
+                            `LUTE_PORT=###`
+    If no port is defined, ZMQ will bind a random port. The Communicator
+    will then define the environment variable so the Task-side can pick it up.
+
+    For Unix sockets:
+    The path to the Unix socket is defined by the environment variable:
+                      `LUTE_SOCKET=/path/to/socket`
+    This class assumes proper permissions and that this above environment
+    variable has been defined. The `Task` is configured as what would commonly
+    be referred to as the `client`, while the `Executor` is configured as the
+    server.
+
+    If the Task process is run on a different machine than the Executor, the
+    Task-side Communicator will open a ssh-tunnel to forward traffic from a local
+    Unix socket to the Executor Unix socket. Opening of the tunnel relies on the
+    environment variable:
+                      `LUTE_EXECUTOR_HOST=<hostname>`
+    to determine the Executor's host. This variable should be defined by the
+    Executor and passed to the Task process automatically, but it can also be
+    defined manually if launching the Task process separately. The Task will use
+    the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
+    created. Currently, it is assumed that the user is identical on both the Task
+    machine and Executor machine.
+    """
+
+    READ_TIMEOUT: float = 0.01
+    """
+    Maximum time to wait to retrieve data.
+    """
+
+    def __init__(self, party: Party = Party.TASK, use_pickle: bool = True) -> None:
+        """IPC over a TCP or Unix socket.
+
+        Args:
+            party (Party): Which object (side/process) the Communicator is
+                managing IPC for. I.e., is this the "Task" or "Executor" side.
+
+            use_pickle (bool): Whether to use pickle. Always True currently,
+                passing False does not change behaviour.
+        """
+        super().__init__(party=party, use_pickle=use_pickle)
+        self.desc: str = "Communicates using ZMQ through TCP or Unix sockets."
+        if self._party == Party.EXECUTOR:
+            # Executor created first so we can define the hostname env variable
+            os.environ["LUTE_EXECUTOR_HOST"] = socket.gethostname()
+
+        self._context: zmq.context.Context = zmq.Context()
+        self._use_ssh_tunnel: bool = False
+        self._ssh_proc: Optional[subprocess.Popen] = None
+        self._local_socket_path: Optional[str] = None
+        self._data_socket: zmq.sugar.socket.Socket = self._create_socket()
+
+    def read(self, proc: subprocess.Popen) -> Message:
+        """Read data from a socket.
+
+        Socket(s) are continuously monitored, and read from when new data is
+        available.
+
+        Args:
+            proc (subprocess.Popen): The process to read from. Provided for
+                compatibility with other Communicator subtypes. Is ignored.
+
+        Returns:
+             msg (Message): The message read, containing contents and signal.
+        """
+        msg: Message = Message()
+        try:
+            data: bytes = self._data_socket.recv(zmq.NOBLOCK)
+            msg = pickle.loads(data)
+        except zmq.error.Again:
+            pass
+        finally:
+            return msg
+
+    def write(self, msg: Message) -> None:
+        """Send a single Message.
+
+        The entire Message (signal and contents) is serialized and sent through
+        a connection over Unix socket.
+
+        Args:
+            msg (Message): The Message to send.
+        """
+        self._write_socket(msg)
+
+    def _init_tcp_socket(self, data_socket: zmq.sugar.socket.Socket) -> None:
+        """Initialize a TCP socket.
+
+        Executor-side code should always be run first. It checks to see if
+        the environment variable
+                                `LUTE_PORT=###`
+        is defined, if so binds it, otherwise find a free port from a selection
+        of random ports. If a port search is performed, the `LUTE_PORT` variable
+        will be defined so it can be picked up by the the Task-side Communicator.
+
+        In the event that no port can be bound on the Executor-side, or the port
+        and hostname information is unavailable to the Task-side, the program
+        will exit.
+
+        Args:
+            data_socket (zmq.socket.Socket): Socket object.
+        """
+        port: Optional[Union[str, int]] = os.getenv("LUTE_PORT")
+        if self._party == Party.EXECUTOR:
+            if port is None:
+                new_port: int = data_socket.bind_to_random_port("tcp://*")
+                if new_port is None:
+                    # Failed to find a port to bind
+                    logger.info(
+                        "Executor failed to bind a port. "
+                        "Try providing a LUTE_PORT directly! Exiting!"
+                    )
+                    sys.exit(-1)
+                port = new_port
+                os.environ["LUTE_PORT"] = str(port)
+            else:
+                data_socket.bind(f"tcp://*:{port}")
+            logger.debug(f"Executor bound port {port}")
+            # data_socket.subscribe(b"") # Can define topics later.
+            # data_socket.setsockopt(zmq.LINGER,0)
+        else:
+            executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
+            if executor_hostname is None or port is None:
+                logger.info(
+                    "Task-side does not have host/port information!"
+                    " Check environment variables! Exiting!"
+                )
+                sys.exit(-1)
+            data_socket.connect(f"tcp://{executor_hostname}:{port}")
+
+    def _init_unix_socket(self, data_socket: zmq.sugar.socket.Socket) -> None:
+        """Initialize a Unix socket object.
+
+        Executor-side code should always be run first. It checks to see if
+        the environment variable
+                                `LUTE_SOCKET=XYZ`
+        is defined, if so binds it, otherwise it will create a new path and
+        define the environment variable for the Task-side to find.
+
+        On the Task (client-side), this method will also open a SSH tunnel to
+        forward a local Unix socket to an Executor Unix socket if the Task and
+        Executor processes are on different machines.
+
+        The SSH tunnel is opened with `ssh -L <local>:<remote> sleep 2`.
+        This method of communication is slightly slower and incurs additional
+        overhead - it should only be used as a backup. If communication across
+        multiple hosts is required consider using TCP.  The Task will use
+        the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
+        created. It is assumed that the user is identical on both the
+        Task machine and Executor machine.
+
+        Args:
+            data_socket (socket.socket): ZMQ object.
+        """
+        try:
+            socket_path = os.environ["LUTE_SOCKET"]
+        except KeyError:
+            import uuid
+            import tempfile
+
+            # Define a path,up and add to environment
+            # Executor-side always created first, Task will use the same one
+            socket_path = f"{tempfile.gettempdir()}/lute_{uuid.uuid4().hex}.sock"
+            os.environ["LUTE_SOCKET"] = socket_path
+            logger.debug(f"ZMQCommunicator defines socket_path: {socket_path}")
+
+        socket_path = f"ipc:/{socket_path}"
+        if self._party == Party.EXECUTOR:
+            if os.path.exists(socket_path):
+                os.unlink(socket_path)
+            data_socket.bind(socket_path)
+            # data_socket.subscribe(b"")
+        elif self._party == Party.TASK:
+            hostname: str = socket.gethostname()
+            executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
+            if executor_hostname is None:
+                logger.info("Hostname for Executor process not found! Exiting!")
+                self._data_socket.close()
+                sys.exit(-1)
+            if hostname == executor_hostname:
+                data_socket.connect(socket_path)
+            else:
+                if "uuid" not in locals():
+                    import uuid
+                self._local_socket_path = f"{socket_path}.task{uuid.uuid4().hex[:4]}"
+                self._use_ssh_tunnel = True
+                ssh_cmd: List[str] = [
+                    "ssh",
+                    "-o",
+                    "LogLevel=quiet",
+                    "-L",
+                    f"{self._local_socket_path[5:]}:{socket_path[5:]}",  # remove ipc:/
+                    executor_hostname,
+                    "sleep",
+                    "2",
+                ]
+                logger.debug(f"Opening tunnel from {hostname} to {executor_hostname}")
+                self._ssh_proc = subprocess.Popen(ssh_cmd)
+                time.sleep(0.4)  # Need to wait... -> Use single Task comm at beginning?
+                data_socket.connect(self._local_socket_path)
+
+    def _create_socket(self) -> zmq.sugar.socket.Socket:
+        """Create either a Unix or TCP socket.
+
+        If the environment variable:
+                              `LUTE_USE_TCP=1`
+        is defined, a TCP socket is returned, otherwise a Unix socket.
+
+        Refer to the individual initialization methods for additional environment
+        variables controlling the behaviour of these two communication types.
+
+        Returns:
+            data_socket (socket.socket): Unix socket object.
+        """
+        socket_type: Literal[zmq.SUB, zmq.PUB]
+        if self._party == Party.EXECUTOR:
+            socket_type = zmq.PULL
+        else:
+            socket_type = zmq.PUSH
+
+        data_socket: zmq.sugar.socket.Socket = self._context.socket(socket_type)
+        data_socket.set_hwm(160000)
+        # Try TCP first
+        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
+        if use_tcp is not None:
+            self._init_tcp_socket(data_socket)
+        else:
+            self._init_unix_socket(data_socket)
+
+        return data_socket
+
+    def _write_socket(self, msg: Message) -> None:
+        """Sends data over a socket from the 'client' (Task) side."""
+        self._data_socket.send(pickle.dumps(msg))
+
+    def _clean_up(self) -> None:
+        """Clean up connections."""
+        self._data_socket.close()
+        self._context.term()
+
+    def __exit__(self):
+        self._clean_up()
+
+    def __del__(self):
+        self._clean_up()
+
+
+def SocketCommunicator(*args, **kwargs) -> Communicator:
+    """Selector for RawSocketCommunicator or ZMQCommunicator.
+
+    Returns:
+        communicator (Communicator): RawSocketCommunicator. ZMQCommunicator
+            is currently unused.
+    """
+    use_zmq: bool = False
+    if use_zmq:
+        return ZMQCommunicator(*args, **kwargs)
+    return RawSocketCommunicator(*args, **kwargs)

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -157,6 +157,10 @@ class Communicator(ABC):
         """Alternative exit method outside of context manager."""
         self.__exit__()
 
+    def delayed_setup(self):
+        """Any setup that should be done later than init."""
+        ...
+
 
 class PipeCommunicator(Communicator):
     """Provides communication through pipes over stderr/stdout.
@@ -407,6 +411,14 @@ class SocketCommunicator(Communicator):
         """
         super().__init__(party=party, use_pickle=use_pickle)
 
+    def delayed_setup(self) -> None:
+        """Delays the creation of socket objects.
+
+        The Executor initializes the Communicator when it is created. Since
+        all Executors are created and available at once we want to delay
+        acquisition of socket resources until a single Executor is ready
+        to use them.
+        """
         self._data_socket: Union[socket.socket, zmq.sugar.socket.Socket]
         if USE_ZMQ:
             self.desc: str = "Communicates using ZMQ through TCP or Unix sockets."

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -9,8 +9,20 @@ pipes to Unix sockets, etc. All communicators pass a single object called a
 
 
 Classes:
+    Party: Enum describing whether Communicator is on Task-side or Executor-side.
 
+    Message: A dataclass used for passing information from Task to Executor.
+
+    Communicator: Abstract base class for Communicator types.
+
+    PipeCommunicator: Manages communication between Task and Executor via pipes
+        (stderr and stdout).
+
+    SocketCommunicator: Manages communication using sockets, either raw or using
+        zmq. Supports both TCP and Unix sockets.
 """
+
+from __future__ import annotations
 
 __all__ = [
     "Party",
@@ -25,7 +37,6 @@ __author__ = "Gabriel Dorlhiac"
 import logging
 import os
 import pickle
-import select
 import socket
 import subprocess
 import sys
@@ -41,7 +52,10 @@ from typing import Any, Optional, Set, List, Literal, Union, Tuple, Type
 import _io
 from typing_extensions import Self
 
-import zmq
+
+USE_ZMQ: bool = False
+if USE_ZMQ:
+    import zmq
 
 LUTE_SIGNALS: Set[str] = {
     "NO_PICKLE_MODE",
@@ -320,8 +334,12 @@ class PipeCommunicator(Communicator):
             sys.stdout.write(raw_contents)
 
 
-class RawSocketCommunicator(Communicator):
-    """Provides communication over raw Unix or TCP sockets.
+class SocketCommunicator(Communicator):
+    """Provides communication over Unix or TCP sockets.
+
+    Communication is provided either using sockets with the Python socket library
+    or using ZMQ. The choice of implementation is controlled by the global bool
+    `USE_ZMQ`.
 
     Whether to use TCP or Unix sockets is controlled by the environment:
                            `LUTE_USE_TCP=1`
@@ -388,9 +406,16 @@ class RawSocketCommunicator(Communicator):
                 passing False does not change behaviour.
         """
         super().__init__(party=party, use_pickle=use_pickle)
-        self.desc: str = "Communicates through a TCP or Unix socket."
 
-        self._data_socket: socket.socket = self._create_socket()
+        self._data_socket: Union[socket.socket, zmq.sugar.socket.Socket]
+        if USE_ZMQ:
+            self.desc: str = "Communicates using ZMQ through TCP or Unix sockets."
+            self._context: zmq.context.Context = zmq.Context()
+            self._data_socket = self._create_socket_zmq()
+        else:
+            self.desc: str = "Communicates through a TCP or Unix socket."
+            self._data_socket = self._create_socket_raw()
+            self._data_socket.settimeout(SocketCommunicator.ACCEPT_TIMEOUT)
 
         if self._party == Party.EXECUTOR:
             # Executor created first so we can define the hostname env variable
@@ -402,18 +427,15 @@ class RawSocketCommunicator(Communicator):
             self._msg_queue: queue.Queue = queue.Queue()
             self._partial_msg: Optional[bytes] = None
             self._stop_thread: bool = False
-            self._data_socket.settimeout(RawSocketCommunicator.ACCEPT_TIMEOUT)
             self._reader_thread.start()
         else:
             # Only used by Party.TASK
-            import struct
-
-            self._data_socket.setsockopt(
-                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 10)
-            )
             self._use_ssh_tunnel: bool = False
             self._ssh_proc: Optional[subprocess.Popen] = None
             self._local_socket_path: Optional[str] = None
+
+    # Read
+    ############################################################################
 
     def read(self, proc: subprocess.Popen) -> Message:
         """Return a message from the queue if available.
@@ -430,7 +452,7 @@ class RawSocketCommunicator(Communicator):
         """
         msg: Message
         try:
-            msg = self._msg_queue.get(timeout=RawSocketCommunicator.ACCEPT_TIMEOUT)
+            msg = self._msg_queue.get(timeout=SocketCommunicator.ACCEPT_TIMEOUT)
         except queue.Empty:
             msg = Message()
 
@@ -442,23 +464,27 @@ class RawSocketCommunicator(Communicator):
         Socket(s) are continuously monitored, and read from when new data is
         available.
 
-        Args:
-            proc (subprocess.Popen): The process to read from. Provided for
-                compatibility with other Communicator subtypes. Is ignored.
-
-        Returns:
-             msg (Message): The message read, containing contents and signal.
+        Calls an underlying method for either raw sockets or ZMQ.
         """
+
         while True:
             if self._stop_thread:
                 logger.debug("Stopping socket reader thread.")
                 break
-            connection: socket.socket
-            addr: Union[str, Tuple[str, int]]
-            try:
-                connection, addr = self._data_socket.accept()
-            except socket.timeout:
-                continue
+            if USE_ZMQ:
+                self._read_socket_zmq()
+            else:
+                self._read_socket_raw()
+
+    def _read_socket_raw(self) -> None:
+        """Read data from a socket.
+
+        Raw socket implementation for the reader thread.
+        """
+        connection: socket.socket
+        addr: Union[str, Tuple[str, int]]
+        try:
+            connection, addr = self._data_socket.accept()
             full_data: bytes = b""
             while True:
                 data: bytes = connection.recv(8192)
@@ -466,8 +492,21 @@ class RawSocketCommunicator(Communicator):
                     full_data += data
                 else:
                     break
-            self._unpack_messages(full_data)
             connection.close()
+            self._unpack_messages(full_data)
+        except socket.timeout:
+            pass
+
+    def _read_socket_zmq(self) -> None:
+        """Read data from a socket.
+
+        ZMQ implementation for the reader thread.
+        """
+        try:
+            full_data: bytes = self._data_socket.recv(0)
+            self._unpack_messages(full_data)
+        except zmq.ZMQError:
+            pass
 
     def _unpack_messages(self, data: bytes) -> None:
         """Unpacks a byte stream into individual messages.
@@ -501,12 +540,11 @@ class RawSocketCommunicator(Communicator):
             try:
                 # Message encoding: <HEAD><SEP><len><SEP><msg><SEP><HEAD[::-1]>
                 end = working_data.find(
-                    RawSocketCommunicator.MSG_SEP + RawSocketCommunicator.MSG_HEAD[::-1]
+                    SocketCommunicator.MSG_SEP + SocketCommunicator.MSG_HEAD[::-1]
                 )
                 msg_parts: List[bytes] = working_data[:end].split(
-                    RawSocketCommunicator.MSG_SEP
+                    SocketCommunicator.MSG_SEP
                 )
-                # print(f"PART LENGTH: {len(msg_parts)}", flush=True)
                 if len(msg_parts) != 3:
                     self._partial_msg = working_data
                     break
@@ -520,18 +558,45 @@ class RawSocketCommunicator(Communicator):
                     break
                 msg = pickle.loads(raw_msg)
                 self._msg_queue.put(msg)
-                print(msg, flush=True)
             except pickle.UnpicklingError:
                 self._partial_msg = working_data
                 break
             if end < len(working_data):
                 # Add len(SEP+HEAD) since end marks the start of <SEP><HEAD[::-1]
                 offset: int = len(
-                    RawSocketCommunicator.MSG_SEP + RawSocketCommunicator.MSG_HEAD
+                    SocketCommunicator.MSG_SEP + SocketCommunicator.MSG_HEAD
                 )
                 working_data = working_data[end + offset :]
             else:
                 working_data = b""
+
+    # Write
+    ############################################################################
+
+    def _write_socket(self, msg: Message) -> None:
+        """Sends data over a socket from the 'client' (Task) side.
+
+        Messages are encoded in the following format:
+                 <HEAD><SEP><len(msg)><SEP><msg><SEP><HEAD[::-1]>
+        The items between <> are replaced as follows:
+            - <HEAD>: A start marker
+            - <SEP>: A separator for components of the message
+            - <len(msg)>: The length of the message payload in bytes.
+            - <msg>: The message payload in bytes
+            - <HEAD[::-1]>: The start marker in reverse to indicate the end.
+
+        This structure is used for decoding the message on the other end.
+        """
+        data: bytes = pickle.dumps(msg)
+        cmd: bytes = SocketCommunicator.MSG_HEAD
+        size: bytes = b"%d" % len(data)
+        end: bytes = SocketCommunicator.MSG_HEAD[::-1]
+        sep: bytes = SocketCommunicator.MSG_SEP
+        packed_msg: bytes = cmd + sep + size + sep + data + sep + end
+        if USE_ZMQ:
+            self._data_socket.send(packed_msg)
+        else:
+            self._data_socket.sendall(packed_msg)
 
     def write(self, msg: Message) -> None:
         """Send a single Message.
@@ -543,6 +608,80 @@ class RawSocketCommunicator(Communicator):
             msg (Message): The Message to send.
         """
         self._write_socket(msg)
+
+    # Generic create
+    ############################################################################
+
+    def _create_socket_raw(self) -> socket.socket:
+        """Create either a Unix or TCP socket.
+
+        If the environment variable:
+                              `LUTE_USE_TCP=1`
+        is defined, a TCP socket is returned, otherwise a Unix socket.
+
+        Refer to the individual initialization methods for additional environment
+        variables controlling the behaviour of these two communication types.
+
+        Returns:
+            data_socket (socket.socket): TCP or Unix socket.
+        """
+        import struct
+
+        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
+        sock: socket.socket
+        if use_tcp is not None:
+            if self._party == Party.EXECUTOR:
+                logger.info("Will use raw TCP sockets.")
+            sock = self._init_tcp_socket_raw()
+        else:
+            if self._party == Party.EXECUTOR:
+                logger.info("Will use raw Unix sockets.")
+            sock = self._init_unix_socket_raw()
+        sock.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 10000)
+        )
+        return sock
+
+    def _create_socket_zmq(self) -> zmq.sugar.socket.Socket:
+        """Create either a Unix or TCP socket.
+
+        If the environment variable:
+                              `LUTE_USE_TCP=1`
+        is defined, a TCP socket is returned, otherwise a Unix socket.
+
+        Refer to the individual initialization methods for additional environment
+        variables controlling the behaviour of these two communication types.
+
+        Returns:
+            data_socket (socket.socket): Unix socket object.
+        """
+        socket_type: Literal[zmq.PULL, zmq.PUSH]
+        if self._party == Party.EXECUTOR:
+            socket_type = zmq.PULL
+        else:
+            socket_type = zmq.PUSH
+
+        data_socket: zmq.sugar.socket.Socket = self._context.socket(socket_type)
+        data_socket.set_hwm(160000)
+        # Need to multiply by 1000 since ZMQ uses ms
+        data_socket.setsockopt(
+            zmq.RCVTIMEO, int(SocketCommunicator.ACCEPT_TIMEOUT * 1000)
+        )
+        # Try TCP first
+        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
+        if use_tcp is not None:
+            if self._party == Party.EXECUTOR:
+                logger.info("Will use TCP (ZMQ).")
+            self._init_tcp_socket_zmq(data_socket)
+        else:
+            if self._party == Party.EXECUTOR:
+                logger.info("Will use Unix sockets (ZMQ).")
+            self._init_unix_socket_zmq(data_socket)
+
+        return data_socket
+
+    # TCP Init
+    ############################################################################
 
     def _find_random_port(
         self, min_port: int = 41923, max_port: int = 64324, max_tries: int = 100
@@ -563,7 +702,7 @@ class RawSocketCommunicator(Communicator):
                 continue
         return None
 
-    def _init_tcp_socket(self) -> socket.socket:
+    def _init_tcp_socket_raw(self) -> socket.socket:
         """Initialize a TCP socket.
 
         Executor-side code should always be run first. It checks to see if
@@ -613,282 +752,11 @@ class RawSocketCommunicator(Communicator):
                 data_socket.connect((executor_hostname, int(port)))
         return data_socket
 
-    def _init_unix_socket(self) -> socket.socket:
-        """Returns a Unix socket object.
+    def _init_tcp_socket_zmq(self, data_socket: zmq.sugar.socket.Socket) -> None:
+        """Initialize a TCP socket using ZMQ.
 
-        Executor-side code should always be run first. It checks to see if
-        the environment variable
-                                `LUTE_SOCKET=XYZ`
-        is defined, if so binds it, otherwise it will create a new path and
-        define the environment variable for the Task-side to find.
-
-        On the Task (client-side), this method will also open a SSH tunnel to
-        forward a local Unix socket to an Executor Unix socket if the Task and
-        Executor processes are on different machines.
-
-        The SSH tunnel is opened with `ssh -L <local>:<remote> sleep 2`.
-        This method of communication is slightly slower and incurs additional
-        overhead - it should only be used as a backup. If communication across
-        multiple hosts is required consider using TCP.  The Task will use
-        the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
-        created. It is assumed that the user is identical on both the
-        Task machine and Executor machine.
-
-        Returns:
-            data_socket (socket.socket): Unix socket object.
-        """
-        socket_path: str
-        try:
-            socket_path = os.environ["LUTE_SOCKET"]
-        except KeyError as err:
-            import uuid
-            import tempfile
-
-            # Define a path,up and add to environment
-            # Executor-side always created first, Task will use the same one
-            socket_path = f"{tempfile.gettempdir()}/lute_{uuid.uuid4().hex}.sock"
-            os.environ["LUTE_SOCKET"] = socket_path
-            logger.debug(f"UnixSocketCommunicator defines socket_path: {socket_path}")
-        data_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if self._party == Party.EXECUTOR:
-            if os.path.exists(socket_path):
-                os.unlink(socket_path)
-            data_socket.bind(socket_path)
-            data_socket.listen()
-        elif self._party == Party.TASK:
-            hostname: str = socket.gethostname()
-            executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
-            if executor_hostname is None:
-                logger.info("Hostname for Executor process not found! Exiting!")
-                self._data_socket.close()
-                sys.exit(-1)
-            if hostname == executor_hostname:
-                data_socket.connect(socket_path)
-            else:
-                if "uuid" not in locals():
-                    import uuid
-                self._local_socket_path = f"{socket_path}.task{uuid.uuid4().hex[:4]}"
-                self._use_ssh_tunnel = True
-                ssh_cmd: List[str] = [
-                    "ssh",
-                    "-o",
-                    "LogLevel=quiet",
-                    "-L",
-                    f"{self._local_socket_path}:{socket_path}",
-                    executor_hostname,
-                    "sleep",
-                    "2",
-                ]
-                logger.debug(f"Opening tunnel from {hostname} to {executor_hostname}")
-                self._ssh_proc = subprocess.Popen(ssh_cmd)
-                time.sleep(0.4)  # Need to wait... -> Use single Task comm at beginning?
-                data_socket.connect(self._local_socket_path)
-        return data_socket
-
-    def _create_socket(self) -> socket.socket:
-        """Create either a Unix or TCP socket.
-
-        If the environment variable:
-                              `LUTE_USE_TCP=1`
-        is defined, a TCP socket is returned, otherwise a Unix socket.
-
-        Refer to the individual initialization methods for additional environment
-        variables controlling the behaviour of these two communication types.
-
-        Returns:
-            data_socket (socket.socket): TCP or Unix socket.
-        """
-        import struct
-
-        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
-        sock: socket.socket
-        if use_tcp is not None:
-            sock = self._init_tcp_socket()
-        else:
-            sock = self._init_unix_socket()
-        sock.setsockopt(
-            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 10000)
-        )
-        return sock
-
-    def _write_socket(self, msg: Message) -> None:
-        """Sends data over a socket from the 'client' (Task) side.
-
-        Messages are encoded in the following format:
-                 <HEAD><SEP><len(msg)><SEP><msg><SEP><HEAD[::-1]>
-        The items between <> are replaced as follows:
-            - <HEAD>: A start marker
-            - <SEP>: A separator for components of the message
-            - <len(msg)>: The length of the message payload in bytes.
-            - <msg>: The message payload in bytes
-            - <HEAD[::-1]>: The start marker in reverse to indicate the end.
-
-        This structure is used for decoding the message on the other end.
-        """
-        data: bytes = pickle.dumps(msg)
-        cmd: bytes = RawSocketCommunicator.MSG_HEAD
-        size: bytes = b"%d" % len(data)
-        end: bytes = RawSocketCommunicator.MSG_HEAD[::-1]
-        sep: bytes = RawSocketCommunicator.MSG_SEP
-        packed_msg: bytes = cmd + sep + size + sep + data + sep + end
-        self._data_socket.sendall(packed_msg)
-
-    def _clean_up(self) -> None:
-        """Clean up connections."""
-        # Check the object exists in case the Communicator is cleaned up before
-        # opening any connections
-        if self._party == Party.EXECUTOR:
-            self._stop_thread = True
-            self._reader_thread.join()
-            logger.debug("Closed reading thread.")
-
-        if hasattr(self, "_data_socket") and not self._data_socket._closed:
-            socket_path: str = self.socket_path
-            self._data_socket.close()
-            if os.getenv("LUTE_USE_TCP"):
-                return
-            if self._party == Party.EXECUTOR or self._use_ssh_tunnel:
-                os.unlink(socket_path)
-                if self._ssh_proc is not None:
-                    self._ssh_proc.terminate()
-
-    @property
-    def socket_path(self) -> str:
-        socket_path: str = self._data_socket.getsockname()
-        if not socket_path:
-            socket_path = os.environ["LUTE_SOCKET"]
-            if self._party == Party.TASK and self._use_ssh_tunnel:
-                # If _use_ssh_tunnel _local_socket_path is defined.
-                return self._local_socket_path
-        return socket_path
-
-    @property
-    def has_messages(self) -> bool:
-        if self._party == Party.TASK:
-            # Shouldn't be called on Task-side
-            return False
-
-        if self._msg_queue.qsize() > 0:
-            return True
-        return False
-
-    def __exit__(self):
-        self._clean_up()
-
-
-class ZMQCommunicator(Communicator):
-    """Provides communication over Unix or TCP sockets with ZMQ.
-
-    Whether to use TCP or Unix sockets is controlled by the environment:
-                           `LUTE_USE_TCP=1`
-    If defined, TCP sockets will be used, otherwise Unix sockets will be used.
-
-    Regardless of socket type, the environment variable
-                      `LUTE_EXECUTOR_HOST=<hostname>`
-    will be defined by the Executor-side Communicator.
-
-
-    For TCP sockets:
-    The Executor-side Communicator should be run first and will bind to all
-    interfaces on the port determined by the environment variable:
-                            `LUTE_PORT=###`
-    If no port is defined, ZMQ will bind a random port. The Communicator
-    will then define the environment variable so the Task-side can pick it up.
-
-    For Unix sockets:
-    The path to the Unix socket is defined by the environment variable:
-                      `LUTE_SOCKET=/path/to/socket`
-    This class assumes proper permissions and that this above environment
-    variable has been defined. The `Task` is configured as what would commonly
-    be referred to as the `client`, while the `Executor` is configured as the
-    server.
-
-    If the Task process is run on a different machine than the Executor, the
-    Task-side Communicator will open a ssh-tunnel to forward traffic from a local
-    Unix socket to the Executor Unix socket. Opening of the tunnel relies on the
-    environment variable:
-                      `LUTE_EXECUTOR_HOST=<hostname>`
-    to determine the Executor's host. This variable should be defined by the
-    Executor and passed to the Task process automatically, but it can also be
-    defined manually if launching the Task process separately. The Task will use
-    the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
-    created. Currently, it is assumed that the user is identical on both the Task
-    machine and Executor machine.
-    """
-
-    READ_TIMEOUT: float = 0.01
-    """
-    Maximum time to wait to retrieve data.
-    """
-
-    def __init__(self, party: Party = Party.TASK, use_pickle: bool = True) -> None:
-        """IPC over a TCP or Unix socket.
-
-        Args:
-            party (Party): Which object (side/process) the Communicator is
-                managing IPC for. I.e., is this the "Task" or "Executor" side.
-
-            use_pickle (bool): Whether to use pickle. Always True currently,
-                passing False does not change behaviour.
-        """
-        super().__init__(party=party, use_pickle=use_pickle)
-        self.desc: str = "Communicates using ZMQ through TCP or Unix sockets."
-        if self._party == Party.EXECUTOR:
-            # Executor created first so we can define the hostname env variable
-            os.environ["LUTE_EXECUTOR_HOST"] = socket.gethostname()
-
-        self._context: zmq.context.Context = zmq.Context()
-        self._use_ssh_tunnel: bool = False
-        self._ssh_proc: Optional[subprocess.Popen] = None
-        self._local_socket_path: Optional[str] = None
-        self._data_socket: zmq.sugar.socket.Socket = self._create_socket()
-
-    def read(self, proc: subprocess.Popen) -> Message:
-        """Read data from a socket.
-
-        Socket(s) are continuously monitored, and read from when new data is
-        available.
-
-        Args:
-            proc (subprocess.Popen): The process to read from. Provided for
-                compatibility with other Communicator subtypes. Is ignored.
-
-        Returns:
-             msg (Message): The message read, containing contents and signal.
-        """
-        msg: Message = Message()
-        try:
-            data: bytes = self._data_socket.recv(zmq.NOBLOCK)
-            msg = pickle.loads(data)
-        except zmq.error.Again:
-            pass
-        finally:
-            return msg
-
-    def write(self, msg: Message) -> None:
-        """Send a single Message.
-
-        The entire Message (signal and contents) is serialized and sent through
-        a connection over Unix socket.
-
-        Args:
-            msg (Message): The Message to send.
-        """
-        self._write_socket(msg)
-
-    def _init_tcp_socket(self, data_socket: zmq.sugar.socket.Socket) -> None:
-        """Initialize a TCP socket.
-
-        Executor-side code should always be run first. It checks to see if
-        the environment variable
-                                `LUTE_PORT=###`
-        is defined, if so binds it, otherwise find a free port from a selection
-        of random ports. If a port search is performed, the `LUTE_PORT` variable
-        will be defined so it can be picked up by the the Task-side Communicator.
-
-        In the event that no port can be bound on the Executor-side, or the port
-        and hostname information is unavailable to the Task-side, the program
-        will exit.
+        Equivalent as the method above but requires passing in a ZMQ socket
+        object instead of returning one.
 
         Args:
             data_socket (zmq.socket.Socket): Socket object.
@@ -909,8 +777,6 @@ class ZMQCommunicator(Communicator):
             else:
                 data_socket.bind(f"tcp://*:{port}")
             logger.debug(f"Executor bound port {port}")
-            # data_socket.subscribe(b"") # Can define topics later.
-            # data_socket.setsockopt(zmq.LINGER,0)
         else:
             executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
             if executor_hostname is None or port is None:
@@ -921,8 +787,34 @@ class ZMQCommunicator(Communicator):
                 sys.exit(-1)
             data_socket.connect(f"tcp://{executor_hostname}:{port}")
 
-    def _init_unix_socket(self, data_socket: zmq.sugar.socket.Socket) -> None:
-        """Initialize a Unix socket object.
+    # Unix Init
+    ############################################################################
+
+    def _get_socket_path(self) -> str:
+        """Return the socket path, defining one if it is not available.
+
+        Returns:
+            socket_path (str): Path to the Unix socket.
+        """
+        socket_path: str
+        try:
+            socket_path = os.environ["LUTE_SOCKET"]
+        except KeyError as err:
+            import uuid
+            import tempfile
+
+            # Define a path, and add to environment
+            # Executor-side always created first, Task will use the same one
+            socket_path = f"{tempfile.gettempdir()}/lute_{uuid.uuid4().hex}.sock"
+            os.environ["LUTE_SOCKET"] = socket_path
+            logger.debug(f"SocketCommunicator defines socket_path: {socket_path}")
+        if USE_ZMQ:
+            return f"ipc://{socket_path}"
+        else:
+            return socket_path
+
+    def _init_unix_socket_raw(self) -> socket.socket:
+        """Returns a Unix socket object.
 
         Executor-side code should always be run first. It checks to see if
         the environment variable
@@ -934,35 +826,46 @@ class ZMQCommunicator(Communicator):
         forward a local Unix socket to an Executor Unix socket if the Task and
         Executor processes are on different machines.
 
-        The SSH tunnel is opened with `ssh -L <local>:<remote> sleep 2`.
-        This method of communication is slightly slower and incurs additional
-        overhead - it should only be used as a backup. If communication across
-        multiple hosts is required consider using TCP.  The Task will use
-        the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
-        created. It is assumed that the user is identical on both the
-        Task machine and Executor machine.
-
-        Args:
-            data_socket (socket.socket): ZMQ object.
+        Returns:
+            data_socket (socket.socket): Unix socket object.
         """
-        try:
-            socket_path = os.environ["LUTE_SOCKET"]
-        except KeyError:
-            import uuid
-            import tempfile
-
-            # Define a path,up and add to environment
-            # Executor-side always created first, Task will use the same one
-            socket_path = f"{tempfile.gettempdir()}/lute_{uuid.uuid4().hex}.sock"
-            os.environ["LUTE_SOCKET"] = socket_path
-            logger.debug(f"ZMQCommunicator defines socket_path: {socket_path}")
-
-        socket_path = f"ipc:/{socket_path}"
+        socket_path: str = self._get_socket_path()
+        data_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         if self._party == Party.EXECUTOR:
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
             data_socket.bind(socket_path)
-            # data_socket.subscribe(b"")
+            data_socket.listen()
+        elif self._party == Party.TASK:
+            hostname: str = socket.gethostname()
+            executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
+            if executor_hostname is None:
+                logger.info("Hostname for Executor process not found! Exiting!")
+                data_socket.close()
+                sys.exit(-1)
+            if hostname == executor_hostname:
+                data_socket.connect(socket_path)
+            else:
+                self._local_socket_path = self._setup_unix_ssh_tunnel(
+                    socket_path, hostname, executor_hostname
+                )
+                data_socket.connect(self._local_socket_path)
+        return data_socket
+
+    def _init_unix_socket_zmq(self, data_socket: zmq.sugar.socket.Socket) -> None:
+        """Initialize a Unix socket object, using ZMQ.
+
+        Equivalent as the method above but requires passing in a ZMQ socket
+        object instead of returning one.
+
+        Args:
+            data_socket (socket.socket): ZMQ object.
+        """
+        socket_path = self._get_socket_path()
+        if self._party == Party.EXECUTOR:
+            if os.path.exists(socket_path):
+                os.unlink(socket_path)
+            data_socket.bind(socket_path)
         elif self._party == Party.TASK:
             hostname: str = socket.gethostname()
             executor_hostname: Optional[str] = os.getenv("LUTE_EXECUTOR_HOST")
@@ -973,66 +876,84 @@ class ZMQCommunicator(Communicator):
             if hostname == executor_hostname:
                 data_socket.connect(socket_path)
             else:
-                if "uuid" not in locals():
-                    import uuid
-                self._local_socket_path = f"{socket_path}.task{uuid.uuid4().hex[:4]}"
-                self._use_ssh_tunnel = True
-                ssh_cmd: List[str] = [
-                    "ssh",
-                    "-o",
-                    "LogLevel=quiet",
-                    "-L",
-                    f"{self._local_socket_path[5:]}:{socket_path[5:]}",  # remove ipc:/
-                    executor_hostname,
-                    "sleep",
-                    "2",
-                ]
-                logger.debug(f"Opening tunnel from {hostname} to {executor_hostname}")
-                self._ssh_proc = subprocess.Popen(ssh_cmd)
-                time.sleep(0.4)  # Need to wait... -> Use single Task comm at beginning?
-                data_socket.connect(self._local_socket_path)
+                # Need to remove ipc:// from socket_path for forwarding
+                self._local_socket_path = self._setup_unix_ssh_tunnel(
+                    socket_path[6:], hostname, executor_hostname
+                )
+                # Need to add it back
+                path: str = f"ipc://{self._local_socket_path}"
+                data_socket.connect(path)
 
-    def _create_socket(self) -> zmq.sugar.socket.Socket:
-        """Create either a Unix or TCP socket.
+    def _setup_unix_ssh_tunnel(
+        self, socket_path: str, hostname: str, executor_hostname: str
+    ) -> str:
+        """Prepares an SSH tunnel for forwarding between Unix sockets on two hosts.
 
-        If the environment variable:
-                              `LUTE_USE_TCP=1`
-        is defined, a TCP socket is returned, otherwise a Unix socket.
-
-        Refer to the individual initialization methods for additional environment
-        variables controlling the behaviour of these two communication types.
+        An SSH tunnel is opened with `ssh -L <local>:<remote> sleep 2`.
+        This method of communication is slightly slower and incurs additional
+        overhead - it should only be used as a backup. If communication across
+        multiple hosts is required consider using TCP.  The Task will use
+        the local socket `<LUTE_SOCKET>.task{##}`. Multiple local sockets may be
+        created. It is assumed that the user is identical on both the
+        Task machine and Executor machine.
 
         Returns:
-            data_socket (socket.socket): Unix socket object.
+            local_socket_path (str): The local Unix socket to connect to.
         """
-        socket_type: Literal[zmq.SUB, zmq.PUB]
-        if self._party == Party.EXECUTOR:
-            socket_type = zmq.PULL
-        else:
-            socket_type = zmq.PUSH
+        if "uuid" not in globals():
+            import uuid
+        local_socket_path = f"{socket_path}.task{uuid.uuid4().hex[:4]}"
+        self._use_ssh_tunnel = True
+        ssh_cmd: List[str] = [
+            "ssh",
+            "-o",
+            "LogLevel=quiet",
+            "-L",
+            f"{local_socket_path}:{socket_path}",
+            executor_hostname,
+            "sleep",
+            "2",
+        ]
+        logger.debug(f"Opening tunnel from {hostname} to {executor_hostname}")
+        self._ssh_proc = subprocess.Popen(ssh_cmd)
+        time.sleep(0.4)  # Need to wait... -> Use single Task comm at beginning?
+        return local_socket_path
 
-        data_socket: zmq.sugar.socket.Socket = self._context.socket(socket_type)
-        data_socket.set_hwm(160000)
-        # Try TCP first
-        use_tcp: Optional[str] = os.getenv("LUTE_USE_TCP")
-        if use_tcp is not None:
-            self._init_tcp_socket(data_socket)
-        else:
-            self._init_unix_socket(data_socket)
-
-        return data_socket
-
-    def _write_socket(self, msg: Message) -> None:
-        """Sends data over a socket from the 'client' (Task) side."""
-        self._data_socket.send(pickle.dumps(msg))
+    # Clean up and properties
+    ############################################################################
 
     def _clean_up(self) -> None:
         """Clean up connections."""
+        if self._party == Party.EXECUTOR:
+            self._stop_thread = True
+            self._reader_thread.join()
+            logger.debug("Closed reading thread.")
+
         self._data_socket.close()
-        self._context.term()
+        if USE_ZMQ:
+            self._context.term()
+        else:
+            ...
+
+        if os.getenv("LUTE_USE_TCP"):
+            return
+        else:
+            if self._party == Party.EXECUTOR:
+                os.unlink(os.getenv("LUTE_SOCKET"))  # Should be defined
+                return
+            elif self._use_ssh_tunnel:
+                if self._ssh_proc is not None:
+                    self._ssh_proc.terminate()
+
+    @property
+    def has_messages(self) -> bool:
+        if self._party == Party.TASK:
+            # Shouldn't be called on Task-side
+            return False
+
+        if self._msg_queue.qsize() > 0:
+            return True
+        return False
 
     def __exit__(self):
         self._clean_up()
-
-
-SocketCommunicator = RawSocketCommunicator

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -352,6 +352,9 @@ class SocketCommunicator(Communicator):
         """
         super().__init__(party=party, use_pickle=use_pickle)
         self.desc: str = "Communicates through a Unix socket."
+        if self._party == Party.EXECUTOR:
+            # Executor created first so we can define the hostname env variable
+            os.environ["LUTE_EXECUTOR_HOST"] = socket.gethostname()
 
         self._use_ssh_tunnel: bool = False
         self._ssh_proc: Optional[subprocess.Popen] = None

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -30,7 +30,7 @@ __all__ = [
     "Communicator",
     "PipeCommunicator",
     "LUTE_SIGNALS",
-    "SocketCommunicator",  # Points to one of two classes below. See bottom
+    "SocketCommunicator",
 ]
 __author__ = "Gabriel Dorlhiac"
 
@@ -735,7 +735,7 @@ class SocketCommunicator(Communicator):
         port: Optional[Union[str, int]] = os.getenv("LUTE_PORT")
         if self._party == Party.EXECUTOR:
             if port is None:
-                # If port is None find onex
+                # If port is None find one
                 # Executor code executes first
                 port = self._find_random_port()
                 if port is None:

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -7,3 +7,4 @@ from .sfx_merge import *
 from .sfx_solve import *
 from .smd import *
 from .tests import *
+from .mpi_tests import *

--- a/lute/io/models/mpi_tests.py
+++ b/lute/io/models/mpi_tests.py
@@ -1,0 +1,49 @@
+"""Models for all test Tasks.
+
+Classes:
+    TestMultiNodeCommunicationParameters(TaskParameters): Model for test Task
+        which verifies that the SocketCommunicator can write back to the
+        Executor on a different node.
+    TestParameters(TaskParameters): Model for most basic test case. Single
+        core first-party Task. Uses only communication via pipes.
+
+    TestBinaryParameters(ThirdPartyParameters): Parameters for a simple multi-
+        threaded binary executable.
+
+    TestSocketParameters(TaskParameters): Model for first-party test requiring
+        communication via socket.
+
+    TestWriteOutputParameters(TaskParameters): Model for test Task which writes
+        an output file. Location of file is recorded in database.
+
+    TestReadOutputParameters(TaskParameters): Model for test Task which locates
+        an output file based on an entry in the database, if no path is provided.
+"""
+
+__all__ = ["TestMultiNodeCommunicationParameters"]
+__author__ = "Gabriel Dorlhiac"
+
+from typing import Dict, Any, Optional, Literal
+
+from pydantic import (
+    BaseModel,
+    Field,
+    validator,
+)
+
+from .base import TaskParameters, ThirdPartyParameters
+from ..db import read_latest_db_entry
+
+
+class TestMultiNodeCommunicationParameters(TaskParameters):
+    """Parameters for the test Task `TestMultiNodeCommunication`.
+
+    Test verifies communication across multiple machines.
+    """
+
+    send_obj: Literal["plot", "array"] = Field(
+        "array", description="Object to send to Executor. `plot` or `array`"
+    )
+    arr_size: Optional[int] = Field(
+        None, description="Size of array to send back to Executor."
+    )

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -27,6 +27,8 @@ WriteTester: Executor = Executor("TestWriteOutput")
 ReadTester: Executor = Executor("TestReadOutput")
 """Runs a test to confirm database reading."""
 
+MultiNodeCommunicationTester: MPIExecutor = MPIExecutor("TestMultiNodeCommunication")
+"""Runs a test to confirm communication works between multiple nodes."""
 
 # SmallData-related
 ###################

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -66,4 +66,8 @@ def import_task(task_name: str) -> Type[Task]:
 
         return ConcatenateStreamFiles
 
+    if task_name == "TestMultiNodeCommunication":
+        from .mpi_test import TestMultiNodeCommunication
+
+        return TestMultiNodeCommunication
     raise TaskNotFoundError

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -8,6 +8,7 @@ Classes:
 __all__ = ["TestMultiNodeCommunication"]
 __author__ = "Gabriel Dorlhiac"
 
+import os
 import time
 
 import numpy as np
@@ -41,6 +42,7 @@ class TestMultiNodeCommunication(Task):
         time.sleep(self._rank)
         msg: Message = Message(
             f"Rank {self._rank} of {self._world_size} sending message."
+            f"  From {MPI.Get_processor_name()} to {os.getenv('LUTE_EXECUTOR_HOST')}."
         )
         self._report_to_executor(msg)
         if self._task_parameters.send_obj == "array":
@@ -49,11 +51,11 @@ class TestMultiNodeCommunication(Task):
                 arr_size = self._task_parameters.arr_size
             else:
                 arr_size = 512
-            msg = Message(contents=np.rand(arr_size))
+            msg = Message(contents=np.random.rand(arr_size))
             self._report_to_executor(msg)
         elif self._task_parameters.send_obj == "plot":
             x: np.ndarray[np.float_] = np.linspace(0, 49, 50)
-            y: np.ndarray[np.float_] = np.random.rand([50])
+            y: np.ndarray[np.float_] = np.random.rand(50)
             fig, ax = plt.subplots(1, 1)
             ax.plot(x, y, label="Test")
             ax.set_title("Multi-Node Communication Test")

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -32,8 +32,8 @@ class TestMultiNodeCommunication(Task):
     nodes.
     """
 
-    def __init__(self, *, params: TaskParameters) -> None:
-        super().__init__(params=params)
+    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+        super().__init__(params=params, use_mpi=use_mpi)
         self._comm: MPI.Intracomm = MPI.COMM_WORLD
         self._rank: int = self._comm.Get_rank()
         self._world_size: int = self._comm.Get_size()

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -1,0 +1,71 @@
+"""Basic test Tasks for testing functionality that requires MPI.
+
+Classes:
+    TestMultiNodeCommunication(Task): Test Task which verifies that the
+        SocketCommunicator can write back to the Executor on a different node.
+"""
+
+__all__ = ["TestMultiNodeCommunication"]
+__author__ = "Gabriel Dorlhiac"
+
+import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+from mpi4py import MPI
+
+from lute.tasks.task import *
+from lute.io.models.base import *
+from lute.execution.ipc import Message
+
+
+class TestMultiNodeCommunication(Task):
+    """Task to test multi-node communication.
+
+    This test only tests the desired functionality if run on a cluster with
+    multiple machines and MPI. E.g. submission via SLURM on S3DF.
+
+    This Task uses MPI and should be submitted with at least 2 ranks (but
+    probably not too many in the interest of not wasting resources). It must be
+    submitted with (SLURM) arguments that ensure the Task is run on at least two
+    nodes.
+    """
+
+    def __init__(self, *, params: TaskParameters) -> None:
+        super().__init__(params=params)
+        self._comm: MPI.Intracomm = MPI.COMM_WORLD
+        self._rank: int = self._comm.Get_rank()
+        self._world_size: int = self._comm.Get_size()
+
+    def _run(self) -> None:
+        time.sleep(self._rank)
+        msg: Message = Message(
+            f"Rank {self._rank} of {self._world_size} sending message."
+        )
+        self._report_to_executor(msg)
+        if self._task_parameters.send_obj == "array":
+            arr_size: int
+            if self._task_parameters.arr_size is not None:
+                arr_size = self._task_parameters.arr_size
+            else:
+                arr_size = 512
+            msg = Message(contents=np.rand(arr_size))
+            self._report_to_executor(msg)
+        elif self._task_parameters.send_obj == "plot":
+            x: np.ndarray[np.float_] = np.linspace(0, 49, 50)
+            y: np.ndarray[np.float_] = np.random.rand([50])
+            fig, ax = plt.subplots(1, 1)
+            ax.plot(x, y, label="Test")
+            ax.set_title("Multi-Node Communication Test")
+            msg = Message(contents=fig)
+            self._report_to_executor(msg)
+        else:
+            # This shouldn't happen -> Pydantic should fail first
+            self._result.summary = "Failed."
+            self._result.task_status = TaskStatus.FAILED
+
+    def _post_run(self) -> None:
+        if self._result.task_status != TaskStatus.FAILED:
+            self._result.summary = "Test Finished."
+            self._result.task_status = TaskStatus.COMPLETED
+        time.sleep(0.1)

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -155,6 +155,8 @@ class Task(ABC):
             comm.Barrier()
             if rank == 0:
                 self._report_to_executor(start_msg)
+        else:
+            self._report_to_executor(start_msg)
 
     def _signal_result(self) -> None:
         """Send the signal that results are ready along with the results."""
@@ -168,6 +170,8 @@ class Task(ABC):
             comm.Barrier()
             if rank == 0:
                 self._report_to_executor(results_msg)
+        else:
+            self._report_to_executor(results_msg)
         time.sleep(0.1)
 
     def _report_to_executor(self, msg: Message) -> None:
@@ -206,11 +210,19 @@ class ThirdPartyTask(Task):
                 it (as would be done via command line). The binary is included
                 with the parameter `executable`. All other parameter names are
                 assumed to be the long/extended names of the flag passed on the
-                command line:
+                command line by default:
                     * `arg_name = 3` is converted to `--arg_name 3`
                 Positional arguments can be included with `p_argN` where `N` is
                 any integer:
                     * `p_arg1 = 3` is converted to `3`
+
+                Note that it is NOT recommended to rely on this default behaviour
+                as command-line arguments can be passed in many ways. Refer to
+                the dcoumentation at
+                https://slac-lcls.github.io/lute/tutorial/new_task/
+                under "Speciyfing a TaskParameters Model for your Task" for more
+                information on how to control parameter parsing from within your
+                TaskParameters model definition.
         """
         super().__init__(params=params)
         self._cmd = self._task_parameters.executable

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -189,6 +189,7 @@ class Task(ABC):
         else:
             communicator = SocketCommunicator()
 
+        communicator.delayed_setup()
         communicator.write(msg)
         communicator.clear_communicator()
 


### PR DESCRIPTION
# Description

This PR overhauls socket-based IPC. Support for TCP is added, and SSH tunnels are provided as a backup if Unix sockets are used across multiple nodes. A first iteration of ZMQ is added as an alternative to raw sockets for future use. The use of ZMQ is currently controlled by a global `bool` but this will be configurable in a more standard manner later.

**Note:** Message order is not controlled. If running with multiple ranks the execution order of the rank as well as the read schedule (and the network) will determine when messages arrive. Messages arriving via the `PipeCommunicator` are not synchronized with those arriving via the `SocketCommunicator` and may also arrive out of order.

## Checklist
- [x] `SocketCommunicator` supports TCP sockets.
- [x] `SocketCommunicator` : `Task`-side will open SSH tunnel if on different machine and using Unix sockets.
- [x] `SocketCommunicator` adds ZMQ support
  - [x]  Works for tcp
  - [x] Works for Unix
- [x] `Executor` passes along information about what host it is on, or what ports to use.
- [x] `LUTE_USE_TCP` environment variable.
- [x] Launch scripts updated
- [x] Documentation updates.
- [x] Test case

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- NA

# Testing
Tested using direct Python submission and with SLURM across multiple nodes using all test classes. Example output
## Testing TCP communication with raw sockets
- SLURM using `MultiNodeCommunicationTester` `Task` which uses MPI.
```bash
# Submit with ntasks=4 -> Becomes 3 ranks split on nodes.
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_slurm.sh -t MultiNodeCommunicationTester -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --account=lcls:data --partition=milano --ntasks=4 --nodes=3
Running in standard mode.
Submitting task MultiNodeCommunicationTester
Submitted batch job 53083354

# Receive both text and figure information from all three ranks
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat MultiNodeCommunicationTester__r0000_2024-08-06_09-50-29.out
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Rank 0 of 3 sending message.  From sdfmilan114 to sdfmilan114.
INFO:lute.execution.executor:Executor: TestMultiNodeCommunication started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') send_obj='plot' arr_size=5
INFO:lute.execution.executor:Rank 1 of 3 sending message.  From sdfmilan114 to sdfmilan114.
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Rank 2 of 3 sending message.  From sdfmilan115 to sdfmilan114.
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Test Finished.
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestMultiNodeCommunication', task_status=<TaskStatus.COMPLETED: 2>, summary='Test Finished.', payload='', impl_schemas=None)
```

- Python submission of `SocketTester` a non-MPI task.
```bash
# Receive 10 arrays and 10 messages that they are being sent
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac/lute]$> LUTE_USE_TCP=1 python -B run_task.py -t SocketTester -c config/test.yaml
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
DEBUG:lute.execution.executor:Absolute path to subprocess_task.py not found.
INFO:lute.execution.executor:Sending array 0
DEBUG:lute.execution.executor:Cannot set result from TaskParameters. `set_result` not specified!
INFO:lute.execution.executor:Executor: TestSocket started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') array_size=8000 num_arrays=10
INFO:lute.execution.executor:Sending array 1
INFO:lute.execution.executor:Sending array 2
INFO:lute.execution.executor:[0.93878673 0.85870327 0.14269453 ... 0.30021307 0.62379757 0.2676032 ]
INFO:lute.execution.executor:[0.21426516 0.95511496 0.11939231 ... 0.68906608 0.11352986 0.34279074]
INFO:lute.execution.executor:Sending array 3
INFO:lute.execution.executor:[0.39335495 0.46792767 0.52884037 ... 0.51449615 0.93212467 0.96204988]
INFO:lute.execution.executor:Sending array 4
INFO:lute.execution.executor:[0.86709589 0.6183857  0.21971463 ... 0.42085349 0.26052249 0.64922644]
INFO:lute.execution.executor:Sending array 5
INFO:lute.execution.executor:[0.6944077  0.81515865 0.09171156 ... 0.46321115 0.485619   0.50942979]
INFO:lute.execution.executor:Sending array 6
INFO:lute.execution.executor:[0.16326848 0.45722451 0.99328962 ... 0.54119834 0.9896704  0.1311367 ]
INFO:lute.execution.executor:Sending array 7
INFO:lute.execution.executor:[0.7469258  0.84533057 0.95389808 ... 0.14454207 0.71833466 0.02560989]
INFO:lute.execution.executor:Sending array 8
INFO:lute.execution.executor:[0.31319232 0.80430753 0.62222915 ... 0.69475618 0.85449827 0.86542318]
INFO:lute.execution.executor:Sending array 9
INFO:lute.execution.executor:[0.28475446 0.80272991 0.13005413 ... 0.46486911 0.14186617 0.57041271]
INFO:lute.execution.executor:[0.02339099 0.4541457  0.10760855 ... 0.4653809  0.96423691 0.71274681]
INFO:lute.execution.executor:Sent 10 arrays
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestSocket', task_status=<TaskStatus.COMPLETED: 2>, summary='Sent 10 arrays', payload=array([0.72978264, 0.22678095, 0.09365268, ..., 0.56888893, 0.49116616,
       0.18841854]), impl_schemas=None)
DEBUG:lute.io._sqlite:_make_task_table[CREATE]: CREATE TABLE IF NOT EXISTS TestSocket(id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, gen_cfg_id INTEGER, exec_cfg_id INTEGER, "array_size" INTEGER, "num_arrays" INTEGER, "result.task_status" TEXT, "result.summary" TEXT, "result.payload" BLOB, "result.impl_schemas" TEXT, valid_flag INTEGER)
DEBUG:root:_gen_cfg_table_entry: Rows matching title LIKE 'LUTE Task Configuration' AND experiment LIKE 'EXPL10000' AND run LIKE '' AND date LIKE '2023/10/25' AND lute_version LIKE '0.1' AND task_timeout LIKE '600': [(1,)]
DEBUG:root:_exec_cfg_table_entry: No matching rows - adding new row: 211
DEBUG:lute.io._sqlite:_add_task_entry: ['"gen_cfg_id"', '"exec_cfg_id"', '"array_size"', '"num_arrays"', '"result.task_status"', '"result.summary"', '"result.payload"', '"result.impl_schemas"', '"valid_flag"']
		[1, 211, 8000, 10, 'COMPLETED', 'Sent 10 arrays', array([0.72978264, 0.22678095, 0.09365268, ..., 0.56888893, 0.49116616,
       0.18841854]), None, 1]
DEBUG:lute.execution.ipc:Stopping socket reader thread.
QUEUE SIZE - 0
HAS MESSAGES: False
DEBUG:lute.execution.ipc:Closed reading thread.
```

## Testing Unix with raw sockets
- SLURM using `MultiNodeCommunicationTester` `Task` which uses MPI.
```bash
# Set TCP mode off. Submit with ntasks=4 -> Becomes 3 ranks split on nodes.
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> LUTE_USE_TCP=0 /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_slurm.sh -t MultiNodeCommunicationTester -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --account=lcls:data --partition=milano --ntasks=4 --nodes=3
# Receive both text and figure information from all three ranks
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat MultiNodeCommunicationTester__r0000_2024-08-06_11-09-54.out
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Rank 0 of 3 sending message.  From sdfmilan111 to sdfmilan111.
INFO:lute.execution.executor:Executor: TestMultiNodeCommunication started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') send_obj='plot' arr_size=5
INFO:lute.execution.executor:Rank 1 of 3 sending message.  From sdfmilan114 to sdfmilan111.
INFO:lute.execution.executor:Rank 2 of 3 sending message.  From sdfmilan114 to sdfmilan111.
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Test Finished.
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestMultiNodeCommunication', task_status=<TaskStatus.COMPLETED: 2>, summary='Test Finished.', payload='', impl_schemas=None)
```
- Python submission of `SocketTester` a non-MPI task. (no SSH)
```bash
# Receive 10 arrays and 10 messages that they are being sent
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac/lute]$> python -B run_task.py -t SocketTester -c config/test.yaml
DEBUG:lute.execution.ipc:UnixSocketCommunicator defines socket_path: /lscratch/dorlhiac/tmp/lute_276e379f3175423aa01a03c11361c7f3.sock
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
INFO:lute.execution.executor:Sourcing file /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh
DEBUG:lute.execution.executor:Absolute path to subprocess_task.py not found.
INFO:lute.execution.executor:Sending array 0
DEBUG:lute.execution.executor:Cannot set result from TaskParameters. `set_result` not specified!
INFO:lute.execution.executor:Executor: TestSocket started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') array_size=8000 num_arrays=10
INFO:lute.execution.executor:Sending array 1
INFO:lute.execution.executor:Sending array 2
INFO:lute.execution.executor:[0.52160079 0.96890058 0.65177914 ... 0.50543691 0.22715026 0.99365486]
INFO:lute.execution.executor:Sending array 3
INFO:lute.execution.executor:[0.41676567 0.88092955 0.09547312 ... 0.59151888 0.38080628 0.78248672]
INFO:lute.execution.executor:[0.39964097 0.51591746 0.34305216 ... 0.13039327 0.36177007 0.17490791]
INFO:lute.execution.executor:[0.42283322 0.7667537  0.27851572 ... 0.99605828 0.63202465 0.29843001]
INFO:lute.execution.executor:Sending array 5
INFO:lute.execution.executor:[0.04352282 0.60851292 0.75757486 ... 0.22440194 0.90463436 0.1703041 ]
INFO:lute.execution.executor:Sending array 6
INFO:lute.execution.executor:[0.4470582  0.94456332 0.20254665 ... 0.16694299 0.18221614 0.37255754]
INFO:lute.execution.executor:Sending array 7
INFO:lute.execution.executor:[0.94784087 0.91379064 0.73552507 ... 0.8184123  0.55642381 0.88222426]
INFO:lute.execution.executor:Sending array 8
INFO:lute.execution.executor:[0.35079542 0.95001879 0.30060745 ... 0.89436458 0.3716709  0.7773894 ]
INFO:lute.execution.executor:Sending array 9
INFO:lute.execution.executor:[0.50044605 0.4128454  0.70774964 ... 0.31209946 0.47164879 0.62445722]
INFO:lute.execution.executor:[0.01827509 0.76334622 0.18165282 ... 0.14527713 0.0569127  0.93727003]
INFO:lute.execution.executor:Sent 10 arrays
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestSocket', task_status=<TaskStatus.COMPLETED: 2>, summary='Sent 10 arrays', payload=array([0.12877769, 0.27503862, 0.34789427, ..., 0.12360039, 0.39367444,
       0.35728848]), impl_schemas=None)
DEBUG:lute.io._sqlite:_make_task_table[CREATE]: CREATE TABLE IF NOT EXISTS TestSocket(id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, gen_cfg_id INTEGER, exec_cfg_id INTEGER, "array_size" INTEGER, "num_arrays" INTEGER, "result.task_status" TEXT, "result.summary" TEXT, "result.payload" BLOB, "result.impl_schemas" TEXT, valid_flag INTEGER)
DEBUG:root:_gen_cfg_table_entry: Rows matching title LIKE 'LUTE Task Configuration' AND experiment LIKE 'EXPL10000' AND run LIKE '' AND date LIKE '2023/10/25' AND lute_version LIKE '0.1' AND task_timeout LIKE '600': [(1,)]
DEBUG:root:_exec_cfg_table_entry: No matching rows - adding new row: 214
DEBUG:lute.io._sqlite:_add_task_entry: ['"gen_cfg_id"', '"exec_cfg_id"', '"array_size"', '"num_arrays"', '"result.task_status"', '"result.summary"', '"result.payload"', '"result.impl_schemas"', '"valid_flag"']
		[1, 214, 8000, 10, 'COMPLETED', 'Sent 10 arrays', array([0.12877769, 0.27503862, 0.34789427, ..., 0.12360039, 0.39367444,
       0.35728848]), None, 1]
DEBUG:lute.execution.ipc:Stopping socket reader thread.
DEBUG:lute.execution.ipc:Closed reading thread.
```

## Testing TCP with ZMQ
- SLURM using `MultiNodeCommunicationTester` `Task` which uses MPI.
```bash
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat multi_tcp_zmq.out
INFO:lute.execution.ipc:Will use TCP (ZMQ).
INFO:lute.execution.executor:Rank 0 of 3 sending message.  From sdfmilan101 to sdfmilan101. 
INFO:lute.execution.executor:Executor: TestMultiNodeCommunication started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') send_obj='plot' arr_size=5
INFO:lute.execution.executor:Rank 1 of 3 sending message.  From sdfmilan101 to sdfmilan101.
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Rank 2 of 3 sending message.  From sdfmilan102 to sdfmilan101. 
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Test Finished.
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestMultiNodeCommunication', task_status=<TaskStatus.COMPLETED: 2>, summary='Test Finished.', payload='', impl_schemas=None)
```
```bash
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat multi_unix_zmq.out
INFO:lute.execution.ipc:Will use Unix sockets (ZMQ).
INFO:lute.execution.executor:Executor: TestMultiNodeCommunication started
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='EXPL10000', run='', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') send_obj='plot' arr_size=5
INFO:lute.execution.executor:Rank 0 of 3 sending message.  From sdfmilan113 to sdfmilan113.
INFO:lute.execution.executor:Rank 1 of 3 sending message.  From sdfmilan113 to sdfmilan113.
INFO:lute.execution.executor:Rank 2 of 3 sending message.  From sdfmilan114 to sdfmilan113.
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Figure(640x480)
INFO:lute.execution.executor:Test Finished.
INFO:lute.execution.executor:TaskStatus.COMPLETED
INFO:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
INFO:lute.execution.executor:TaskResult(task_name='TestMultiNodeCommunication', task_status=<TaskStatus.COMPLETED: 2>, summary='Test Finished.', payload='', impl_schemas=None)
```
## Testing Unix with ZMQ
# Screenshots

