### PR TITLE
MNT Default to new Airflow user for running

### DIFF
--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -38,8 +38,10 @@ else:
 def _retrieve_pw(instance: str = "prod", is_admin: bool = False) -> str:
     user_type: str
     if is_admin:
+        logger.debug("Running as operator.")
         user_type = "admin"
     else:
+        logger.debug("Running as user.")
         user_type = "user"
     path: str = "/sdf/group/lcls/ds/tools/lute/airflow_{instance}_{user_type}.txt"
     if instance == "prod" or instance == "test":

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -188,7 +188,8 @@ if __name__ == "__main__":
     }
 
     pw: str = _retrieve_pw(instance_str, is_admin=args.admin)
-    auth: HTTPBasicAuth = HTTPBasicAuth("btx", pw)
+    user_name: str = "btx" if args.admin else "lcls_user"
+    auth: HTTPBasicAuth = HTTPBasicAuth(user_name, pw)
     resp: requests.models.Response = requests.get(
         f"{airflow_instance}/{airflow_api_endpoints['health']}",
         auth=auth,

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -35,10 +35,15 @@ else:
     logger.setLevel(logging.INFO)
 
 
-def _retrieve_pw(instance: str = "prod") -> str:
-    path: str = "/sdf/group/lcls/ds/tools/lute/airflow_{instance}.txt"
+def _retrieve_pw(instance: str = "prod", is_admin: bool = False) -> str:
+    user_type: str
+    if is_admin:
+        user_type = "admin"
+    else:
+        user_type = "user"
+    path: str = "/sdf/group/lcls/ds/tools/lute/airflow_{instance}_{user_type}.txt"
     if instance == "prod" or instance == "test":
-        path = path.format(instance=instance)
+        path = path.format(instance=instance, user_type=user_type)
     else:
         raise ValueError('`instance` must be either "test" or "prod"!')
 
@@ -90,6 +95,9 @@ if __name__ == "__main__":
         prog="trigger_airflow_lute_dag",
         description="Trigger Airflow to begin executing a LUTE DAG.",
         epilog="Refer to https://github.com/slac-lcls/lute for more information.",
+    )
+    parser.add_argument(
+        "-a", "--admin", help="Run as admin. Requires permissions.", action="store_true"
     )
     parser.add_argument("-c", "--config", type=str, help="Path to config YAML file.")
     parser.add_argument("-d", "--debug", help="Run in debug mode.", action="store_true")
@@ -179,7 +187,7 @@ if __name__ == "__main__":
         ),
     }
 
-    pw: str = _retrieve_pw(instance_str)
+    pw: str = _retrieve_pw(instance_str, is_admin=args.admin)
     auth: HTTPBasicAuth = HTTPBasicAuth("btx", pw)
     resp: requests.models.Response = requests.get(
         f"{airflow_instance}/{airflow_api_endpoints['health']}",

--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -32,7 +32,6 @@ fi
 CMD="${@}"
 CMD="${CMD} --partition=${PARTITION} --account=${ACCOUNT}"
 echo $CMD
-CMD="/sdf/group/lcls/ds/tools/lute/lute_launcher ${CMD}"
 SLURM_ARGS="--partition=${PARTITION} --account=${ACCOUNT} --ntasks=1"
 echo "Running ${CMD} with ${SLURM_ARGS}"
 sbatch $SLURM_ARGS --wrap "${CMD}"


### PR DESCRIPTION
# Description

This PR defaults to a different Airflow user for running with the standard launch scripts. The old user is still available via an additional flag but requires additional permissions. This removes the use of the previous `lute_launcher` executables.

## Checklist
- [x] Update the Airflow users and roles.
- [x] Update `launch_airflow.py` to use the new user by default.
- [x] Update `submit_launch_airflow.sh` to not use the launcher executable.
- [x] Documentation changes.

## PR Type:
- [x] Style/Maintenance

## Address issues:
- No open issues but simplifies credential management

# Testing

# Screenshots
## Testing against Production Instance
`lcls_user` can start DAG runs
![image](https://github.com/user-attachments/assets/2f499047-4e6d-4d89-84aa-3a7719e9bc57)

`lcls_user` cannot access web interface
![image](https://github.com/user-attachments/assets/ae69a50b-3d6c-4d0c-8ada-10f07207bcd2)

`lcls_user` can still run dynamic workflows
![image](https://github.com/user-attachments/assets/c1342b3f-3aa5-4a92-bc88-55ffccad8c0a)

Elevated submission also works by providing the `--admin` flag:
```
[dorlhiac@sdfiana001 /sdf/scratch/users/d/dorlhiac]$> ./lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --admin --debug --partition=milano --account=lcls:data
```

## Testing against Test/Dev Instance
We see equivalent behaviour as with the production instance.

Testing as `lcls_user`
```
[dorlhiac@sdfiana001 /sdf/scratch/users/d/dorlhiac]$> ./lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --debug --partition=milano --account=lcls:data --test
mkdir: cannot create directory '/sdf/home/d/dorlhiac/.tmp_cache': File exists
/sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --debug --test --partition=milano --account=lcls:data
Running /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --debug --test --partition=milano --account=lcls:data with --partition=milano --account=lcls:data --ntasks=1
Submitted batch job 54202711
[dorlhiac@sdfiana001 /sdf/scratch/users/d/dorlhiac]$> cat slurm-54202711.out
DEBUG:Launch_Airflow:Running as user.
INFO:Launch_Airflow:Submitted DAG (Workflow): test
DAG_RUN_ID: 82bc6fd0-7bec-4da0-97e0-331f6161ab18
INFO:Launch_Airflow:DAG is queued
```

No web access
![image](https://github.com/user-attachments/assets/9ddb0a03-0d15-4af7-bba9-119f8a78bd76)


Testing with additional privileges.
```bash
[dorlhiac@sdfiana001 /sdf/scratch/users/d/dorlhiac]$> ./lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --admin --debug --partition=milano --account=lcls:data --test -W /sdf/scratch/users/d/dorlhiac/test2.dag
/sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --admin --debug --test -W /sdf/scratch/users/d/dorlhiac/test2.dag --partition=milano --account=lcls:data
Running /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --admin --debug --test -W /sdf/scratch/users/d/dorlhiac/test2.dag --partition=milano --account=lcls:data with --partition=milano --account=lcls:data --ntasks=1
Submitted batch job 54205852
[dorlhiac@sdfiana001 /sdf/scratch/users/d/dorlhiac]$> cat slurm-54205852.out
INFO:Launch_Airflow:Will attempt running custom DAG
DEBUG:Launch_Airflow:Running as operator.
INFO:Launch_Airflow:Submitted DAG (Workflow): test_dynamic
DAG_RUN_ID: 387acec1-6260-45f3-b400-1c6be3c8761a
INFO:Launch_Airflow:DAG is queued
INFO:Launch_Airflow:Contains Managed Tasks (alphabetical, not execution order):
	- retrieve_workflow,
```