### PR TITLE
ENH Tasklet support

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -3,15 +3,16 @@
 - Please refer to the `madr_template.md` for creating new ADRs. This template was adapted from the [MADR template](https://adr.github.io/madr/) (MIT License).
 - A table of ADRs is provided below.
 
-| ADR No. | Record Date | Title                                                                       | Status       |
-|:-------:|:-----------:|:----------------------------------------------------------------------------|:------------:|
-| 1       | 2023-11-06  | All analysis `Task`s inherit from a base class                              | **Accepted** |
-| 2       | 2023-11-06  | Analysis `Task` submission and communication is performed via `Executor`s   | **Accepted** |
-| 3       | 2023-11-06  | `Executor`s will run all `Task`s via subprocess                             | **Proposed** |
-| 4       | 2023-11-06  | Airflow `Operator`s and LUTE `Executor`s are separate entities.             | **Proposed** |
-| 5       | 2023-12-06  | Task-Executor IPC is Managed by Communicator Objects                        | **Proposed** |
-| 6       | 2024-02-12  | Third-party Config Files Managed by Templates Rendered by `ThirdPartyTask`s | **Proposed** |
-| 7       | 2024-02-12  | `Task` Configuration is Stored in a Database Managed by `Executor`s         | **Proposed** |
-| 8       | 2024-03-18  | Airflow credentials/authorization requires special launch program.          | **Proposed** |
-| 9       | 2024-04-15  | Airflow launch script will run as long lived batch job.                     | **Proposed** |
-|         |             |                                                                             |              |
+| ADR No. | Record Date | Title                                                                            | Status       |
+|:-------:|:-----------:|:---------------------------------------------------------------------------------|:------------:|
+| 1       | 2023-11-06  | All analysis `Task`s inherit from a base class                                   | **Accepted** |
+| 2       | 2023-11-06  | Analysis `Task` submission and communication is performed via `Executor`s        | **Accepted** |
+| 3       | 2023-11-06  | `Executor`s will run all `Task`s via subprocess                                  | **Proposed** |
+| 4       | 2023-11-06  | Airflow `Operator`s and LUTE `Executor`s are separate entities.                  | **Proposed** |
+| 5       | 2023-12-06  | Task-Executor IPC is Managed by Communicator Objects                             | **Proposed** |
+| 6       | 2024-02-12  | Third-party Config Files Managed by Templates Rendered by `ThirdPartyTask`s      | **Proposed** |
+| 7       | 2024-02-12  | `Task` Configuration is Stored in a Database Managed by `Executor`s              | **Proposed** |
+| 8       | 2024-03-18  | Airflow credentials/authorization requires special launch program.               | **Proposed** |
+| 9       | 2024-04-15  | Airflow launch script will run as long lived batch job.                          | **Proposed** |
+| 10      | 2024-09-08  | Tasklet functions provide supplemental/auxiliary analysis for `ThirdPartyTask`s. | **Proposed** |
+|         |             |                                                                                  |              |

--- a/docs/adrs/adr-10.md
+++ b/docs/adrs/adr-10.md
@@ -1,0 +1,39 @@
+# [ADR-10] Tasklet functions provide supplemental/auxiliary analysis for `ThirdPartyTask`s
+
+**Date:** 2024-04-15
+
+## Status
+**Proposed**
+
+## Context and Problem Statement
+- Often need to extract some information for presentation after running some third-party analysis code.
+- There is non-zero over-head associated with running a `Task`.
+- Complexity of a `Task` is often overkill for simple operations such as parsing a text file, concatenating files or sending some small amoumnt of information to the eLog.
+
+## Decision
+The `Executor` will provide a mechanism to run some small functions either before or after the main `Task` has executed. These "tasklets" are Python functions which perform an action and optionally return a value to the `Executor`. Depending on the type of the returned value (if any), the `Executor` may take a number of actions, e.g. posting a message, creating a plot, moving files.
+
+### Decision Drivers
+* Need to provide a mechanism to summarize information as `Task`s complete. Just running the `Task` provides no feedback to the user on its own.
+* Want to present information to the eLog as an option.
+* Some functions need to be run before the `Task` starts, and others after it has finished.
+* Want a mechanism to change which functions are run.
+
+### Considered Options
+* Any operation at all must be a fully-implemented `Task`.
+  * There is overhead to launching a new batch job just to run a single function.
+* Additional options in the configuration of the pydantic model for a third-party `Task` to include auxiliary functions to run.
+  * This doesn't easily allow the function to be run after the `Task` has completed.
+
+## Consequences
+* Additional complexity for configuring `Executor`.
+  * This adds additional knobs to turn, points of failure, and makes on boarding new developers more challenging.
+* Adding new tasklets is straightforward.
+* Tasklets can be used in first-party `Task` code as they are just Python functions.
+
+## Compliance
+
+
+## Metadata
+- This ADR WILL be revisited during the post-mortem of the first prototype.
+- Compliance section will be updated as prototype evolves.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -424,12 +424,12 @@ These parameters, in order, are:
 - `tasklet` : Any callable function. A number of tasklets are already defined in the `lute.tasks.tasklets` module as examples. Some of these are already associated with **managed** `Task`s.
 - `args` : This is a list/tuple (or any iterable) of arguments to pass to the `tasklet`. The arguments can be substituted similarly to templates (below) or parameters in the configuration YAML. This is discussed further below.
 - `when`: This is a string literal taking the values of `"before"` or `"after"`, indicating whether the tasklet function should be run before or after the actual `Task`, respectively.
-- `set_result`: Is a bool. If `True`, the **main result payload** will be overwritten with the return values of the tasklet. In general this is not the appropriate option to use.
+- `set_result`: Is a bool. If `True`, the **main result payload** will be overwritten in the database with the return values of the tasklet. This affects only the database archiving - any actual files, etc., will not be overwritten. Regardless, in general this is not the appropriate option to use with a third-party `Task`.
 - `set_summary`: Is a bool. If `True`, the **result summary** is set to the return values of the tasklet. This allows the main result of the `Task` to be recorded in addition to some auxiliary summary information. In general, we will want to use this option.
 
 ##### Substituting parameters for `tasklet` arguments
 
-We often want the input to a tasklet to depend on some of the `TaskParameters` for the main associated `Task`. We can specify this using a Jinja-like substitution syntax. When passing arguments to the `add_tasklet` method, we can enclose the name of parameters from the `TaskParameters` model in a string between doubly curly brackets: `"{{ param_to_sub }}"`. For example if we wanted to use the output file as the input to the tasklet, assuming it had the parameter name `out_file`, we would use `{{ out_file }}`.
+We often want the input to a tasklet to depend on some of the `TaskParameters` for the main associated `Task`. We can specify this using a Jinja-like substitution syntax. When passing arguments to the `add_tasklet` method, we can enclose the name of parameters from the `TaskParameters` model in a string between doubly curly brackets: `"{{ param_to_sub }}"`. For example if we wanted to use the output file as the input to the tasklet, assuming it had the parameter name `out_file`, we would use `"{{ out_file }}"`.
 
 You can substitute multiple parameters in every string if necessary, with each parameter to substitute enclosed in its own set of double curly brackets.
 

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -881,3 +881,9 @@ def import_task(task_name: str) -> Type[Task]:
 
 ### Defining an `Executor`
 The process of `Executor` definition is identical to the process as described for `ThirdPartyTask`s above. The one exception is if you defined the `Task` to use MPI as described in the section above (Using MPI for your `Task`), you will likely consider using the `MPIExecutor`.
+
+#### Environment setup
+Currently, first-party `Task`s are expected to use the same environment as the `Executor`, so while you can use the environment update methods to insert environment variables, complete replacement of the environment is not supported. If you have a compelling reason to require this feature, contact the maintainers.
+
+#### `tasklet` usage
+You can also use `tasklet` functions with first-party `Task`s if needed. The preferred method, however, would be to incorporate whatever tasklet code is needed directly into your `Task`.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -390,6 +390,70 @@ Task2Runner: Executor = Executor("RunTask2")
 Task2Runner.shell_source("/sdf/group/lcls/ds/tools/new_task_setup.sh") # Will source new_task_setup.sh script
 ```
 
+#### Parsing inputs and outputs: `tasklets`
+
+Generally, in addition to the final output from the `Task`, we are also interested in some summary information. This could be a text summary of some key result in the larger output, or a graphical figure that describes the portions of interest.
+
+For a third-party `Task` there isn't an easy way to insert code that provides these summaries into the `Task` itself, so the `tasklet` mechanism is provided. Tasklets are just Python functions. They are executed by the `Executor` either before or after the main `Task` has been run. One major use case of tasklets, is that the `Executor` can use the return values from these functions as the summary information for the main `Task` they are associated with. Tasklets are added to the `Executor` in much the same way that the execution environment is modified: using the `add_tasklet` method. E.g.
+
+```py
+Task3Runner: Executor = Executor("RunTask3")
+Task3Runner.add_tasklet(
+    callable,
+    [arg1, arg2, arg3],
+    when="before",
+    set_result=False,
+    set_summary=True
+)
+```
+
+The `add_tasklet` method has the following signature:
+```py
+def add_tasklet(
+    self,
+    tasklet: Callable,
+    args: Union[List[Any], Tuple[Any,...]],
+    when: str,
+    set_result: bool,
+    set_summary: bool
+)
+```
+
+These parameters, in order, are:
+
+- `tasklet` : Any callable function. A number of tasklets are already defined in the `lute.tasks.tasklets` module as examples. Some of these are already associated with **managed** `Task`s.
+- `args` : This is a list/tuple (or any iterable) of arguments to pass to the `tasklet`. The arguments can be substituted similarly to templates (below) or parameters in the configuration YAML. This is discussed further below.
+- `when`: This is a string literal taking the values of `"before"` or `"after"`, indicating whether the tasklet function should be run before or after the actual `Task`, respectively.
+- `set_result`: Is a bool. If `True`, the **main result payload** will be overwritten with the return values of the tasklet. In general this is not the appropriate option to use.
+- `set_summary`: Is a bool. If `True`, the **result summary** is set to the return values of the tasklet. This allows the main result of the `Task` to be recorded in addition to some auxiliary summary information. In general, we will want to use this option.
+
+##### Substituting parameters for `tasklet` arguments
+
+We often want the input to a tasklet to depend on some of the `TaskParameters` for the main associated `Task`. We can specify this using a Jinja-like substitution syntax. When passing arguments to the `add_tasklet` method, we can enclose the name of parameters from the `TaskParameters` model in a string between doubly curly brackets: `"{{ param_to_sub }}"`. For example if we wanted to use the output file as the input to the tasklet, assuming it had the parameter name `out_file`, we would use `{{ out_file }}`.
+
+You can substitute multiple parameters in every string if necessary, with each parameter to substitute enclosed in its own set of double curly brackets.
+
+**Note:** The parameter substitutions must be passed as strings. Type conversions will be performed to the actual type of the parameter you are substituting.
+
+##### Examples
+
+Some example `tasklets` are available in `lute.tasks.tasklets`. Some of these are reproduced below.
+
+**Generic Usage**
+
+- `concat_files(location: str, in_files_glob: str, out_file: str)`: Concatenate a set of output files
+- `grep(match_str: str, in_file: str)`: Search for occurences of a string in some output file.
+- `git_clone(repo: str, location: str, permissions: str)`: Clone a git repository. This is generally of more use as a tasklet run **before** the main `Task` is run.
+
+**Specific Examples**
+
+- `indexamajig_summary_indexing_rate`: Calculates indexing rate based on parsing a stream file.
+- `compare_hkl_fom_summary`: Extracts a figure of merit **and** produces a summary plot.
+
+Refer to `managed_tasks` to see how these are specifically called with `CrystFELIndexer` and `HKLComparer` respectively.
+
+
+
 ### Using templates: managing third-party configuration files
 
 Some third-party executables will require their own configuration files. These are often separate JSON or YAML files, although they can also be bash or Python scripts which are intended to be edited. Since LUTE requires its own configuration YAML file, it attempts to handle these cases by using Jinja templates. When wrapping a third-party task a template can also be provided - with small modifications to the `Task`'s pydantic model, LUTE can process special types of parameters to render them in the template. LUTE offloads all the template rendering to Jinja, making the required additions to the pydantic model small. On the other hand, it does require understanding the Jinja syntax, and the provision of a well-formatted template, to properly parse parameters. Some basic examples of this syntax will be shown below; however, it is recommended that the `Task` implementer refer to the [official Jinja documentation](https://jinja.palletsprojects.com/en/3.1.x/) for more information.

--- a/docs/tutorial/new_task.md
+++ b/docs/tutorial/new_task.md
@@ -435,6 +435,17 @@ You can substitute multiple parameters in every string if necessary, with each p
 
 **Note:** The parameter substitutions must be passed as strings. Type conversions will be performed to the actual type of the parameter you are substituting.
 
+##### Return types and associated actions
+
+The `Executor` will decide on what to do with a returned value from a tasklet based upon the specific type. Note that these types can also be used in first-party `Task`s to perform the same actions; however, in that case, users should set the `_result.summary` or `_result.payload` directly, rather than using a tasklet (if possible).
+
+The following types and actions are currently defined:
+
+- `Dict[str, str]`: Post key/value pairs under the report section in the control tab of the eLog. These key/values are also posted as run parameters if possible. This return type is best used for short text summaries, e.g. indexing rate, execution time, etc. The key/value pairs are converted to a semi-colon delimited string for storage in the database. E.g. `{"Rate": 0.05, "Total": 10}` will be stored as `Rate: 0.05;Total: 10` in the database.
+- `ElogSummaryPlots`: This special dataclass, defined in `lute.tasks.dataclasses` is used to create an eLog summary plot under the Summaries tab. The path to the created HTML file is stored in the database.
+
+You can return any number of these objects from a tasklet as a tuple. Each item will be processed independently. For datbase archiving, the various entries are stored semi-colon delimited.
+
 ##### Examples
 
 Some example `tasklets` are available in `lute.tasks.tasklets`. Some of these are reproduced below.

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -138,8 +138,8 @@ if __name__ == "__main__":
     use_kerberos: bool = (
         True  # Always copy kerberos ticket so non-active experiments can work.
     )
+    cache_file: Optional[str] = os.getenv("KRB5CCNAME")
     if os.getenv("Authorization") is None:
-        cache_file: Optional[str] = os.getenv("KRB5CCNAME")
         if cache_file is None:
             logger.info("No Kerberos cache. Try running `kinit` and resubmitting.")
             sys.exit(-1)
@@ -378,8 +378,9 @@ if __name__ == "__main__":
         logger.debug("Removing duplicate Kerberos credentials.")
         # This should be defined if we get here
         # Format is FILE:/.../...
-        os.remove(cache_file[5:])
-        os.rmdir(f"{os.path.expanduser('~')}/.tmp_cache")
+        if cache_file is not None:
+            os.remove(cache_file[5:])
+            os.rmdir(f"{os.path.expanduser('~')}/.tmp_cache")
 
     if dag_state == "failed":
         sys.exit(1)

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -135,7 +135,9 @@ if __name__ == "__main__":
     extra_args: List[str]  # Should contain all SLURM arguments!
     args, extra_args = parser.parse_known_args()
     # Check if was submitted from ARP - look for token
-    use_kerberos: bool = True # Always copy kerberos ticket so non-active experiments can work.
+    use_kerberos: bool = (
+        True  # Always copy kerberos ticket so non-active experiments can work.
+    )
     if os.getenv("Authorization") is None:
         cache_file: Optional[str] = os.getenv("KRB5CCNAME")
         if cache_file is None:

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -268,6 +268,7 @@ if __name__ == "__main__":
             "Authorization": os.environ.get("Authorization"),
             "user": getpass.getuser(),
             "lute_location": os.path.abspath(f"{os.path.dirname(__file__)}/.."),
+            "kerb_file": cache_file,
             "lute_params": params,
             "slurm_params": extra_args,
             "workflow": wf_defn,  # Only used for custom defined workflows.

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -380,7 +380,10 @@ if __name__ == "__main__":
         # This should be defined if we get here
         # Format is FILE:/.../...
         if cache_file is not None:
-            os.remove(cache_file[5:])
+            try:
+                os.remove(cache_file[5:])
+            except FileNotFoundError:
+                logger.error("No cache file found to remove.")
             os.rmdir(f"{os.path.expanduser('~')}/.tmp_cache")
 
     if dag_state == "failed":

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -135,9 +135,8 @@ if __name__ == "__main__":
     extra_args: List[str]  # Should contain all SLURM arguments!
     args, extra_args = parser.parse_known_args()
     # Check if was submitted from ARP - look for token
-    use_kerberos: bool = False
+    use_kerberos: bool = True # Always copy kerberos ticket so non-active experiments can work.
     if os.getenv("Authorization") is None:
-        use_kerberos = True
         cache_file: Optional[str] = os.getenv("KRB5CCNAME")
         if cache_file is None:
             logger.info("No Kerberos cache. Try running `kinit` and resubmitting.")

--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -23,8 +23,11 @@ set -- "${POS[@]}"
 # Bodge Kerberos credentials
 # These duplicates are removed later by the workflow process
 KERB_CACHE_PATH=$(klist -l | awk -F"FILE:" '{printf (NF>1)? $NF : ""}')
-mkdir $HOME/.tmp_cache
+if [[ ! -d $HOME/.tmp_cache ]]; then
+    mkdir $HOME/.tmp_cache
+fi
 cp $KERB_CACHE_PATH $HOME/.tmp_cache/kerbcache
+echo $?
 export KRB5CCNAME="FILE:${HOME}/.tmp_cache/kerbcache"
 
 CMD="${@}"

--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -22,12 +22,10 @@ set -- "${POS[@]}"
 
 # Bodge Kerberos credentials
 # These duplicates are removed later by the workflow process
-if [[ -z $Authorization ]]; then
-    KERB_CACHE_PATH=$(klist -l | awk -F"FILE:" '{printf (NF>1)? $NF : ""}')
-    mkdir $HOME/.tmp_cache
-    cp $KERB_CACHE_PATH $HOME/.tmp_cache/kerbcache
-    export KRB5CCNAME="FILE:${HOME}/.tmp_cache/kerbcache"
-fi
+KERB_CACHE_PATH=$(klist -l | awk -F"FILE:" '{printf (NF>1)? $NF : ""}')
+mkdir $HOME/.tmp_cache
+cp $KERB_CACHE_PATH $HOME/.tmp_cache/kerbcache
+export KRB5CCNAME="FILE:${HOME}/.tmp_cache/kerbcache"
 
 CMD="${@}"
 CMD="${CMD} --partition=${PARTITION} --account=${ACCOUNT}"

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -94,15 +94,18 @@ if [[ -v KERB_CACHE ]]; then
 fi
 
 if [[ -v EXP_PARAM ]]; then
-    export EXPERIMENT=$EXP_PARAM
+    EXPERIMENT=$EXP_PARAM
 fi
+export EXPERIMENT
 # Setup logfile names - $EXPERIMENT and $RUN_NUM will be available if ARP submitted
 # RUN_NUM is actually in format RUN_DATETIME
 RUN_TIME_ARR=(${RUN_NUM//_/ })
 RUN="${RUN_TIME_ARR[0]}"
 if [[ -v RUN_PARAM ]]; then
-    export RUN=$RUN_PARAM
+    RUN_NUM=$RUN_PARAM
+    RUN=$RUN_NUM
 fi
+export RUN_NUM
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
 SLURM_ARGS+=" --output=${LOG_FILE}.out"

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -27,6 +27,8 @@ $(basename "$0"):
           Experiment name.
         -r|--run
           Run number.
+        -K|--KERB
+          Kerberos cache file variable. This should NOT be set manually!
 EOF
 }
 
@@ -49,6 +51,11 @@ do
         ;;
     -r|--run)
         RUN_PARAM="$2"
+        shift
+        shift
+        ;;
+    -K|--KERB)
+        KERB_CACHE="$2"
         shift
         shift
         ;;
@@ -82,15 +89,19 @@ fi
 # Assume all other arguments are for SLURM
 SLURM_ARGS=$@
 
+if [[ -v KERB_CACHE ]]; then
+    export KRB5CCNAME=$KERB_CACHE
+fi
+
 if [[ -v EXP_PARAM ]]; then
-    EXPERIMENT=$EXP_PARAM
+    export EXPERIMENT=$EXP_PARAM
 fi
 # Setup logfile names - $EXPERIMENT and $RUN_NUM will be available if ARP submitted
 # RUN_NUM is actually in format RUN_DATETIME
 RUN_TIME_ARR=(${RUN_NUM//_/ })
 RUN="${RUN_TIME_ARR[0]}"
 if [[ -v RUN_PARAM ]]; then
-    RUN=$RUN_PARAM
+    export RUN=$RUN_PARAM
 fi
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -18,6 +18,15 @@ $(basename "$0"):
           mandatory. All additional arguments are transparently passed to SLURM.
           You will need to provide at least the queue and account using, e.g.:
                   --partition=milano --account=lcls:<experiment>
+
+    Additional options:
+    You can also optionally provide experiment and run number. Do this only when
+    NOT running from the eLog using the ARP. These options set environment
+    variables EXPERIMENT and RUN, which can alternatively be set directly.
+        -e|--experiment
+          Experiment name.
+        -r|--run
+          Run number.
 EOF
 }
 
@@ -29,10 +38,20 @@ do
 
     case $flag in
     -c|--config)
-      CONFIGPATH="$2"
-      shift
-      shift
-      ;;
+        CONFIGPATH="$2"
+        shift
+        shift
+        ;;
+    -e|--experiment)
+        EXP_PARAM="$2"
+        shift
+        shift
+        ;;
+    -r|--run)
+        RUN_PARAM="$2"
+        shift
+        shift
+        ;;
     -h|--help)
         usage
         exit
@@ -63,10 +82,16 @@ fi
 # Assume all other arguments are for SLURM
 SLURM_ARGS=$@
 
+if [[ -v EXP_PARAM ]]; then
+    EXPERIMENT=$EXP_PARAM
+fi
 # Setup logfile names - $EXPERIMENT and $RUN_NUM will be available if ARP submitted
 # RUN_NUM is actually in format RUN_DATETIME
 RUN_TIME_ARR=(${RUN_NUM//_/ })
-export RUN="${RUN_TIME_ARR[0]}"
+RUN="${RUN_TIME_ARR[0]}"
+if [[ -v RUN_PARAM ]]; then
+    RUN=$RUN_PARAM
+fi
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
 SLURM_ARGS+=" --output=${LOG_FILE}.out"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -170,7 +170,7 @@ class BaseExecutor(ABC):
 
     def add_tasklet(
         self,
-        tasklet: Callable[[Any], Any],
+        tasklet: Callable,
         args: List[Any],
         when: str = "after",
         set_result: bool = False,
@@ -971,7 +971,10 @@ class Executor(BaseExecutor):
         exp: str = self._analysis_desc.task_parameters.lute_config.experiment
         run: int = int(self._analysis_desc.task_parameters.lute_config.run)
         logger.debug("Posting eLog run parameters.")
-        post_elog_run_table(exp, run, params)
+        try:
+            post_elog_run_table(exp, run, params)
+        except Exception as err:
+            logger.error(f"Unable to post run parameters! Error: {err}")
         summary_str: str = ";".join(f"{key}: {value}" for key, value in params.items())
         return summary_str
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -695,7 +695,7 @@ class Executor(BaseExecutor):
 
         def no_pickle_mode(
             self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ):
+        ) -> None:
             for idx, communicator in enumerate(self._communicators):
                 if isinstance(communicator, PipeCommunicator):
                     self._communicators[idx] = PipeCommunicator(
@@ -704,7 +704,7 @@ class Executor(BaseExecutor):
 
         self.add_hook("no_pickle_mode", no_pickle_mode)
 
-        def task_started(self: Executor, msg: Message, proc: subprocess.Popen):
+        def task_started(self: Executor, msg: Message, proc: subprocess.Popen) -> None:
             if isinstance(msg.contents, TaskParameters):
                 self._analysis_desc.task_parameters = msg.contents
                 # Run "before" tasklets
@@ -729,7 +729,7 @@ class Executor(BaseExecutor):
 
         def task_failed(
             self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ):
+        ) -> None:
             elog_data: Dict[str, str] = {
                 f"{self._analysis_desc.task_result.task_name} status": "FAILED",
             }
@@ -739,7 +739,7 @@ class Executor(BaseExecutor):
 
         def task_stopped(
             self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ):
+        ) -> None:
             elog_data: Dict[str, str] = {
                 f"{self._analysis_desc.task_result.task_name} status": "STOPPED",
             }
@@ -749,7 +749,7 @@ class Executor(BaseExecutor):
 
         def task_done(
             self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ):
+        ) -> None:
             elog_data: Dict[str, str] = {
                 f"{self._analysis_desc.task_result.task_name} status": "COMPLETED",
             }
@@ -759,7 +759,7 @@ class Executor(BaseExecutor):
 
         def task_cancelled(
             self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ):
+        ) -> None:
             elog_data: Dict[str, str] = {
                 f"{self._analysis_desc.task_result.task_name} status": "CANCELLED",
             }

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -938,7 +938,7 @@ class Executor(BaseExecutor):
             self._analysis_desc.task_result.summary = self._process_summary_run_params(
                 summary
             )
-        elif isinstance(summary, list):
+        elif isinstance(summary, list) or isinstance(summary, tuple):
             new_summary_str: str = ""
             for item in summary:
                 if isinstance(item, dict):

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -944,6 +944,11 @@ class Executor(BaseExecutor):
                 if isinstance(item, dict):
                     ret: str = self._process_summary_run_params(item)
                     new_summary_str = ";".join(filter(None, (new_summary_str, ret)))
+                elif isinstance(item, ElogSummaryPlots):
+                    plot_path: Optional[str] = self._process_elog_plot(item)
+                    new_summary_str = ";".join(
+                        filter(None, (new_summary_str, plot_path))
+                    )
             self._analysis_desc.task_result.summary = new_summary_str
         elif isinstance(summary, str):
             ...

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -975,6 +975,7 @@ class Executor(BaseExecutor):
             post_elog_run_table(exp, run, params)
         except Exception as err:
             logger.error(f"Unable to post run parameters! Error: {err}")
+        post_elog_run_status(params)
         summary_str: str = ";".join(f"{key}: {value}" for key, value in params.items())
         return summary_str
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -233,7 +233,7 @@ class BaseExecutor(ABC):
                         new_arg = float(new_arg)
                     except ValueError:
                         pass
-                new_args.append(new_arg)
+            new_args.append(new_arg)
         return new_args
 
     def _run_tasklets(self, *, when: str) -> None:
@@ -249,7 +249,12 @@ class BaseExecutor(ABC):
             tasklet, args, set_result, set_summary = tasklet_spec
             args = self._sub_tasklet_parameters(args)
             logger.debug(f"Running {tasklet} with {args}")
-            output: Any = tasklet(*args)  # Many don't return anything
+            output: Any
+            try:
+                output = tasklet(*args)  # Many don't return anything
+            except Exception as err:
+                logger.error(f"Tasklet failed! Error: {err}")
+                output = None
             # We set result payloads or summaries now, but the processing is done
             # by process_results method called sometime after the last tasklet
             if set_result and output is not None:

--- a/lute/io/_sqlite.py
+++ b/lute/io/_sqlite.py
@@ -3,7 +3,7 @@
 Functions should be used only by the higher-level database module.
 """
 
-__all__ = ["write_cfg_to_db", "read_latest_db_entry"]
+__all__ = []
 __author__ = "Gabriel Dorlhiac"
 
 import sqlite3
@@ -296,4 +296,4 @@ def _select_from_db(
     with con:
         res: sqlite3.Cursor = con.execute(sql)
         entries: List[Any] = res.fetchall()
-    return entries[-1][0] if entries else None
+    return entries if entries else None

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -20,7 +20,7 @@ __all__ = ["record_analysis_db", "read_latest_db_entry"]
 __author__ = "Gabriel Dorlhiac"
 
 import logging
-from typing import List, Dict, Dict, Any, Tuple, Optional
+from typing import List, Dict, Dict, Any, Tuple, Optional, Union
 
 from .models.base import TaskParameters, TemplateParameters
 from ..tasks.dataclasses import TaskResult, TaskStatus, DescribedAnalysis
@@ -292,7 +292,11 @@ def record_analysis_db(cfg: DescribedAnalysis) -> None:
 
 
 def read_latest_db_entry(
-    db_dir: str, task_name: str, param: str, valid_only: bool = True
+    db_dir: str,
+    task_name: str,
+    param: str,
+    valid_only: bool = True,
+    for_run: Optional[Union[str, int]] = None,
 ) -> Optional[Any]:
     """Read most recent value entered into the database for a Task parameter.
 
@@ -309,6 +313,9 @@ def read_latest_db_entry(
             An input file may be useful even if the Task result is invalid
             (Failed). Default = True.
 
+        for_run (Optional[str | int]): Only consider latest entries from the
+            specific experiment run provided.
+
     Returns:
         val (Any): The most recently entered value for `param` of `task_name`
             that can be found in the database. Returns None if nothing found.
@@ -322,6 +329,8 @@ def read_latest_db_entry(
             cond: Dict[str, str] = {}
             if valid_only:
                 cond = {"valid_flag": "1"}
+            if for_run is not None:
+                ...
             entry: Any = _select_from_db(con, task_name, param, cond)
         except sqlite3.OperationalError as err:
             logger.debug(f"Cannot retrieve value {param} due to: {err}")

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -382,7 +382,7 @@ def post_elog_run_status(
     if update_url is None:
         update_url = os.environ.get("JID_UPDATE_COUNTERS")
         if update_url is None:
-            logger.info("eLog Update Failed! JID_UPDATE_COUNTERS is not defined!")
+            logger.error("eLog Update Failed! JID_UPDATE_COUNTERS is not defined!")
             return
     current_status: Dict[str, Union[str, int, float]] = _get_current_run_status(
         update_url
@@ -427,7 +427,7 @@ def post_elog_message(
         try:
             out_files.append(format_file_for_post(in_file=f))
         except ElogFileFormatError as err:
-            logger.debug(f"ElogFileFormatError: {err}")
+            logger.error(f"ElogFileFormatError: {err}")
     post: Dict[str, str] = {}
     post["log_text"] = msg
     if tag:

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -47,7 +47,6 @@ class FindPeaksPyAlgosParameters(TaskParameters):
         description="Tag to add to the output file names",
     )
     pv_camera_length: Union[str, float] = Field(
-        "",
         description="PV associated with camera length "
         "(if a number, camera length directly)",
     )

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -484,7 +484,7 @@ class ConcatenateStreamFilesParameters(TaskParameters):
     def validate_out_file(cls, tag: str, values: Dict[str, Any]) -> str:
         if tag == "":
             stream_out_file: str = str(
-                Path(values["in_file"]).parent / f"{values['tag'].stream}"
+                Path(values["in_file"]).parent / f"{values['tag']}.stream"
             )
             return stream_out_file
         return tag

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -63,6 +63,14 @@ class IndexCrystFELParameters(ThirdPartyParameters):
         rename_param="o",
         is_result=True,
     )
+    peaks: Optional[str] = Field(
+        None,
+        description=(
+            "Peak finding algorithm, or file type. E.g. peakfinder8 to peak find, "
+            "or use cxi for CXI files."
+        ),
+        flag_type="--",
+    )
     geometry: str = Field(
         "", description="Path to geometry file.", flag_type="-", rename_param="g"
     )

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -87,7 +87,7 @@ HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 """Runs analysis on merge results for statistics/figures of merit.."""
 HKLComparer.add_tasklet(
     compare_hkl_fom_summary,
-    ["{{ shell_file }}", "test/rsplit"],
+    ["{{ shell_file }}", "r{{ lute_config.run }}/{{ fom }}"],
     when="after",
     set_result=False,
     set_summary=True,

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -6,7 +6,10 @@ here.
 
 from lute.execution.executor import *
 from lute.io.config import *
-from lute.tasks.tasklets import compare_hkl_fom_summary
+from lute.tasks.tasklets import (
+    compare_hkl_fom_summary,
+    indexamajig_summary_indexing_rate,
+)
 
 # Tests
 #######
@@ -61,6 +64,13 @@ CrystFELIndexer.update_environment(
             "/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin"
         )
     }
+)
+CrystFELIndexer.add_tasklet(
+    indexamajig_summary_indexing_rate,
+    ["{{ out_file }}"],
+    when="after",
+    set_result=False,
+    set_summary=True,
 )
 
 StreamFileConcatenator: Executor = Executor("ConcatenateStreamFiles")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -4,8 +4,9 @@ Executor-managed Tasks with specific environment specifications are defined
 here.
 """
 
-from .execution.executor import *
-from .io.config import *
+from lute.execution.executor import *
+from lute.io.config import *
+from lute.tasks.tasklets import compare_hkl_fom_summary
 
 # Tests
 #######
@@ -62,6 +63,9 @@ CrystFELIndexer.update_environment(
     }
 )
 
+StreamFileConcatenator: Executor = Executor("ConcatenateStreamFiles")
+"""Concatenate output stream files."""
+
 CCTBXMerger: Executor = Executor("MergeCCTBXXFEL")
 """Runs crystallographic merging using cctbx.xfel."""
 CCTBXMerger.shell_source("/sdf/group/lcls/ds/tools/cctbx/setup.sh")
@@ -71,6 +75,13 @@ PartialatorMerger: Executor = Executor("MergePartialator")
 
 HKLComparer: Executor = Executor("CompareHKL")  # For figures of merit
 """Runs analysis on merge results for statistics/figures of merit.."""
+HKLComparer.add_tasklet(
+    compare_hkl_fom_summary,
+    ["{{ shell_file }}", "test/rsplit"],
+    when="after",
+    set_result=False,
+    set_summary=True,
+)
 
 HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do more
 """Performs format conversions (among other things) of merge results."""

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -733,7 +733,7 @@ class FindPeaksPyAlgos(Task):
                 rank=self._task_parameters.peak_rank,
                 r0=self._task_parameters.r0,
                 dr=self._task_parameters.dr,
-                #      nsigm=self._task_parameters.nsigm,
+                nsigm=self._task_parameters.nsigm,
             )
 
             num_events += 1

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -756,12 +756,13 @@ class FindPeaksPyAlgos(Task):
                     photon_energy: float = (
                         Detector("EBeam").get(evt).ebeamPhotonEnergy()
                     )
-                except AttributeError:
+                    if numpy.isinf(photon_energy):
+                        raise ValueError
+                except (AttributeError, ValueError):
                     photon_energy = (
                         1.23984197386209e-06
                         / ds.env().epicsStore().value("SIOC:SYS0:ML00:AO192")
-                        / 1.0e9
-                    )
+                    ) * 1e9
 
                 file_writer.write_event(
                     img=img,

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -834,6 +834,11 @@ class FindPeaksPyAlgos(Task):
                 )
                 print(f"No. hits per rank: {num_hits_per_rank}", file=f)
 
+            self._result.summary = {
+                "Number of events processed": str(num_events_per_rank[-1]),
+                "Number of hits found": str(num_hits_total),
+                "Fractional hit rate": f"{num_hits_total/num_events_per_rank[-1]:.2f}",
+            }
             with open(Path(self._task_parameters.out_file), "w") as f:
                 print(f"{master_fname}", file=f)
 

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -755,10 +755,9 @@ class FindPeaksPyAlgos(Task):
                     decompressed = compressor.decode(compressed_img, decompressed_img)
                     img = decompressed_img
 
+                photon_energy: float
                 try:
-                    photon_energy: float = (
-                        Detector("EBeam").get(evt).ebeamPhotonEnergy()
-                    )
+                    photon_energy = Detector("EBeam").get(evt).ebeamPhotonEnergy()
                     if numpy.isinf(photon_energy):
                         raise ValueError
                 except (AttributeError, ValueError):

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -159,7 +159,10 @@ class Task(ABC):
             self._report_to_executor(start_msg)
 
         # We stop process here so Executor can do any tasklet work if needed
-        os.kill(os.getpid(), signal.SIGSTOP)
+        if os.getenv("LUTE_CONFIGPATH") is not None:
+            # Guard w/ environment variable that is set only by Executor - don't
+            # SIGSTOP if Task is running without Executor
+            os.kill(os.getpid(), signal.SIGSTOP)
 
     def _signal_result(self) -> None:
         """Send the signal that results are ready along with the results."""

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -158,6 +158,9 @@ class Task(ABC):
         else:
             self._report_to_executor(start_msg)
 
+        # We stop process here so Executor can do any tasklet work if needed
+        os.kill(os.getpid(), signal.SIGSTOP)
+
     def _signal_result(self) -> None:
         """Send the signal that results are ready along with the results."""
         signal: str = "TASK_RESULT"

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -82,7 +82,7 @@ def git_clone(repo: str, location: str, permissions: str) -> None:
 
         permissions (str): Permissions to set on the repository.
     """
-    repo_only: str = repo.split("/")[0]
+    repo_only: str = repo.split("/")[1]
     if os.path.exists(f"location/{repo_only}"):
         logger.debug(
             f"Repository {repo} already exists at {location}. Will not overwrite."

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -148,7 +148,19 @@ def indexamajig_summary_indexing_rate(stream_file: str) -> Dict[str, str]:
         n_indexed = len(res[:-1])
     else:
         n_indexed = 0
-    return {"Number of lattices indexed": str(n_indexed)}
+    res = grep("End chunk", stream_file)
+    n_hits: int
+    rate: float
+    if res:
+        n_hits = len(res[:-1])
+        rate = n_indexed / n_hits
+    else:
+        n_hits = 0
+        rate = 0
+    return {
+        "Number of lattices indexed": str(n_indexed),
+        "Indexing rate": f"{rate:.2f}",
+    }
 
 
 def compare_hkl_fom_summary(

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -1,0 +1,117 @@
+"""Tasklet functions to be run before or after a Task.
+
+"Tasklets" are simple processing steps which are intended to be run by an
+Executor after the main Task has finished. These functions help provide a way to
+handle some common operations which may need to be performed, such as examining
+an output text file, or doing simple file conversions. These operations can be
+also be imported for use in first-party Tasks. In particular for
+`ThirdPartyTask`s, it is not easy to append operations to a Task which is why
+the Executor mechanism is provided.
+
+Functions:
+    git_clone(repo: str, location: str, permissions: str): Clone a git repo.
+
+    concat_files(location: str, in_files_glob: str, out_file: str): Concatenate
+        a group of files into a single output file.
+
+    grep(match_str: str, in_file: str) -> str | List[str]: grep for text in a
+        specific file. Returns the results.
+
+Usage:
+    As tasklets are just functions they can be imported and used within Task
+    code normally if needed.
+
+    However, tasklets can also be managed through the Executor in a similar way
+    to environment changes. E.g., to add a tasklet to an Executor instance one
+    would:
+
+    # First create Executor instance as normal to run the Task
+    MyTaskRunner: Executor = Executor("RunMyTask")
+    #MyTaskRunner.update_environment(...) # if needed
+    MyTaskRunner.add_tasklet(
+        tasklet, args, when="before", set_result=False, set_summary=False
+    )
+
+    A special substitution syntax can be used in args if specific values
+    from a `TaskParameters` object will be needed to run the Tasklet:
+        args=("{{ param_to_sub }}", ...)
+"""
+
+__all__ = ["grep", "git_clone"]
+__author__ = "Gabriel Dorlhiac"
+
+import logging
+import os
+import subprocess
+from typing import Union, List
+
+
+if __debug__:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.INFO)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def concat_files(location: str, in_files_glob: str, out_file: str) -> None:
+    """Concatenate a series of files into a single output file.
+
+    Args:
+        location (str): Path to the files to concatenate.
+
+        in_files_glob (str): A glob to match a series of files at the specified
+            path. These will all be concatenated.
+
+        out_file (str): Name of the concatenated output.
+    """
+    ...
+
+
+def git_clone(repo: str, location: str, permissions: str) -> None:
+    """Clone a git repository.
+
+    Will not overwrite a directory of there is already a folder at the specified
+    location.
+
+    Args:
+        repo (str): Name of the repository to clone. Should be specified as:
+            "<user_or_organization>/<repository_name>"
+
+        location (str): Path to the location to clone to.
+
+        permissions (str): Permissions to set on the repository.
+    """
+    repo_only: str = repo.split("/")[0]
+    if os.path.exists(f"location/{repo_only}"):
+        logger.debug(
+            f"Repository {repo} already exists at {location}. Will not overwrite."
+        )
+        return
+    cmd: List[str] = ["git", "clone", f"https://github.com/{repo}.git", location]
+    out: str
+    out, _ = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+
+
+def grep(match_str: str, in_file: str) -> Union[str, List[str], None]:
+    """Grep for specific lines of text output.
+
+    Args:
+        match_str (str): String to search for.
+
+        in_file (str): File to search.
+
+    Returns:
+        lines (str | List[str]): The matches. It may be an empty string if
+            nothing is found.
+    """
+    cmd: List[str] = ["grep", match_str, in_file]
+    out: str
+    out, _ = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+
+    lines: List[str] = out.split("\n")
+    return lines[0] if len(lines) == 1 else lines

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -17,6 +17,13 @@ Functions:
     grep(match_str: str, in_file: str) -> str | List[str]: grep for text in a
         specific file. Returns the results.
 
+    indexamajig_summary_indexing_rate(stream_file: str) -> Dict[str, str]: Parse
+        an output stream file to determine indexed patterns/indexing rate.
+
+    compare_hkl_fom_summary(shell_file: str, figure_display_name: str) ->
+        Tuple[Dict[str, str], Optional[ElogSummaryPlots]]: Extract the figure of
+        merit and produce a plot of figure of merit/resolution ring.
+
 Usage:
     As tasklets are just functions they can be imported and used within Task
     code normally if needed.

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -72,7 +72,19 @@ def concat_files(location: str, in_files_glob: str, out_file: str) -> None:
 
         out_file (str): Name of the concatenated output.
     """
-    ...
+    import shutil
+    from pathlib import Path
+    from typing import BinaryIO
+
+    in_file_path: Path = Path(f"{location}")
+    in_file_list: List[Path] = list(in_file_path.rglob(f"{in_files_glob}"))
+
+    wf: BinaryIO
+    with open(out_file, "wb") as wf:
+        for in_file in in_file_list:
+            rf: BinaryIO
+            with open(in_file, "rb") as rf:
+                shutil.copyfileobj(rf, wf)
 
 
 def git_clone(repo: str, location: str, permissions: str) -> None:

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -43,7 +43,7 @@ __author__ = "Gabriel Dorlhiac"
 import logging
 import os
 import subprocess
-from typing import Union, List
+from typing import Union, List, Dict
 
 
 if __debug__:
@@ -95,7 +95,7 @@ def git_clone(repo: str, location: str, permissions: str) -> None:
     ).communicate()
 
 
-def grep(match_str: str, in_file: str) -> Union[str, List[str], None]:
+def grep(match_str: str, in_file: str) -> List[str]:
     """Grep for specific lines of text output.
 
     Args:
@@ -104,8 +104,8 @@ def grep(match_str: str, in_file: str) -> Union[str, List[str], None]:
         in_file (str): File to search.
 
     Returns:
-        lines (str | List[str]): The matches. It may be an empty string if
-            nothing is found.
+        lines (List[str]): The matches. It may be a list with just an empty
+            string if nothing is found.
     """
     cmd: List[str] = ["grep", match_str, in_file]
     out: str
@@ -114,4 +114,15 @@ def grep(match_str: str, in_file: str) -> Union[str, List[str], None]:
     ).communicate()
 
     lines: List[str] = out.split("\n")
-    return lines[0] if len(lines) == 1 else lines
+    return lines
+
+
+def indexamajig_summary_indexing_rate(stream_file: str) -> Dict[str, str]:
+    """Return indexing rate from indexamajig output.
+
+    Args:
+        stream_file (str): Input stream file.
+    """
+    res: List[str] = grep("Cell parameters", stream_file)
+    n_indexed: int = len(res[:-1])
+    return {"Number of lattices indexed": str(n_indexed)}

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -131,7 +131,11 @@ def indexamajig_summary_indexing_rate(stream_file: str) -> Dict[str, str]:
         stream_file (str): Input stream file.
     """
     res: List[str] = grep("Cell parameters", stream_file)
-    n_indexed: int = len(res[:-1])
+    n_indexed: int
+    if res:
+        n_indexed = len(res[:-1])
+    else:
+        n_indexed = 0
     return {"Number of lattices indexed": str(n_indexed)}
 
 

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -11,13 +11,27 @@ import requests
 import shutil
 import subprocess
 import sys
-from typing import List, Dict, Tuple, Any
+from typing import List, Dict, Any
 
 from krtc import KerberosTicket
 
 
 logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger(__name__)
+
+def _run_subprocess_log(cmd: List[str]) -> None:
+    """Run a subprocess with logging."""
+    global logger
+
+    out: str
+    err: str
+    out, err = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+    if out:
+        logger.info(out)
+    if err:
+        logger.info(err)
 
 
 def git_clone(repo: str, location: str, tag: str) -> None:
@@ -45,27 +59,24 @@ def git_clone(repo: str, location: str, tag: str) -> None:
         f"https://github.com/{repo}.git",
         f"{location}/{repo_only}",
     ]
-    out: str
-    out, err = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-    ).communicate()
-    if out:
-        logger.info(out)
-    if err:
-        logger.info(err)
+    _run_subprocess_log(cmd)
 
     cwd: str = os.getcwd()
     os.chdir(f"{location}/{repo_only}")
     cmd = ["git", "checkout", tag]
-    out, _ = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-    ).communicate()
-    if out:
-        logger.info(out)
-    if err:
-        logger.info(err)
+    _run_subprocess_log(cmd)
     os.chdir(cwd)
 
+def inplace_sed(in_file: str, pattern: str) -> None:
+    """Perform an in-place operation on a file using sed.
+
+    Args:
+        in_file (str): Path to the file to perform the substitution on.
+
+        pattern (str): Operation. E.g. substitute with "s/old_text/new_text/g"
+    """
+    cmd: List[str] = ["sed", "-i", pattern, in_file]
+    _run_subprocess_log(cmd)
 
 def modify_permissions(lute_path: str):
     """Recursively set permissions for a LUTE installation."""
@@ -149,6 +160,9 @@ if __name__ == "__main__":
     else:
         shutil.copy(std_hutch_config, config_path)
     os.chmod(config_path, 0o666)
+    # Substitute the work_dir in LUTE's config to the experiment results folder.
+    sed_pattern: str = f"s|work_dir:\(.*\)|work_dir: \\\"{results_dir}\\\"|g"
+    inplace_sed(config_path, sed_pattern)
 
     param_string: str = f"{launch_executable} -c {config_path} -w {args.workflow}"
 

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -425,7 +425,7 @@ class JIDSlurmOperator(BaseOperator):
         logger.info(f"Final status: {final_status}")
         if final_status in ("FAILED", "EXITED"):
             # Only DONE indicates success. EXITED may be cancelled or SLURM err
-            logger.error("`Task` job marked as failed!")
+            logger.error(f"`Task` job marked as {final_status}!")
             sys.exit(-1)
 
         failure_messages: List[str] = [

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -12,7 +12,7 @@ Classes:
 """
 
 __all__ = ["JIDSlurmOperator", "RequestOnlyOperator"]
-__author__ = "Fred Poitevin, Murali Shankar"
+__author__ = "Fred Poitevin, Murali Shankar, Gabriel Dorlhiac"
 
 import sys
 import uuid

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -261,6 +261,10 @@ class JIDSlurmOperator(BaseOperator):
         else:
             lute_param_str = f"--taskname {self.lute_task_id} --config {config_path}"
 
+        kerb_file: Optional[str] = dagrun_config.get("kerb_file")
+        if kerb_file is not None:
+            lute_param_str = f"{lute_param_str} -K {kerb_file}"
+
         slurm_param_str: str
         if self.custom_slurm_params:  # SLURM params != ""
             slurm_param_str = self.custom_slurm_params

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -418,6 +418,7 @@ class JIDSlurmOperator(BaseOperator):
             )
             time.sleep(self.poke_interval)
 
+        print(f"Final status: {jobs[0].get('status')}")
         # Logs out to xcom
         out = self.rpc("job_log_file", jobs[0], context)
         context["task_instance"].xcom_push(key="log", value=out)

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -423,7 +423,8 @@ class JIDSlurmOperator(BaseOperator):
         context["task_instance"].xcom_push(key="log", value=out)
         final_status: str = jobs[0].get("status")
         logger.info(f"Final status: {final_status}")
-        if final_status == "FAILED":
+        if final_status in ("FAILED", "EXITED"):
+            # Only DONE indicates success. EXITED may be cancelled or SLURM err
             logger.error("`Task` job marked as failed!")
             sys.exit(-1)
 

--- a/workflows/airflow/pyalgos_sfx.py
+++ b/workflows/airflow/pyalgos_sfx.py
@@ -35,29 +35,33 @@ dag: DAG = DAG(
 peak_finder: JIDSlurmOperator = JIDSlurmOperator(task_id="PeakFinderPyAlgos", dag=dag)
 
 indexer: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=120, task_id="CrystFELIndexer", dag=dag
+    max_cores=120, max_nodes=1, task_id="CrystFELIndexer", dag=dag
+)
+
+concatenator: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="StreamFileConcatenator", dag=dag
 )
 
 # Merge
 merger: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=120, task_id="PartialatorMerger", dag=dag
+    max_cores=120, max_nodes=1, task_id="PartialatorMerger", dag=dag
 )
 
 # Figures of merit
 hkl_comparer: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=8, task_id="HKLComparer", dag=dag
+    max_cores=8, max_nodes=1, task_id="HKLComparer", dag=dag
 )
 
 # HKL conversions
 hkl_manipulator: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=8, task_id="HKLManipulator", dag=dag
+    max_cores=8, max_nodes=1, task_id="HKLManipulator", dag=dag
 )
 
-# SHELX Tasks
+# CCP4
 dimple_runner: JIDSlurmOperator = JIDSlurmOperator(task_id="DimpleSolver", dag=dag)
 
 
-peak_finder >> indexer >> merger >> hkl_manipulator >> dimple_runner
+peak_finder >> indexer >> concatenator >> merger >> hkl_manipulator >> dimple_runner
 merger >> hkl_comparer
 
 # Run summaries


### PR DESCRIPTION
# Description

This PR introduces the concept of a `tasklet` which is a small function the `Executor` can run before or after a `Task` finishes. These allow simple operations to be performed like examining a text file, concatenating a file or cloning a repository.

`Tasklet`s are just functions. The provided `tasklet`s can also be included in `Task` code as is. Any Python function can be used as a `tasklet` alternatively.

## Checklist
- [x] Suspend `Task` on start so `tasklet`s can be run.
- [x] `Executor` infrastructure to run `tasklet`s before a `Task` starts or after it completes.
- [x] Ability to subsitute parameters from a `TaskParameters` object into the `tasklet` parameters.
- [x] Documentation
- [x] Some useful `tasklets`
- [x] Bug fixes for pyalgos peak finding
- [x] Improvements to JIDSlurmOperator
  - [x] Correct reflection of more SLURM job failures
  - [x] Reduce default poke interval to 5 seconds to make response faster.
- [x] Pass kerberos information through airflow to the running SLURM jobs.
- [x] Update database access to allow filtering for latest entries for a specific run. 

## PR Type:
- [x] New features/Enhancement
- [x] Bug fix

## Address issues:
- NA

# Testing
Tested against `mfxx49820`. Output available in `/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute_output` and `/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac`. Status updates are available through the eLog.

Kerberos credentials can be used to post run table data even for old experiments; however, the automatic transfer of credentials to make them available to batch jobs only works if submitting `submit_launch_airflow.sh` from the command-line. Alternatively the credentials can be manually copied to `~/.tmp_cache/kerbcache` before launching from the eLog. This will be removed after each run however.

# Screenshots
## Control Tab
![image](https://github.com/user-attachments/assets/47434283-3d88-4650-8547-2bd82e4ef286)
Tasklets produce the summaries under `CompareHKL` and `IndexCrystFEL`.

The summaries under `FindPeaksPyAlgos` is produced through the same summary processing mechanisms by the `Executor` but as it is a first-party `Task` the `_result.summary` is directly assigned prior to the `Task` completing.

![image](https://github.com/user-attachments/assets/52c764a3-098a-4348-9f0f-c94c37df8a44)

Plot created automatically by tasklet for `CompareHKL`.
