### PR TITLE
ENH Provide initial CCTBX integration

### DIFF
--- a/config/templates/cctbx_index.phil
+++ b/config/templates/cctbx_index.phil
@@ -1,0 +1,358 @@
+input {
+  file_list = None
+  glob = None
+  image_tag = None
+  show_image_tags = False
+  max_images = None
+}
+dispatch {
+  process_percent = None
+  hit_finder {
+    enable = True
+    minimum_number_of_reflections = 16
+    maximum_number_of_reflections = None
+  }
+}
+output {
+  output_dir = .
+  composite_output = True
+  logging_dir = None
+  logging_option = normal *suppressed disabled
+  experiments_filename = None
+  strong_filename = None
+  indexed_filename = %s_indexed.refl
+  refined_experiments_filename = %s_refined.expt
+  integrated_filename = %s_integrated.refl
+  integrated_experiments_filename = %s_integrated.expt
+  coset_filename = %s_coset%d.refl
+  coset_experiments_filename = %s_coset%d.expt
+  profile_filename = None
+}
+mp {
+  method = *multiprocessing sge lsf pbs mpi
+  nproc = 1
+  composite_stride = None
+}
+input {
+  reference_geometry = None
+  sync_reference_geom = True
+}
+output {
+  shoeboxes = True
+}
+spotfinder {
+  lookup {
+    mask = None
+  }
+  write_hot_mask = False
+  hot_mask_prefix = 'hot_mask'
+  force_2d = False
+  scan_range = None
+  region_of_interest = None
+  compute_mean_background = False
+  filter {
+    min_spot_size = Auto
+    max_spot_size = 1000
+    max_strong_pixel_fraction = 0.25
+    border = 0
+    d_min = None
+    d_max = None
+    disable_parallax_correction = False
+    resolution_range = None
+    untrusted {
+      panel = None
+      circle = None
+      rectangle = None
+      polygon = None
+      pixel = None
+    }
+    ice_rings {
+      filter = False
+    }
+  }
+  mp {
+    method = *none drmaa sge lsf pbs
+    njobs = 1
+    nproc = 1
+    chunksize = auto
+    min_chunksize = 20
+  }
+  threshold {
+    algorithm = dispersion *dispersion_extended radial_profile
+    dispersion {
+      gain = None
+      global_threshold = 0
+    }
+    radial_profile {
+      n_iqr = 6
+      blur = narrow wide
+      n_bins = 100
+    }
+  }
+}
+indexing {
+  nproc = 1
+  known_symmetry {
+    space_group = None
+    unit_cell = None
+  }
+  index_assignment {
+    simple {
+      hkl_tolerance = 0.3
+    }
+  }
+  check_misindexing {
+    grid_search_scope = 0
+  }
+  refinement_protocol {
+    n_macro_cycles = 5
+    d_min_step = Auto
+    d_min_start = None
+    d_min_final = None
+  }
+  stills {
+    ewald_proximity_resolution_cutoff = 2.0
+    refine_all_candidates = True
+    rmsd_min_px = 2
+    ewald_proximal_volume_max = 0.0025
+    isoforms {
+      name = None
+      cell = None
+      lookup_symbol = None
+      rmsd_target_mm = None
+      beam_restraint = None
+    }
+    set_domain_size_ang_value = None
+    set_mosaic_half_deg_value = None
+  }
+}
+indexing {
+  method = *fft1d fft3d real_space_grid_search low_res_spot_match \
+           pink_indexer
+}
+refinement {
+  parameterisation {
+    scan_varying = False
+    interval_width_degrees = None
+    set_scan_varying_errors = False
+    beam {
+      fix = *all in_spindle_plane out_spindle_plane wavelength
+    }
+    crystal {
+      fix = all cell orientation
+    }
+    detector {
+      fix = *all position orientation distance
+    }
+    goniometer {
+      fix = *all in_beam_plane out_beam_plane
+    }
+  }
+  reflections {
+    outlier {
+      algorithm = null *auto mcd tukey sauter_poon
+    }
+  }
+}
+integration {
+  lookup {
+    mask = None
+  }
+  block {
+    size = auto
+    units = *degrees radians frames
+    threshold = 0.95
+    force = False
+    max_memory_usage = 0.90
+  }
+  use_dynamic_mask = True
+  debug {
+    reference {
+      filename = "reference_profiles.refl"
+      output = False
+    }
+    during = modelling *integration
+    output = False
+    separate_files = True
+    delete_shoeboxes = False
+    select = None
+    split_experiments = True
+  }
+  profile {
+    fitting = False
+    validation {
+      number_of_partitions = 1
+      min_partition_size = 100
+    }
+  }
+  overlaps_filter {
+    foreground_foreground {
+      enable = False
+    }
+    foreground_background {
+      enable = False
+    }
+  }
+  mp {
+    method = *multiprocessing drmaa sge lsf pbs
+    njobs = 1
+    nproc = 1
+    multiprocessing.n_subset_split = None
+  }
+  summation {
+    detector_gain = 1
+  }
+  background {
+    algorithm = Auto glm gmodel null *simple
+    glm {
+      robust {
+        tuning_constant = 1.345
+      }
+      model {
+        algorithm = constant2d *constant3d loglinear2d loglinear3d
+      }
+      min_pixels = 10
+    }
+    gmodel {
+      robust {
+        algorithm = False
+        tuning_constant = 1.345
+      }
+      min_pixels = 10
+      model = None
+    }
+    simple {
+      outlier {
+        algorithm = null nsigma truncated normal *plane tukey
+      }
+      model {
+        algorithm = constant2d constant3d *linear2d linear3d
+      }
+      min_pixels = 10
+    }
+  }
+  centroid {
+    algorithm = *simple
+  }
+}
+profile {
+  algorithm = ellipsoid *gaussian_rs
+  ellipsoid {
+    rlp_mosaicity {
+      model = simple1 *simple6 simple1angular1 simple1angular3 \
+              simple6angular1
+    }
+    wavelength_spread {
+      model = *delta
+    }
+    unit_cell {
+      fixed = False
+    }
+    orientation {
+      fixed = False
+    }
+    indexing {
+      fail_on_bad_index = False
+    }
+    refinement {
+      max_separation = 2
+      outlier_probability = 0.975
+      n_macro_cycles = 3
+      n_cycles = 3
+      min_n_reflections = 10
+      max_iter = 100
+      LL_tolerance = 1e-3
+      mosaicity_max_limit = 0.004
+      max_cell_volume_change_fraction = 0.2
+    }
+    prediction {
+      d_min = None
+      probability = 0.997300
+    }
+  }
+  gaussian_rs {
+    scan_varying = False
+    min_spots {
+      overall = 0
+      per_degree = 20
+    }
+    sigma_m_algorithm = basic *extended
+    centroid_definition = com *s1
+    parameters {
+      n_sigma = 3.0
+      sigma_b = None
+      sigma_m = None
+    }
+    filter {
+      min_zeta = 0.05
+    }
+    fitting {
+      scan_step = 5
+      grid_size = 5
+      threshold = 0.02
+      grid_method = single *regular_grid circular_grid spherical_grid
+      fit_method = *reciprocal_space detector_space
+      detector_space {
+        deconvolution = False
+      }
+    }
+  }
+}
+prediction {
+  d_min = None
+  d_max = None
+  margin = 1
+  force_static = False
+  padding = 1.0
+}
+indexing {
+  stills {
+    method_list = None
+    reflection_subsampling {
+      enable = False
+      step_start = 100
+      step_stop = 50
+      step_size = 2
+      n_attempts_per_step = 1
+    }
+  }
+}
+integration {
+  absorption_correction {
+    apply = False
+    algorithm = fuller_kapton kapton_2019 other
+    fuller_kapton {
+      xtal_height_above_kapton_mm {
+        value = 0.02
+        sigma = 0.01
+      }
+      rotation_angle_deg {
+        value = 1.15
+        sigma = 0.1
+      }
+      kapton_half_width_mm {
+        value = 1.5875
+        sigma = 0.5
+      }
+      kapton_thickness_mm {
+        value = 0.05
+        sigma = 0.005
+      }
+      smart_sigmas = False
+      within_spot_sigmas = True
+    }
+  }
+  coset {
+    transformation = 6
+  }
+  integration_only_overrides {
+    trusted_range = None
+  }
+}
+profile {
+  gaussian_rs {
+    parameters {
+      sigma_b_cutoff = 0.1
+    }
+  }
+}

--- a/config/templates/cctbx_index.phil
+++ b/config/templates/cctbx_index.phil
@@ -1,17 +1,17 @@
-{%- if input_reference_geometry is defined -%}
+{%- if input_reference_geometry is defined and input_reference_geometry -%}
 input {
-  reference_geometry = ""
+  reference_geometry = {{ input_reference_geometry }}
 }
-{%- endif -%}
-{%- if geometry_detector_panel_origin is defined -%}
+{% endif %}
+{%- if geometry_detector_panel_origin is defined and geometry_detector_panel_origin -%}
 geometry {
   detector {
     panel {
-      origin =
+      origin = {{ geometry_detector_panel_origin }}
     }
   }
 }
-{%- endif -%}
+{% endif -%}
 output {
   output_dir = {{ output_output_dir }}
   composite_output = {{ output_composite_output }}

--- a/config/templates/cctbx_index.phil
+++ b/config/templates/cctbx_index.phil
@@ -1,3 +1,17 @@
+{%- if input_reference_geometry is defined -%}
+input {
+  reference_geometry = ""
+}
+{%- endif -%}
+{%- if geometry_detector_panel_origin is defined -%}
+geometry {
+  detector {
+    panel {
+      origin =
+    }
+  }
+}
+{%- endif -%}
 output {
   output_dir = {{ output_output_dir }}
   composite_output = {{ output_composite_output }}
@@ -10,15 +24,18 @@ dispatch {
   integrate = {{ dispatch_integrate }}
 }
 mp {
-  method = {{ mp_mpi_method }}
+  method = {{ mp_method }}
 }
 spotfinder {
+  lookup {
+    mask = {{ spotfinder_lookup_mask }}
+  }
   threshold {
     dispersion {
       gain = {{ spotfinder_threshold_dispersion_gain }}
       sigma_background = {{ spotfinder_threshold_dispersion_sigma_bkgnd }}
       sigma_strong = {{ spotfinder_threshold_dispersion_sigma_strong}}
-      global_threshold = {{ spotfinder_threshold_dispersion_global_thresh }}
+      global_threshold = {{ spotfinder_threshold_dispersion_global_threshold }}
       kernel_size = {{ spotfinder_threshold_dispersion_kernel_size }}
     }
   }

--- a/config/templates/cctbx_index.phil
+++ b/config/templates/cctbx_index.phil
@@ -1,358 +1,68 @@
-input {
-  file_list = None
-  glob = None
-  image_tag = None
-  show_image_tags = False
-  max_images = None
+output {
+  output_dir = {{ output_output_dir }}
+  composite_output = {{ output_composite_output }}
+  logging_dir = {{ output_logging_dir }}
+  logging_option = normal *suppressed disabled
 }
 dispatch {
-  process_percent = None
-  hit_finder {
-    enable = True
-    minimum_number_of_reflections = 16
-    maximum_number_of_reflections = None
-  }
-}
-output {
-  output_dir = .
-  composite_output = True
-  logging_dir = None
-  logging_option = normal *suppressed disabled
-  experiments_filename = None
-  strong_filename = None
-  indexed_filename = %s_indexed.refl
-  refined_experiments_filename = %s_refined.expt
-  integrated_filename = %s_integrated.refl
-  integrated_experiments_filename = %s_integrated.expt
-  coset_filename = %s_coset%d.refl
-  coset_experiments_filename = %s_coset%d.expt
-  profile_filename = None
+  index = {{ dispatch_index }}
+  refine = {{ dispatch_refine }}
+  integrate = {{ dispatch_integrate }}
 }
 mp {
-  method = *multiprocessing sge lsf pbs mpi
-  nproc = 1
-  composite_stride = None
-}
-input {
-  reference_geometry = None
-  sync_reference_geom = True
-}
-output {
-  shoeboxes = True
+  method = {{ mp_mpi_method }}
 }
 spotfinder {
-  lookup {
-    mask = None
-  }
-  write_hot_mask = False
-  hot_mask_prefix = 'hot_mask'
-  force_2d = False
-  scan_range = None
-  region_of_interest = None
-  compute_mean_background = False
-  filter {
-    min_spot_size = Auto
-    max_spot_size = 1000
-    max_strong_pixel_fraction = 0.25
-    border = 0
-    d_min = None
-    d_max = None
-    disable_parallax_correction = False
-    resolution_range = None
-    untrusted {
-      panel = None
-      circle = None
-      rectangle = None
-      polygon = None
-      pixel = None
-    }
-    ice_rings {
-      filter = False
-    }
-  }
-  mp {
-    method = *none drmaa sge lsf pbs
-    njobs = 1
-    nproc = 1
-    chunksize = auto
-    min_chunksize = 20
-  }
   threshold {
-    algorithm = dispersion *dispersion_extended radial_profile
     dispersion {
-      gain = None
-      global_threshold = 0
+      gain = {{ spotfinder_threshold_dispersion_gain }}
+      sigma_background = {{ spotfinder_threshold_dispersion_sigma_bkgnd }}
+      sigma_strong = {{ spotfinder_threshold_dispersion_sigma_strong}}
+      global_threshold = {{ spotfinder_threshold_dispersion_global_thresh }}
+      kernel_size = {{ spotfinder_threshold_dispersion_kernel_size }}
     }
-    radial_profile {
-      n_iqr = 6
-      blur = narrow wide
-      n_bins = 100
-    }
+  }
+  filter {
+    min_spot_size = {{ spotfinder_filter_min_spot_size }}
+    d_min = {{ spotfinder_filter_d_min }}
   }
 }
 indexing {
-  nproc = 1
-  known_symmetry {
-    space_group = None
-    unit_cell = None
-  }
-  index_assignment {
-    simple {
-      hkl_tolerance = 0.3
-    }
-  }
-  check_misindexing {
-    grid_search_scope = 0
-  }
-  refinement_protocol {
-    n_macro_cycles = 5
-    d_min_step = Auto
-    d_min_start = None
-    d_min_final = None
-  }
   stills {
-    ewald_proximity_resolution_cutoff = 2.0
-    refine_all_candidates = True
-    rmsd_min_px = 2
-    ewald_proximal_volume_max = 0.0025
-    isoforms {
-      name = None
-      cell = None
-      lookup_symbol = None
-      rmsd_target_mm = None
-      beam_restraint = None
-    }
-    set_domain_size_ang_value = None
-    set_mosaic_half_deg_value = None
+    refine_candidates_with_known_symmetry = {{ indexing_stills_refine_candidates_with_known_symmetry }}
+    refine_all_candidates = {{ indexing_stills_refine_all_candidates }}
+    nv_reject_outliers = {{ indexing_stills_nv_reject_outliers }}
   }
-}
-indexing {
-  method = *fft1d fft3d real_space_grid_search low_res_spot_match \
-           pink_indexer
-}
-refinement {
-  parameterisation {
-    scan_varying = False
-    interval_width_degrees = None
-    set_scan_varying_errors = False
-    beam {
-      fix = *all in_spindle_plane out_spindle_plane wavelength
-    }
-    crystal {
-      fix = all cell orientation
-    }
-    detector {
-      fix = *all position orientation distance
-    }
-    goniometer {
-      fix = *all in_beam_plane out_beam_plane
-    }
-  }
-  reflections {
-    outlier {
-      algorithm = null *auto mcd tukey sauter_poon
-    }
+  known_symmetry {
+    space_group = {{ indexing_known_symmetry_space_group if indexing_known_symmetry_space_group else "None" }}
+    unit_cell = {{ indexing_known_symmetry_unit_cell if indexing_known_symmetry_unit_cell else "None" }}
   }
 }
 integration {
-  lookup {
-    mask = None
-  }
-  block {
-    size = auto
-    units = *degrees radians frames
-    threshold = 0.95
-    force = False
-    max_memory_usage = 0.90
-  }
-  use_dynamic_mask = True
-  debug {
-    reference {
-      filename = "reference_profiles.refl"
-      output = False
-    }
-    during = modelling *integration
-    output = False
-    separate_files = True
-    delete_shoeboxes = False
-    select = None
-    split_experiments = True
-  }
-  profile {
-    fitting = False
-    validation {
-      number_of_partitions = 1
-      min_partition_size = 100
-    }
-  }
-  overlaps_filter {
-    foreground_foreground {
-      enable = False
-    }
-    foreground_background {
-      enable = False
-    }
-  }
-  mp {
-    method = *multiprocessing drmaa sge lsf pbs
-    njobs = 1
-    nproc = 1
-    multiprocessing.n_subset_split = None
-  }
-  summation {
-    detector_gain = 1
-  }
   background {
-    algorithm = Auto glm gmodel null *simple
-    glm {
-      robust {
-        tuning_constant = 1.345
-      }
-      model {
-        algorithm = constant2d *constant3d loglinear2d loglinear3d
-      }
-      min_pixels = 10
-    }
-    gmodel {
-      robust {
-        algorithm = False
-        tuning_constant = 1.345
-      }
-      min_pixels = 10
-      model = None
-    }
     simple {
       outlier {
-        algorithm = null nsigma truncated normal *plane tukey
-      }
-      model {
-        algorithm = constant2d constant3d *linear2d linear3d
-      }
-      min_pixels = 10
-    }
-  }
-  centroid {
-    algorithm = *simple
-  }
-}
-profile {
-  algorithm = ellipsoid *gaussian_rs
-  ellipsoid {
-    rlp_mosaicity {
-      model = simple1 *simple6 simple1angular1 simple1angular3 \
-              simple6angular1
-    }
-    wavelength_spread {
-      model = *delta
-    }
-    unit_cell {
-      fixed = False
-    }
-    orientation {
-      fixed = False
-    }
-    indexing {
-      fail_on_bad_index = False
-    }
-    refinement {
-      max_separation = 2
-      outlier_probability = 0.975
-      n_macro_cycles = 3
-      n_cycles = 3
-      min_n_reflections = 10
-      max_iter = 100
-      LL_tolerance = 1e-3
-      mosaicity_max_limit = 0.004
-      max_cell_volume_change_fraction = 0.2
-    }
-    prediction {
-      d_min = None
-      probability = 0.997300
-    }
-  }
-  gaussian_rs {
-    scan_varying = False
-    min_spots {
-      overall = 0
-      per_degree = 20
-    }
-    sigma_m_algorithm = basic *extended
-    centroid_definition = com *s1
-    parameters {
-      n_sigma = 3.0
-      sigma_b = None
-      sigma_m = None
-    }
-    filter {
-      min_zeta = 0.05
-    }
-    fitting {
-      scan_step = 5
-      grid_size = 5
-      threshold = 0.02
-      grid_method = single *regular_grid circular_grid spherical_grid
-      fit_method = *reciprocal_space detector_space
-      detector_space {
-        deconvolution = False
+        outlier {
+          plane {
+            n_sigma = {{ integration_background_simple_outlier_plane_n_sigma }}
+          }
+        }
       }
     }
   }
-}
-prediction {
-  d_min = None
-  d_max = None
-  margin = 1
-  force_static = False
-  padding = 1.0
-}
-indexing {
-  stills {
-    method_list = None
-    reflection_subsampling {
-      enable = False
-      step_start = 100
-      step_stop = 50
-      step_size = 2
-      n_attempts_per_step = 1
-    }
-  }
-}
-integration {
-  absorption_correction {
-    apply = False
-    algorithm = fuller_kapton kapton_2019 other
-    fuller_kapton {
-      xtal_height_above_kapton_mm {
-        value = 0.02
-        sigma = 0.01
-      }
-      rotation_angle_deg {
-        value = 1.15
-        sigma = 0.1
-      }
-      kapton_half_width_mm {
-        value = 1.5875
-        sigma = 0.5
-      }
-      kapton_thickness_mm {
-        value = 0.05
-        sigma = 0.005
-      }
-      smart_sigmas = False
-      within_spot_sigmas = True
-    }
-  }
-  coset {
-    transformation = 6
-  }
-  integration_only_overrides {
-    trusted_range = None
+  summation {
+    detector_gain = {{ integration_summation_detector_gain }}
   }
 }
 profile {
   gaussian_rs {
-    parameters {
-      sigma_b_cutoff = 0.1
+    centroid_definition = {{ profile_gaussian_rs_centroid_definition }}
+  }
+}
+refinement {
+  reflections {
+    outlier {
+      algorithm = {{ refinement_reflections_outlier_algorithm if refinement_reflections_outlier_algorithm else "None" }}
     }
   }
 }

--- a/config/templates/cctbx_index.phil
+++ b/config/templates/cctbx_index.phil
@@ -31,7 +31,6 @@ indexing {
   stills {
     refine_candidates_with_known_symmetry = {{ indexing_stills_refine_candidates_with_known_symmetry }}
     refine_all_candidates = {{ indexing_stills_refine_all_candidates }}
-    nv_reject_outliers = {{ indexing_stills_nv_reject_outliers }}
   }
   known_symmetry {
     space_group = {{ indexing_known_symmetry_space_group if indexing_known_symmetry_space_group else "None" }}
@@ -42,10 +41,8 @@ integration {
   background {
     simple {
       outlier {
-        outlier {
-          plane {
+        plane {
             n_sigma = {{ integration_background_simple_outlier_plane_n_sigma }}
-          }
         }
       }
     }

--- a/config/templates/cctbx_index_defaults.phil
+++ b/config/templates/cctbx_index_defaults.phil
@@ -1,0 +1,364 @@
+
+
+
+input {
+  file_list = None
+  glob = None
+  image_tag = None
+  show_image_tags = False
+  max_images = None
+}
+dispatch {
+  index = True
+  refine = True
+  integrate = True
+  process_percent = None
+  hit_finder {
+    enable = True
+    minimum_number_of_reflections = 16
+    maximum_number_of_reflections = None
+  }
+}
+output {
+  output_dir = {{ output_output_dir }}
+  composite_output = {{ output_composite_output }}
+  logging_dir = {{ output_logging_dir }}
+  logging_option = normal *suppressed disabled
+  experiments_filename = None
+  strong_filename = None
+  indexed_filename = %s_indexed.refl
+  refined_experiments_filename = %s_refined.expt
+  integrated_filename = %s_integrated.refl
+  integrated_experiments_filename = %s_integrated.expt
+  coset_filename = %s_coset%d.refl
+  coset_experiments_filename = %s_coset%d.expt
+  profile_filename = None
+}
+mp {
+  method = *multiprocessing sge lsf pbs mpi
+  nproc = 1
+  composite_stride = None
+}
+input {
+  reference_geometry = None
+  sync_reference_geom = True
+}
+output {
+  shoeboxes = True
+}
+spotfinder {
+  lookup {
+    mask = None
+  }
+  write_hot_mask = False
+  hot_mask_prefix = 'hot_mask'
+  force_2d = False
+  scan_range = None
+  region_of_interest = None
+  compute_mean_background = False
+  filter {
+    min_spot_size = Auto
+    max_spot_size = 1000
+    max_strong_pixel_fraction = 0.25
+    border = 0
+    d_min = None
+    d_max = None
+    disable_parallax_correction = False
+    resolution_range = None
+    untrusted {
+      panel = None
+      circle = None
+      rectangle = None
+      polygon = None
+      pixel = None
+    }
+    ice_rings {
+      filter = False
+    }
+  }
+  mp {
+    method = *none drmaa sge lsf pbs
+    njobs = 1
+    nproc = 1
+    chunksize = auto
+    min_chunksize = 20
+  }
+  threshold {
+    algorithm = dispersion *dispersion_extended radial_profile
+    dispersion {
+      gain = None
+      global_threshold = 0
+    }
+    radial_profile {
+      n_iqr = 6
+      blur = narrow wide
+      n_bins = 100
+    }
+  }
+}
+indexing {
+  nproc = 1
+  known_symmetry {
+    space_group = None
+    unit_cell = None
+  }
+  index_assignment {
+    simple {
+      hkl_tolerance = 0.3
+    }
+  }
+  check_misindexing {
+    grid_search_scope = 0
+  }
+  refinement_protocol {
+    n_macro_cycles = 5
+    d_min_step = Auto
+    d_min_start = None
+    d_min_final = None
+  }
+  stills {
+    ewald_proximity_resolution_cutoff = 2.0
+    refine_all_candidates = True
+    rmsd_min_px = 2
+    ewald_proximal_volume_max = 0.0025
+    isoforms {
+      name = None
+      cell = None
+      lookup_symbol = None
+      rmsd_target_mm = None
+      beam_restraint = None
+    }
+    set_domain_size_ang_value = None
+    set_mosaic_half_deg_value = None
+  }
+}
+indexing {
+  method = *fft1d fft3d real_space_grid_search low_res_spot_match \
+           pink_indexer
+}
+refinement {
+  parameterisation {
+    scan_varying = False
+    interval_width_degrees = None
+    set_scan_varying_errors = False
+    beam {
+      fix = *all in_spindle_plane out_spindle_plane wavelength
+    }
+    crystal {
+      fix = all cell orientation
+    }
+    detector {
+      fix = *all position orientation distance
+    }
+    goniometer {
+      fix = *all in_beam_plane out_beam_plane
+    }
+  }
+  reflections {
+    outlier {
+      algorithm = null *auto mcd tukey sauter_poon
+    }
+  }
+}
+integration {
+  lookup {
+    mask = None
+  }
+  block {
+    size = auto
+    units = *degrees radians frames
+    threshold = 0.95
+    force = False
+    max_memory_usage = 0.90
+  }
+  use_dynamic_mask = True
+  debug {
+    reference {
+      filename = "reference_profiles.refl"
+      output = False
+    }
+    during = modelling *integration
+    output = False
+    separate_files = True
+    delete_shoeboxes = False
+    select = None
+    split_experiments = True
+  }
+  profile {
+    fitting = False
+    validation {
+      number_of_partitions = 1
+      min_partition_size = 100
+    }
+  }
+  overlaps_filter {
+    foreground_foreground {
+      enable = False
+    }
+    foreground_background {
+      enable = False
+    }
+  }
+  mp {
+    method = *multiprocessing drmaa sge lsf pbs
+    njobs = 1
+    nproc = 1
+    multiprocessing.n_subset_split = None
+  }
+  summation {
+    detector_gain = 1
+  }
+  background {
+    algorithm = Auto glm gmodel null *simple
+    glm {
+      robust {
+        tuning_constant = 1.345
+      }
+      model {
+        algorithm = constant2d *constant3d loglinear2d loglinear3d
+      }
+      min_pixels = 10
+    }
+    gmodel {
+      robust {
+        algorithm = False
+        tuning_constant = 1.345
+      }
+      min_pixels = 10
+      model = None
+    }
+    simple {
+      outlier {
+        algorithm = null nsigma truncated normal *plane tukey
+      }
+      model {
+        algorithm = constant2d constant3d *linear2d linear3d
+      }
+      min_pixels = 10
+    }
+  }
+  centroid {
+    algorithm = *simple
+  }
+}
+profile {
+  algorithm = ellipsoid *gaussian_rs
+  ellipsoid {
+    rlp_mosaicity {
+      model = simple1 *simple6 simple1angular1 simple1angular3 \
+              simple6angular1
+    }
+    wavelength_spread {
+      model = *delta
+    }
+    unit_cell {
+      fixed = False
+    }
+    orientation {
+      fixed = False
+    }
+    indexing {
+      fail_on_bad_index = False
+    }
+    refinement {
+      max_separation = 2
+      outlier_probability = 0.975
+      n_macro_cycles = 3
+      n_cycles = 3
+      min_n_reflections = 10
+      max_iter = 100
+      LL_tolerance = 1e-3
+      mosaicity_max_limit = 0.004
+      max_cell_volume_change_fraction = 0.2
+    }
+    prediction {
+      d_min = None
+      probability = 0.997300
+    }
+  }
+  gaussian_rs {
+    scan_varying = False
+    min_spots {
+      overall = 0
+      per_degree = 20
+    }
+    sigma_m_algorithm = basic *extended
+    centroid_definition = com *s1
+    parameters {
+      n_sigma = 3.0
+      sigma_b = None
+      sigma_m = None
+    }
+    filter {
+      min_zeta = 0.05
+    }
+    fitting {
+      scan_step = 5
+      grid_size = 5
+      threshold = 0.02
+      grid_method = single *regular_grid circular_grid spherical_grid
+      fit_method = *reciprocal_space detector_space
+      detector_space {
+        deconvolution = False
+      }
+    }
+  }
+}
+prediction {
+  d_min = None
+  d_max = None
+  margin = 1
+  force_static = False
+  padding = 1.0
+}
+indexing {
+  stills {
+    method_list = None
+    reflection_subsampling {
+      enable = False
+      step_start = 100
+      step_stop = 50
+      step_size = 2
+      n_attempts_per_step = 1
+    }
+  }
+}
+integration {
+  absorption_correction {
+    apply = False
+    algorithm = fuller_kapton kapton_2019 other
+    fuller_kapton {
+      xtal_height_above_kapton_mm {
+        value = 0.02
+        sigma = 0.01
+      }
+      rotation_angle_deg {
+        value = 1.15
+        sigma = 0.1
+      }
+      kapton_half_width_mm {
+        value = 1.5875
+        sigma = 0.5
+      }
+      kapton_thickness_mm {
+        value = 0.05
+        sigma = 0.005
+      }
+      smart_sigmas = False
+      within_spot_sigmas = True
+    }
+  }
+  coset {
+    transformation = 6
+  }
+  integration_only_overrides {
+    trusted_range = None
+  }
+}
+profile {
+  gaussian_rs {
+    parameters {
+      sigma_b_cutoff = 0.1
+    }
+  }
+}

--- a/config/templates/cctbx_merge.phil
+++ b/config/templates/cctbx_merge.phil
@@ -1,472 +1,66 @@
-dispatch {
-  step_list = None
-}
 input {
-  override_identifiers = False
-  alist {
-    file = None
-    type = *tags files
-    op = *keep reject
-  }
-  persistent_refl_cols = None
-  keep_imagesets = True
-  read_image_headers = False
-  path = None
-  reflections_suffix = _integrated.refl
-  experiments_suffix = _integrated.expt
+  path = {{ input_path }}
+  experiments_suffix = {{ input_experiments_suffix }}
+  reflections_suffix = {{ input_reflections_suffix }}
   parallel_file_load {
-    method = *uniform node_memory
-    node_memory {
-      architecture = "Cori KNL"
-      limit = 90.0
-      pickle_to_memory = 3.5
-    }
-    ranks_per_node = 68
-    balance = *global1 global2 per_node
-    balance_verbose = False
+    method = {{ input_parallel_file_load_method }}
   }
-}
-mp {
-  method = *mpi
-  debug {
-    cProfile = False
-  }
-}
-tdata {
-  output_path = None
 }
 filter {
-  algorithm = n_obs reindex resolution unit_cell report
-  n_obs {
-    min = 15
-  }
-  reindex {
-    data_reindex_op = h,k,l
-    reverse_lookup = None
-    sampling_number_of_lattices = 1000
-  }
-  resolution {
-    d_min = None
-    model_or_image = model image
-  }
+  algorithm = {{ filter_algorithm }}
   unit_cell {
-    algorithm = range *value cluster
-    value {
-      target_unit_cell = Auto
-      relative_length_tolerance = 0.1
-      absolute_angle_tolerance = 2.
-      target_space_group = Auto
-    }
+    algorithm = {{ filter_unit_cell_algorithm }}
     cluster {
-      algorithm = rodgriguez_laio dbscan *covariance
       covariance {
-        file = None
-        component = 0
-        skip_component = None
-        mahalanobis = 4.0
-        skip_mahalanobis = 4.0
+        file = {{ filter_unit_cell_cluster_covariance_file }}
+        component = {{ filter_unit_cell_cluster_covariance_component }}
+        mahalanobis = {{ filter_unit_cell_cluster_covariance_mahalanobis }}
       }
-      isoform = None
     }
   }
   outlier {
-    mad_thresh = None
-    min_corr = 0.1
-    assmann_diederichs {
-    }
-  }
-}
-modify {
-  algorithm = *polarization
-  reindex_to_reference {
-    dataframe = None
-  }
-  cosym {
-    partiality_threshold = 0.4
-    unit_cell_clustering {
-      threshold = 5000
-      log = False
-    }
-    reference_model {
-    }
-    normalisation = kernel quasi *ml_iso ml_aniso
-    d_min = Auto
-    min_i_mean_over_sigma_mean = 4
-    min_cc_half = 0.6
-    lattice_group = None
-    space_group = None
-    lattice_symmetry_max_delta = 5.0
-    best_monoclinic_beta = True
-    dimensions = Auto
-    use_curvatures = False
-    weights = count standard_error
-    cc_weights = None sigma
-    min_pairs = 3
-    minimization {
-      engine = *scitbx scipy
-      max_iterations = 100
-      max_calls = None
-    }
-    nproc = Auto
-    relative_length_tolerance = 0.05
-    absolute_angle_tolerance = 2
-    min_reflections = 10
-    seed = 230
-    output {
-      suffix = "_reindexed"
-      log = dials.cosym.log
-      experiments = "symmetrized.expt"
-      reflections = "symmetrized.refl"
-      json = dials.cosym.json
-      html = dials.cosym.html
-    }
-    dataframe = None
-    anchor = False
-    tranch_size = 600
-    twin_axis = None
-    twin_rotation = None
-    single_cb_op_to_minimum = False
-    voting_method = *consensus majority
-    plot {
-      do_plot = True
-      n_max = 1
-      interactive = False
-      format = *png pdf
-      filename = cosym_embedding
-    }
-  }
-  reindex_to_abc {
-    change_of_basis_op = a,b,c
-    hkl_offset = None
-    space_group = None
-    reference {
-      experiments = None
-      reflections = None
-      reference_model {
-      }
-    }
-    output {
-      experiments = reindexed.expt
-      reflections = reindexed.refl
-      log = dials.reindex.log
-    }
+    min_corr = {{ filter_outlier_min_corr }}
   }
 }
 select {
-  algorithm = panel cspad_sensor significance_filter
-  cspad_sensor {
-    number = None
-    operation = *deselect select
-  }
+  algorithm = {{ select_algorithm }}
   significance_filter {
-    n_bins = 12
-    min_ct = 10
-    max_ct = 50
-    sigma = 0.5
+    sigma = {{ select_significance_filter_sigma }}
   }
 }
 scaling {
-  model = None
-  unit_cell = None
-  space_group = None
-  model_reindex_op = h,k,l
-  resolution_scalar = 0.969
-  mtz {
-    mtz_column_F = fobs
-    minimum_common_hkls = -1
-  }
-  pdb {
-    include_bulk_solvent = True
-    k_sol = 0.35
-    b_sol = 46.00
-    solvent_algorithm = *mosaic flat
-  }
-  algorithm = *mark0 mark1
-  weights = *unit icalc icalc_sigma
+  model = {{ scaling_model }}
+  resolution_scalar = {{ scaling_resolution_scalar }}
 }
 postrefinement {
-  partiality_threshold_hcfix = 0.2
-  rs {
-    fix = thetax thetay *RS G BFACTOR
-  }
-  rs2 {
-  }
-  rs_hybrid {
-    partiality_threshold = 0.2
-  }
-  target_weighting = *unit variance gentle extreme
-  merge_weighting = *variance
-  merge_partiality_exponent = 0
-  lineshape = *lorentzian gaussian
-  show_trumpet_plot = False
-  delta_corr_limit = 0.1
+  enable = {{ postrefinement_enable }}
+  algorithm = {{ postrefinement_algorithm }}
 }
 merging {
-  minimum_multiplicity = 2
+  d_min = {{ merging_d_min }}
+  merge_anomalous = {{ merging_merge_anomalous }}
+  set_average_unit_cell = {{ merging_set_average_unit_cell }}
   error {
-    model = ha14 *ev11 mm24 errors_from_sample_residuals
-    ev11 {
-      minimizer = *lbfgs LevMar
-      refine_propagated_errors = False
-      show_finite_differences = False
-      plot_refinement_steps = False
-    }
-    mm24 {
-      expected_gain = None
-      number_of_intensity_bins = 100
-      n_degrees = 2
-      tuning_param = 10
-      n_max_differences = 100
-      random_seed = 50298
-      tuning_param_opt = False
-      likelihood = normal *t-dist
-      cc_after_pr = True
-      do_diagnostics = False
-    }
+    model = {{ merging_error_model }}
   }
-  plot_single_index_histograms = False
-  set_average_unit_cell = True
-  d_min = None
-  d_max = None
-  merge_anomalous = False
-  include_multiplicity_column = False
-}
-output {
-  expanded_bookkeeping = False
-  prefix = iobs
-  title = None
-  output_dir = .
-  tmp_dir = None
-  do_timing = False
-  log_level = 1
-  save_experiments_and_reflections = False
 }
 statistics {
-  shuffle_ids = False
-  n_bins = 10
-  cc1_2 {
-    hash_filenames = False
-  }
+  n_bins = {{ statistics_n_bins }}
+  report_ML = {{ statistics_report_ML }}
   cciso {
-    mtz_file = None
-    mtz_column_F = fobs
+    mtz_file = {{ statistics_cciso_mtz_file }}
+    mtz_column_F = {{ statistics_cciso_mtz_column_F }}
   }
-  predictions_to_edge {
-    apply = False
-    image = None
-    detector_phil = None
-  }
-  report_ML = True
-  uc_precision = 2
+}
+output {
+  prefix = {{ output_prefix }}
+  output_dir = {{ output_output_dir }}
+  tmp_dir = {{ output_tmp_dir }}
+  do_timing = {{ output_do_timing }}
+  log_level = {{ output_log_level }}
+  save_experiments_and_reflections = {{ output_save_experiments_and_reflections }}
 }
 parallel {
+  a2a = {{ parallel_a2a }}
 }
-lunus {
-  deck_file = None
-}
-publish {
-  drive {
-    credential_file = None
-    shared_folder_id = None
-  }
-  input {
-    mtz_file = None
-    disregard_mtz = False
-    log_file = None
-    other_files = None
-    dataset_root = None
-    version = None
-    guess_root_and_version = True
-  }
-}
-diffBragg {
-  simulator {
-    oversample = 0
-    device_id = 0
-    init_scale = 1
-    total_flux = 1e12
-    crystal {
-      ncells_abc = (10,10,10)
-      ncells_def = (0,0,0)
-      has_isotropic_ncells = False
-      has_isotropic_mosaicity = False
-      mosaicity = 0
-      anisotropic_mosaicity = None
-      num_mosaicity_samples = 1
-      mos_angles_per_axis = 10
-      num_mos_axes = 10
-      mosaicity_method = 2
-      rotXYZ_ucell = None
-    }
-    gonio {
-      delta_phi = None
-      phi_steps = 50
-    }
-    structure_factors {
-      from_pdb {
-        name = None
-        add_anom = True
-        k_sol = None
-        b_sol = None
-      }
-      mtz_name = None
-      mtz_column = None
-      dmin = 1
-      dmax = None
-      default_F = 0
-    }
-    spectrum {
-      filename = None
-      stride = 1
-      filename_list = None
-      gauss_spec {
-        fwhm = 10
-        nchannels = 20
-        res = 1
-      }
-    }
-    beam {
-      size_mm = 1
-    }
-    detector {
-      thick = None
-      atten = None
-      force_zero_thickness = False
-      thicksteps = 1
-    }
-    psf {
-      use = False
-      fwhm = 100
-      radius = 7
-    }
-  }
-  refiner {
-    check_expt_format = True
-    refldata_trusted = *allValid fg bg
-    refldata_to_photons = False
-    load_data_from_refl = False
-    test_gathered_file = False
-    gather_dir = None
-    break_signal = None
-    debug_pixel_panelfastslow = None
-    gain_map_min_max = [.5,2]
-    refine_gain_map = False
-    save_gain_freq = 10
-    region_size = [50,50]
-    res_ranges = None
-    force_symbol = None
-    force_unit_cell = None
-    num_devices = 1
-    refine_Fcell = None
-    refine_spot_scale = None
-    refine_Nabc = False
-    gain_restraint = None
-    max_calls = [100]
-    panel_group_file = None
-    update_oversample_during_refinement = False
-    sigma_r = 3
-    adu_per_photon = 1
-    use_curvatures_threshold = 10
-    curvatures = False
-    start_with_curvatures = False
-    tradeps = 1e-2
-    io {
-      restart_file = None
-      output_dir = None
-    }
-    quiet = False
-    verbose = 0
-    num_macro_cycles = 1
-    ncells_mask = *000 110 101 011 111
-    reference_geom = None
-    stage_two {
-      use_nominal_hkl = True
-      save_model_freq = 50
-      save_Z_freq = 25
-      min_multiplicity = 1
-      Fref_mtzname = None
-      Fref_mtzcol = "Famp(+),Famp(-)"
-      d_min = 2
-      d_max = 999
-      n_bin = 10
-    }
-  }
-  roi {
-    centroid = *obs cal
-    trusted_range = None
-    mask_all_if_any_outside_trusted_range = True
-    mask_outside_trusted_range = False
-    only_filter_zingers_above_mean = True
-    cache_dir_only = False
-    fit_tilt = False
-    force_negative_background_to_zero = False
-    background_threshold = 3.5
-    pad_shoebox_for_background_estimation = None
-    shoebox_size = 10
-    deltaQ = None
-    reject_edge_reflections = True
-    reject_roi_with_hotpix = True
-    hotpixel_mask = None
-    panels = None
-    fit_tilt_using_weights = False
-    allow_overlapping_spots = False
-    skip_roi_with_negative_bg = True
-  }
-  geometry {
-    save_state_freq = 50
-    save_state_overwrite = True
-    pandas_dir = None
-    optimized_results_tag = None
-    refls_key = stage1_refls
-    optimize_method = *lbfgsb nelder
-    input_pkl = None
-    input_pkl_glob = None
-    optimize = False
-    save_optimized_det_freq = 1
-    optimized_detector_name = "diffBragg_detector.expt"
-    min {
-      panel_rotations = -1,-1,-1
-      panel_translations = -1,-1,-1
-    }
-    max {
-      panel_rotations = 1,1,1
-      panel_translations = 1,1,1
-    }
-    center {
-      panel_rotations = 0,0,0
-      panel_translations = 0,0,0
-    }
-    betas {
-      panel_rot = 1e6,1e6,1e6
-      panel_xyz = 1e6,1e6,1e6
-      close_distances = None
-    }
-    fix {
-      panel_rotations = 0,0,0
-      panel_translations = 0,0,0
-    }
-  }
-  predictions {
-    use_peak_detection = False
-    verbose = False
-    laue_mode = False
-    qcut = 0.1
-    label_weak_col = "xyzobs.px.value"
-    weak_fraction = 0.5
-    threshold = 1e-3
-    thicksteps_override = None
-    use_diffBragg_mtz = False
-    pink_stride_override = None
-    default_Famplitude = 1e3
-    resolution_range = [1,999]
-    symbol_override = None
-    method = *diffbragg exascale
-  }
-}
-monitor {
-  detail = *rank node rank0 none
-  period = 5.0
-  plot = True
-  prefix = monitor
-  write = True
-}
+

--- a/config/templates/cctbx_merge.phil
+++ b/config/templates/cctbx_merge.phil
@@ -1,0 +1,472 @@
+dispatch {
+  step_list = None
+}
+input {
+  override_identifiers = False
+  alist {
+    file = None
+    type = *tags files
+    op = *keep reject
+  }
+  persistent_refl_cols = None
+  keep_imagesets = True
+  read_image_headers = False
+  path = None
+  reflections_suffix = _integrated.refl
+  experiments_suffix = _integrated.expt
+  parallel_file_load {
+    method = *uniform node_memory
+    node_memory {
+      architecture = "Cori KNL"
+      limit = 90.0
+      pickle_to_memory = 3.5
+    }
+    ranks_per_node = 68
+    balance = *global1 global2 per_node
+    balance_verbose = False
+  }
+}
+mp {
+  method = *mpi
+  debug {
+    cProfile = False
+  }
+}
+tdata {
+  output_path = None
+}
+filter {
+  algorithm = n_obs reindex resolution unit_cell report
+  n_obs {
+    min = 15
+  }
+  reindex {
+    data_reindex_op = h,k,l
+    reverse_lookup = None
+    sampling_number_of_lattices = 1000
+  }
+  resolution {
+    d_min = None
+    model_or_image = model image
+  }
+  unit_cell {
+    algorithm = range *value cluster
+    value {
+      target_unit_cell = Auto
+      relative_length_tolerance = 0.1
+      absolute_angle_tolerance = 2.
+      target_space_group = Auto
+    }
+    cluster {
+      algorithm = rodgriguez_laio dbscan *covariance
+      covariance {
+        file = None
+        component = 0
+        skip_component = None
+        mahalanobis = 4.0
+        skip_mahalanobis = 4.0
+      }
+      isoform = None
+    }
+  }
+  outlier {
+    mad_thresh = None
+    min_corr = 0.1
+    assmann_diederichs {
+    }
+  }
+}
+modify {
+  algorithm = *polarization
+  reindex_to_reference {
+    dataframe = None
+  }
+  cosym {
+    partiality_threshold = 0.4
+    unit_cell_clustering {
+      threshold = 5000
+      log = False
+    }
+    reference_model {
+    }
+    normalisation = kernel quasi *ml_iso ml_aniso
+    d_min = Auto
+    min_i_mean_over_sigma_mean = 4
+    min_cc_half = 0.6
+    lattice_group = None
+    space_group = None
+    lattice_symmetry_max_delta = 5.0
+    best_monoclinic_beta = True
+    dimensions = Auto
+    use_curvatures = False
+    weights = count standard_error
+    cc_weights = None sigma
+    min_pairs = 3
+    minimization {
+      engine = *scitbx scipy
+      max_iterations = 100
+      max_calls = None
+    }
+    nproc = Auto
+    relative_length_tolerance = 0.05
+    absolute_angle_tolerance = 2
+    min_reflections = 10
+    seed = 230
+    output {
+      suffix = "_reindexed"
+      log = dials.cosym.log
+      experiments = "symmetrized.expt"
+      reflections = "symmetrized.refl"
+      json = dials.cosym.json
+      html = dials.cosym.html
+    }
+    dataframe = None
+    anchor = False
+    tranch_size = 600
+    twin_axis = None
+    twin_rotation = None
+    single_cb_op_to_minimum = False
+    voting_method = *consensus majority
+    plot {
+      do_plot = True
+      n_max = 1
+      interactive = False
+      format = *png pdf
+      filename = cosym_embedding
+    }
+  }
+  reindex_to_abc {
+    change_of_basis_op = a,b,c
+    hkl_offset = None
+    space_group = None
+    reference {
+      experiments = None
+      reflections = None
+      reference_model {
+      }
+    }
+    output {
+      experiments = reindexed.expt
+      reflections = reindexed.refl
+      log = dials.reindex.log
+    }
+  }
+}
+select {
+  algorithm = panel cspad_sensor significance_filter
+  cspad_sensor {
+    number = None
+    operation = *deselect select
+  }
+  significance_filter {
+    n_bins = 12
+    min_ct = 10
+    max_ct = 50
+    sigma = 0.5
+  }
+}
+scaling {
+  model = None
+  unit_cell = None
+  space_group = None
+  model_reindex_op = h,k,l
+  resolution_scalar = 0.969
+  mtz {
+    mtz_column_F = fobs
+    minimum_common_hkls = -1
+  }
+  pdb {
+    include_bulk_solvent = True
+    k_sol = 0.35
+    b_sol = 46.00
+    solvent_algorithm = *mosaic flat
+  }
+  algorithm = *mark0 mark1
+  weights = *unit icalc icalc_sigma
+}
+postrefinement {
+  partiality_threshold_hcfix = 0.2
+  rs {
+    fix = thetax thetay *RS G BFACTOR
+  }
+  rs2 {
+  }
+  rs_hybrid {
+    partiality_threshold = 0.2
+  }
+  target_weighting = *unit variance gentle extreme
+  merge_weighting = *variance
+  merge_partiality_exponent = 0
+  lineshape = *lorentzian gaussian
+  show_trumpet_plot = False
+  delta_corr_limit = 0.1
+}
+merging {
+  minimum_multiplicity = 2
+  error {
+    model = ha14 *ev11 mm24 errors_from_sample_residuals
+    ev11 {
+      minimizer = *lbfgs LevMar
+      refine_propagated_errors = False
+      show_finite_differences = False
+      plot_refinement_steps = False
+    }
+    mm24 {
+      expected_gain = None
+      number_of_intensity_bins = 100
+      n_degrees = 2
+      tuning_param = 10
+      n_max_differences = 100
+      random_seed = 50298
+      tuning_param_opt = False
+      likelihood = normal *t-dist
+      cc_after_pr = True
+      do_diagnostics = False
+    }
+  }
+  plot_single_index_histograms = False
+  set_average_unit_cell = True
+  d_min = None
+  d_max = None
+  merge_anomalous = False
+  include_multiplicity_column = False
+}
+output {
+  expanded_bookkeeping = False
+  prefix = iobs
+  title = None
+  output_dir = .
+  tmp_dir = None
+  do_timing = False
+  log_level = 1
+  save_experiments_and_reflections = False
+}
+statistics {
+  shuffle_ids = False
+  n_bins = 10
+  cc1_2 {
+    hash_filenames = False
+  }
+  cciso {
+    mtz_file = None
+    mtz_column_F = fobs
+  }
+  predictions_to_edge {
+    apply = False
+    image = None
+    detector_phil = None
+  }
+  report_ML = True
+  uc_precision = 2
+}
+parallel {
+}
+lunus {
+  deck_file = None
+}
+publish {
+  drive {
+    credential_file = None
+    shared_folder_id = None
+  }
+  input {
+    mtz_file = None
+    disregard_mtz = False
+    log_file = None
+    other_files = None
+    dataset_root = None
+    version = None
+    guess_root_and_version = True
+  }
+}
+diffBragg {
+  simulator {
+    oversample = 0
+    device_id = 0
+    init_scale = 1
+    total_flux = 1e12
+    crystal {
+      ncells_abc = (10,10,10)
+      ncells_def = (0,0,0)
+      has_isotropic_ncells = False
+      has_isotropic_mosaicity = False
+      mosaicity = 0
+      anisotropic_mosaicity = None
+      num_mosaicity_samples = 1
+      mos_angles_per_axis = 10
+      num_mos_axes = 10
+      mosaicity_method = 2
+      rotXYZ_ucell = None
+    }
+    gonio {
+      delta_phi = None
+      phi_steps = 50
+    }
+    structure_factors {
+      from_pdb {
+        name = None
+        add_anom = True
+        k_sol = None
+        b_sol = None
+      }
+      mtz_name = None
+      mtz_column = None
+      dmin = 1
+      dmax = None
+      default_F = 0
+    }
+    spectrum {
+      filename = None
+      stride = 1
+      filename_list = None
+      gauss_spec {
+        fwhm = 10
+        nchannels = 20
+        res = 1
+      }
+    }
+    beam {
+      size_mm = 1
+    }
+    detector {
+      thick = None
+      atten = None
+      force_zero_thickness = False
+      thicksteps = 1
+    }
+    psf {
+      use = False
+      fwhm = 100
+      radius = 7
+    }
+  }
+  refiner {
+    check_expt_format = True
+    refldata_trusted = *allValid fg bg
+    refldata_to_photons = False
+    load_data_from_refl = False
+    test_gathered_file = False
+    gather_dir = None
+    break_signal = None
+    debug_pixel_panelfastslow = None
+    gain_map_min_max = [.5,2]
+    refine_gain_map = False
+    save_gain_freq = 10
+    region_size = [50,50]
+    res_ranges = None
+    force_symbol = None
+    force_unit_cell = None
+    num_devices = 1
+    refine_Fcell = None
+    refine_spot_scale = None
+    refine_Nabc = False
+    gain_restraint = None
+    max_calls = [100]
+    panel_group_file = None
+    update_oversample_during_refinement = False
+    sigma_r = 3
+    adu_per_photon = 1
+    use_curvatures_threshold = 10
+    curvatures = False
+    start_with_curvatures = False
+    tradeps = 1e-2
+    io {
+      restart_file = None
+      output_dir = None
+    }
+    quiet = False
+    verbose = 0
+    num_macro_cycles = 1
+    ncells_mask = *000 110 101 011 111
+    reference_geom = None
+    stage_two {
+      use_nominal_hkl = True
+      save_model_freq = 50
+      save_Z_freq = 25
+      min_multiplicity = 1
+      Fref_mtzname = None
+      Fref_mtzcol = "Famp(+),Famp(-)"
+      d_min = 2
+      d_max = 999
+      n_bin = 10
+    }
+  }
+  roi {
+    centroid = *obs cal
+    trusted_range = None
+    mask_all_if_any_outside_trusted_range = True
+    mask_outside_trusted_range = False
+    only_filter_zingers_above_mean = True
+    cache_dir_only = False
+    fit_tilt = False
+    force_negative_background_to_zero = False
+    background_threshold = 3.5
+    pad_shoebox_for_background_estimation = None
+    shoebox_size = 10
+    deltaQ = None
+    reject_edge_reflections = True
+    reject_roi_with_hotpix = True
+    hotpixel_mask = None
+    panels = None
+    fit_tilt_using_weights = False
+    allow_overlapping_spots = False
+    skip_roi_with_negative_bg = True
+  }
+  geometry {
+    save_state_freq = 50
+    save_state_overwrite = True
+    pandas_dir = None
+    optimized_results_tag = None
+    refls_key = stage1_refls
+    optimize_method = *lbfgsb nelder
+    input_pkl = None
+    input_pkl_glob = None
+    optimize = False
+    save_optimized_det_freq = 1
+    optimized_detector_name = "diffBragg_detector.expt"
+    min {
+      panel_rotations = -1,-1,-1
+      panel_translations = -1,-1,-1
+    }
+    max {
+      panel_rotations = 1,1,1
+      panel_translations = 1,1,1
+    }
+    center {
+      panel_rotations = 0,0,0
+      panel_translations = 0,0,0
+    }
+    betas {
+      panel_rot = 1e6,1e6,1e6
+      panel_xyz = 1e6,1e6,1e6
+      close_distances = None
+    }
+    fix {
+      panel_rotations = 0,0,0
+      panel_translations = 0,0,0
+    }
+  }
+  predictions {
+    use_peak_detection = False
+    verbose = False
+    laue_mode = False
+    qcut = 0.1
+    label_weak_col = "xyzobs.px.value"
+    weak_fraction = 0.5
+    threshold = 1e-3
+    thicksteps_override = None
+    use_diffBragg_mtz = False
+    pink_stride_override = None
+    default_Famplitude = 1e3
+    resolution_range = [1,999]
+    symbol_override = None
+    method = *diffbragg exascale
+  }
+}
+monitor {
+  detail = *rank node rank0 none
+  period = 5.0
+  plot = True
+  prefix = monitor
+  write = True
+}

--- a/config/templates/cctbx_merge_defaults.phil
+++ b/config/templates/cctbx_merge_defaults.phil
@@ -1,0 +1,472 @@
+dispatch {
+  step_list = None
+}
+input {
+  override_identifiers = False
+  alist {
+    file = None
+    type = *tags files
+    op = *keep reject
+  }
+  persistent_refl_cols = None
+  keep_imagesets = True
+  read_image_headers = False
+  path = None
+  reflections_suffix = _integrated.refl
+  experiments_suffix = _integrated.expt
+  parallel_file_load {
+    method = *uniform node_memory
+    node_memory {
+      architecture = "Cori KNL"
+      limit = 90.0
+      pickle_to_memory = 3.5
+    }
+    ranks_per_node = 68
+    balance = *global1 global2 per_node
+    balance_verbose = False
+  }
+}
+mp {
+  method = *mpi
+  debug {
+    cProfile = False
+  }
+}
+tdata {
+  output_path = None
+}
+filter {
+  algorithm = n_obs reindex resolution unit_cell report
+  n_obs {
+    min = 15
+  }
+  reindex {
+    data_reindex_op = h,k,l
+    reverse_lookup = None
+    sampling_number_of_lattices = 1000
+  }
+  resolution {
+    d_min = None
+    model_or_image = model image
+  }
+  unit_cell {
+    algorithm = range *value cluster
+    value {
+      target_unit_cell = Auto
+      relative_length_tolerance = 0.1
+      absolute_angle_tolerance = 2.
+      target_space_group = Auto
+    }
+    cluster {
+      algorithm = rodgriguez_laio dbscan *covariance
+      covariance {
+        file = None
+        component = 0
+        skip_component = None
+        mahalanobis = 4.0
+        skip_mahalanobis = 4.0
+      }
+      isoform = None
+    }
+  }
+  outlier {
+    mad_thresh = None
+    min_corr = 0.1
+    assmann_diederichs {
+    }
+  }
+}
+modify {
+  algorithm = *polarization
+  reindex_to_reference {
+    dataframe = None
+  }
+  cosym {
+    partiality_threshold = 0.4
+    unit_cell_clustering {
+      threshold = 5000
+      log = False
+    }
+    reference_model {
+    }
+    normalisation = kernel quasi *ml_iso ml_aniso
+    d_min = Auto
+    min_i_mean_over_sigma_mean = 4
+    min_cc_half = 0.6
+    lattice_group = None
+    space_group = None
+    lattice_symmetry_max_delta = 5.0
+    best_monoclinic_beta = True
+    dimensions = Auto
+    use_curvatures = False
+    weights = count standard_error
+    cc_weights = None sigma
+    min_pairs = 3
+    minimization {
+      engine = *scitbx scipy
+      max_iterations = 100
+      max_calls = None
+    }
+    nproc = Auto
+    relative_length_tolerance = 0.05
+    absolute_angle_tolerance = 2
+    min_reflections = 10
+    seed = 230
+    output {
+      suffix = "_reindexed"
+      log = dials.cosym.log
+      experiments = "symmetrized.expt"
+      reflections = "symmetrized.refl"
+      json = dials.cosym.json
+      html = dials.cosym.html
+    }
+    dataframe = None
+    anchor = False
+    tranch_size = 600
+    twin_axis = None
+    twin_rotation = None
+    single_cb_op_to_minimum = False
+    voting_method = *consensus majority
+    plot {
+      do_plot = True
+      n_max = 1
+      interactive = False
+      format = *png pdf
+      filename = cosym_embedding
+    }
+  }
+  reindex_to_abc {
+    change_of_basis_op = a,b,c
+    hkl_offset = None
+    space_group = None
+    reference {
+      experiments = None
+      reflections = None
+      reference_model {
+      }
+    }
+    output {
+      experiments = reindexed.expt
+      reflections = reindexed.refl
+      log = dials.reindex.log
+    }
+  }
+}
+select {
+  algorithm = panel cspad_sensor significance_filter
+  cspad_sensor {
+    number = None
+    operation = *deselect select
+  }
+  significance_filter {
+    n_bins = 12
+    min_ct = 10
+    max_ct = 50
+    sigma = 0.5
+  }
+}
+scaling {
+  model = None
+  unit_cell = None
+  space_group = None
+  model_reindex_op = h,k,l
+  resolution_scalar = 0.969
+  mtz {
+    mtz_column_F = fobs
+    minimum_common_hkls = -1
+  }
+  pdb {
+    include_bulk_solvent = True
+    k_sol = 0.35
+    b_sol = 46.00
+    solvent_algorithm = *mosaic flat
+  }
+  algorithm = *mark0 mark1
+  weights = *unit icalc icalc_sigma
+}
+postrefinement {
+  partiality_threshold_hcfix = 0.2
+  rs {
+    fix = thetax thetay *RS G BFACTOR
+  }
+  rs2 {
+  }
+  rs_hybrid {
+    partiality_threshold = 0.2
+  }
+  target_weighting = *unit variance gentle extreme
+  merge_weighting = *variance
+  merge_partiality_exponent = 0
+  lineshape = *lorentzian gaussian
+  show_trumpet_plot = False
+  delta_corr_limit = 0.1
+}
+merging {
+  minimum_multiplicity = 2
+  error {
+    model = ha14 *ev11 mm24 errors_from_sample_residuals
+    ev11 {
+      minimizer = *lbfgs LevMar
+      refine_propagated_errors = False
+      show_finite_differences = False
+      plot_refinement_steps = False
+    }
+    mm24 {
+      expected_gain = None
+      number_of_intensity_bins = 100
+      n_degrees = 2
+      tuning_param = 10
+      n_max_differences = 100
+      random_seed = 50298
+      tuning_param_opt = False
+      likelihood = normal *t-dist
+      cc_after_pr = True
+      do_diagnostics = False
+    }
+  }
+  plot_single_index_histograms = False
+  set_average_unit_cell = True
+  d_min = None
+  d_max = None
+  merge_anomalous = False
+  include_multiplicity_column = False
+}
+output {
+  expanded_bookkeeping = False
+  prefix = iobs
+  title = None
+  output_dir = .
+  tmp_dir = None
+  do_timing = False
+  log_level = 1
+  save_experiments_and_reflections = False
+}
+statistics {
+  shuffle_ids = False
+  n_bins = 10
+  cc1_2 {
+    hash_filenames = False
+  }
+  cciso {
+    mtz_file = None
+    mtz_column_F = fobs
+  }
+  predictions_to_edge {
+    apply = False
+    image = None
+    detector_phil = None
+  }
+  report_ML = True
+  uc_precision = 2
+}
+parallel {
+}
+lunus {
+  deck_file = None
+}
+publish {
+  drive {
+    credential_file = None
+    shared_folder_id = None
+  }
+  input {
+    mtz_file = None
+    disregard_mtz = False
+    log_file = None
+    other_files = None
+    dataset_root = None
+    version = None
+    guess_root_and_version = True
+  }
+}
+diffBragg {
+  simulator {
+    oversample = 0
+    device_id = 0
+    init_scale = 1
+    total_flux = 1e12
+    crystal {
+      ncells_abc = (10,10,10)
+      ncells_def = (0,0,0)
+      has_isotropic_ncells = False
+      has_isotropic_mosaicity = False
+      mosaicity = 0
+      anisotropic_mosaicity = None
+      num_mosaicity_samples = 1
+      mos_angles_per_axis = 10
+      num_mos_axes = 10
+      mosaicity_method = 2
+      rotXYZ_ucell = None
+    }
+    gonio {
+      delta_phi = None
+      phi_steps = 50
+    }
+    structure_factors {
+      from_pdb {
+        name = None
+        add_anom = True
+        k_sol = None
+        b_sol = None
+      }
+      mtz_name = None
+      mtz_column = None
+      dmin = 1
+      dmax = None
+      default_F = 0
+    }
+    spectrum {
+      filename = None
+      stride = 1
+      filename_list = None
+      gauss_spec {
+        fwhm = 10
+        nchannels = 20
+        res = 1
+      }
+    }
+    beam {
+      size_mm = 1
+    }
+    detector {
+      thick = None
+      atten = None
+      force_zero_thickness = False
+      thicksteps = 1
+    }
+    psf {
+      use = False
+      fwhm = 100
+      radius = 7
+    }
+  }
+  refiner {
+    check_expt_format = True
+    refldata_trusted = *allValid fg bg
+    refldata_to_photons = False
+    load_data_from_refl = False
+    test_gathered_file = False
+    gather_dir = None
+    break_signal = None
+    debug_pixel_panelfastslow = None
+    gain_map_min_max = [.5,2]
+    refine_gain_map = False
+    save_gain_freq = 10
+    region_size = [50,50]
+    res_ranges = None
+    force_symbol = None
+    force_unit_cell = None
+    num_devices = 1
+    refine_Fcell = None
+    refine_spot_scale = None
+    refine_Nabc = False
+    gain_restraint = None
+    max_calls = [100]
+    panel_group_file = None
+    update_oversample_during_refinement = False
+    sigma_r = 3
+    adu_per_photon = 1
+    use_curvatures_threshold = 10
+    curvatures = False
+    start_with_curvatures = False
+    tradeps = 1e-2
+    io {
+      restart_file = None
+      output_dir = None
+    }
+    quiet = False
+    verbose = 0
+    num_macro_cycles = 1
+    ncells_mask = *000 110 101 011 111
+    reference_geom = None
+    stage_two {
+      use_nominal_hkl = True
+      save_model_freq = 50
+      save_Z_freq = 25
+      min_multiplicity = 1
+      Fref_mtzname = None
+      Fref_mtzcol = "Famp(+),Famp(-)"
+      d_min = 2
+      d_max = 999
+      n_bin = 10
+    }
+  }
+  roi {
+    centroid = *obs cal
+    trusted_range = None
+    mask_all_if_any_outside_trusted_range = True
+    mask_outside_trusted_range = False
+    only_filter_zingers_above_mean = True
+    cache_dir_only = False
+    fit_tilt = False
+    force_negative_background_to_zero = False
+    background_threshold = 3.5
+    pad_shoebox_for_background_estimation = None
+    shoebox_size = 10
+    deltaQ = None
+    reject_edge_reflections = True
+    reject_roi_with_hotpix = True
+    hotpixel_mask = None
+    panels = None
+    fit_tilt_using_weights = False
+    allow_overlapping_spots = False
+    skip_roi_with_negative_bg = True
+  }
+  geometry {
+    save_state_freq = 50
+    save_state_overwrite = True
+    pandas_dir = None
+    optimized_results_tag = None
+    refls_key = stage1_refls
+    optimize_method = *lbfgsb nelder
+    input_pkl = None
+    input_pkl_glob = None
+    optimize = False
+    save_optimized_det_freq = 1
+    optimized_detector_name = "diffBragg_detector.expt"
+    min {
+      panel_rotations = -1,-1,-1
+      panel_translations = -1,-1,-1
+    }
+    max {
+      panel_rotations = 1,1,1
+      panel_translations = 1,1,1
+    }
+    center {
+      panel_rotations = 0,0,0
+      panel_translations = 0,0,0
+    }
+    betas {
+      panel_rot = 1e6,1e6,1e6
+      panel_xyz = 1e6,1e6,1e6
+      close_distances = None
+    }
+    fix {
+      panel_rotations = 0,0,0
+      panel_translations = 0,0,0
+    }
+  }
+  predictions {
+    use_peak_detection = False
+    verbose = False
+    laue_mode = False
+    qcut = 0.1
+    label_weak_col = "xyzobs.px.value"
+    weak_fraction = 0.5
+    threshold = 1e-3
+    thicksteps_override = None
+    use_diffBragg_mtz = False
+    pink_stride_override = None
+    default_Famplitude = 1e3
+    resolution_range = [1,999]
+    symbol_override = None
+    method = *diffbragg exascale
+  }
+}
+monitor {
+  detail = *rank node rank0 none
+  period = 5.0
+  plot = True
+  prefix = monitor
+  write = True
+}

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -189,9 +189,11 @@ IndexCCTBXXFEL:
   # Begin template parameters for .phil file
   # Comment out to avoid re-writing .phil
   phil_parameters:
-    output_output_dir: "..."
+    #input_reference_geometry: ""
+    #geometry_detector_panel_origin: [0, 0, 0]
+    #output_output_dir: "..."
     output_composite_output: true
-    output_logging_dir: "..."
+    #output_logging_dir: "..."
     dispatch_index: true
     dispatch_refine: true
     dispatch_integrate: true
@@ -200,17 +202,17 @@ IndexCCTBXXFEL:
     spotfinder_threshold_dispersion_sigma_bkgnd: 2
     spotfinder_threshold_dispersion_sigma_strong: 2
     spotfinder_threshold_dispersion_global_thresh: 10
-    spotfinder_threshold_dispersion_kernel_size: "6 6"
+    spotfinder_threshold_dispersion_kernel_size: [6, 6]
     spotfinder_filter_min_spot_size: 3
     spotfinder_filter_d_min: 3
     indexing_stills_refine_candidates_with_known_symmetry: true
     indexing_stills_refine_all_candidates: false
-    indexing_known_symmetry_space_group: "..."
-    indexing_known_symmetry_unit_cell: "..."
+    #indexing_known_symmetry_space_group: "P 41 21 2"
+    #indexing_known_symmetry_unit_cell: "140 140 140 90 90 90"
     integration_background_simple_outlier_plane_n_sigma: 10
     integration_summation_detector_gain: 1.0
     profile_gaussian_rs_centroid_definition: "com"
-    refinement_reflections_outlier_algorithm: "..."
+    #refinement_reflections_outlier_algorithm: "..."
 
 MergePartialator:
   #in_file: ""

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -172,12 +172,77 @@ IndexCrystFEL:
   profile: True
   no_revalidate: True
 
+IndexCCTBXXFEL:
+  #phil_file: ...
+  # Begin template parameters for .phil file
+  # Comment out to avoid re-writing .phil
+  phil_parameters:
+    output_output_dir: "..."
+    output_composite_output: true
+    output_logging_dir: "..."
+    dispatch_index: true
+    dispatch_refine: true
+    dispatch_integrate: true
+    mp_mpi_method: "mpi" # "*multiprocessing sge lsf pbs mpi"
+    spotfinder_threshold_dispersion_gain: 1.6
+    spotfinder_threshold_dispersion_sigma_bkgnd: 2
+    spotfinder_threshold_dispersion_sigma_strong: 2
+    spotfinder_threshold_dispersion_global_thresh: 10
+    spotfinder_threshold_dispersion_kernel_size: 6
+    spotfinder_filter_min_spot_size: 3
+    spotfinder_filter_d_min: 3
+    indexing_stills_refine_candidates_with_known_symmetry: true
+    indexing_stills_refine_all_candidates: false
+    indexing_stills_nv_reject_outliers: false
+    indexing_known_symmetry_space_group: "..."
+    indexing_known_symmetry_unit_cell: "..."
+    integration_background_simple_outlier_plane_n_sigma: 10
+    integration_summation_detector_gain: 1.0
+    profile_gaussian_rs_centroid_definition: "com"
+    refinement_reflections_outlier_algorithm: "..."
+
 MergePartialator:
   #in_file: ""
   #out_file: ""
   #model: "unity"
   #niter: 1
   symmetry: "mmm"
+
+MergeCCTBXXFEL:
+  #phil_file: ...
+  # Begin template parameters for .phil file
+  # Comment out to avoid re-writing .phil
+  phil_parameters:
+    input_path: "path/to/input"
+    input_experiments_suffix: "_integrated.expt"
+    input_reflections_suffix: "_integrated.refl"
+    input_parallel_file_load_method: "uniform"
+    filter_algorithm: "unit_cell"
+    filter_unit_cell_algorithm: "cluster"
+    filter_unit_cell_cluster_covariance_file: "..."
+    filter_unit_cell_cluster_covariance_component: 0
+    filter_unit_cell_cluster_covariance_mahalanobis: 5.0
+    filter_outlier_min_corr: -1.0
+    select_algorithm: "significance_filter"
+    select_significance_filter_sigma: 0.1
+    scaling_model: ""
+    scaling_resolution_scalar: 0.993420862158964
+    postrefinement_enable: true
+    postrefinement_algorithm: "rs"
+    merging_d_min: 3
+    merging_merge_anomalous: false
+    merging_set_average_unit_cell: true
+    merging_error_model: "ev11"
+    statistics_n_bins: 20
+    statistics_report_ML: true
+    statistics_cciso_mtz_file: ""
+    statistics_cciso_mtz_column_F: "F" # "fobs"
+    output_prefix: ""
+    output_output_dir: ""
+    output_tmp_dir: ""
+    output_do_timing: true
+    output_log_level: true
+    parallel_a2a: 1
 
 CompareHKL:
   #in_files: ""

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -174,6 +174,18 @@ IndexCrystFEL:
 
 IndexCCTBXXFEL:
   #phil_file: ...
+  #in_file: ...
+  # Comment out data_spec if providing one
+  # Make sure in_file is appropriately set in that case.
+  data_spec:
+    experiment: "{{ experiment }}"
+    run: "{{ run }}"
+    detector_address: "Rayonix"
+    wavelength_offset: -0.004414643434400234
+    spectrum_eV_per_pixel: 0.07523816551020232
+    spectrum_eV_offset: 9723.778479641995
+    rayonix.bin_size: 4
+
   # Begin template parameters for .phil file
   # Comment out to avoid re-writing .phil
   phil_parameters:
@@ -188,12 +200,11 @@ IndexCCTBXXFEL:
     spotfinder_threshold_dispersion_sigma_bkgnd: 2
     spotfinder_threshold_dispersion_sigma_strong: 2
     spotfinder_threshold_dispersion_global_thresh: 10
-    spotfinder_threshold_dispersion_kernel_size: 6
+    spotfinder_threshold_dispersion_kernel_size: "6 6"
     spotfinder_filter_min_spot_size: 3
     spotfinder_filter_d_min: 3
     indexing_stills_refine_candidates_with_known_symmetry: true
     indexing_stills_refine_all_candidates: false
-    indexing_stills_nv_reject_outliers: false
     indexing_known_symmetry_space_group: "..."
     indexing_known_symmetry_unit_cell: "..."
     integration_background_simple_outlier_plane_n_sigma: 10

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -448,10 +448,25 @@ class BaseExecutor(ABC):
             # Iterate parameters to find the one that is the result
             schema: Dict[str, Any] = self._analysis_desc.task_parameters.schema()
             for param, value in self._analysis_desc.task_parameters.dict().items():
+                param_attrs: Dict[str, Any]
                 if isinstance(value, TemplateParameters):
                     # Extract TemplateParameters if needed
                     value = value.params
-                param_attrs: Dict[str, Any] = schema["properties"][param]
+                    extra_models: List[str] = schema["definitions"].keys()
+                    for model in extra_models:
+                        if model in ("AnalysisHeader", "TemplateConfig"):
+                            continue
+                        if param in schema["definitions"][model]["properties"]:
+                            param_attrs = schema["definitions"][model]["properties"][
+                                param
+                            ]
+                            break
+                    else:
+                        param_attrs = self._analysis_desc.task_parameters._unknown_template_params[
+                            param
+                        ]
+                else:
+                    param_attrs = schema["properties"][param]
                 if "is_result" in param_attrs:
                     is_result: bool = param_attrs["is_result"]
                     if isinstance(is_result, bool) and is_result:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -241,8 +241,6 @@ class BaseExecutor(ABC):
         new_environment: Dict[str, str] = {}
         for key, value in tmp_environment.items():
             new_environment[f"LUTE_TENV_{key}"] = value
-            if key == "PATH":
-                new_environment[key] = value
         self._analysis_desc.task_env = new_environment
 
     def _pre_task(self) -> None:
@@ -462,9 +460,16 @@ class BaseExecutor(ABC):
                             ]
                             break
                     else:
-                        param_attrs = self._analysis_desc.task_parameters._unknown_template_params[
-                            param
-                        ]
+                        if isinstance(
+                            self._analysis_desc.task_parameters, ThirdPartyParameters
+                        ):
+                            param_attrs = self._analysis_desc.task_parameters._unknown_template_params[
+                                param
+                            ]
+                        else:
+                            raise ValueError(
+                                f"No parameter schema for {param}. Check model!"
+                            )
                 else:
                     param_attrs = schema["properties"][param]
                 if "is_result" in param_attrs:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -39,12 +39,12 @@ from abc import ABC, abstractmethod
 import warnings
 import copy
 
-from .ipc import *
-from ..tasks.task import *
-from ..tasks.dataclasses import *
-from ..io.models.base import TaskParameters
-from ..io.db import record_analysis_db
-from ..io.elog import post_elog_run_status
+from lute.execution.ipc import *
+from lute.tasks.task import *
+from lute.tasks.dataclasses import *
+from lute.io.models.base import TaskParameters, TemplateParameters
+from lute.io.db import record_analysis_db
+from lute.io.elog import post_elog_run_status
 
 if __debug__:
     warnings.simplefilter("default")
@@ -437,6 +437,9 @@ class BaseExecutor(ABC):
             # Iterate parameters to find the one that is the result
             schema: Dict[str, Any] = self._analysis_desc.task_parameters.schema()
             for param, value in self._analysis_desc.task_parameters.dict().items():
+                if isinstance(value, TemplateParameters):
+                    # Extract TemplateParameters if needed
+                    value = value.params
                 param_attrs: Dict[str, Any] = schema["properties"][param]
                 if "is_result" in param_attrs:
                     is_result: bool = param_attrs["is_result"]

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -241,6 +241,8 @@ class BaseExecutor(ABC):
         new_environment: Dict[str, str] = {}
         for key, value in tmp_environment.items():
             new_environment[f"LUTE_TENV_{key}"] = value
+            if key == "PATH":
+                new_environment[key] = value
         self._analysis_desc.task_env = new_environment
 
     def _pre_task(self) -> None:

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -134,6 +134,10 @@ def substitute_variables(
                 if key_to_sub[0] == "$":
                     sub = os.getenv(key_to_sub[1:], None)
                     if sub is None:
+                        # Check if we use a different env - substitution happens
+                        # before environment reset
+                        sub = os.getenv(f"LUTE_TENV_{key_to_sub[1:]}")
+                    if sub is None:
                         print(
                             f"Environment variable {key_to_sub[1:]} not found! Cannot substitute in YAML config!",
                             flush=True,

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -52,7 +52,7 @@ def _cfg_to_exec_entry_cols(
     selected_env_vars: Dict[str, str] = {
         key: cfg.task_env[key]
         for key in cfg.task_env
-        if "LUTE_" in key or "SLURM_" in key
+        if ("LUTE_" in key and "_TENV_" not in key) or "SLURM_" in key
     }
     entry: Dict[str, Any] = {
         "env": ";".join(f"{key}={value}" for key, value in selected_env_vars.items()),

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -36,8 +36,10 @@ from pydantic import (
     Field,
     root_validator,
     validator,
+    PrivateAttr,
 )
 from pydantic.dataclasses import dataclass
+from pydantic.schema import model_schema, default_ref_template
 
 
 class AnalysisHeader(BaseModel):
@@ -281,15 +283,35 @@ class ThirdPartyParameters(TaskParameters):
         set_result: bool = True
         """Whether the Executor should mark a specified parameter as a result."""
 
+    _unknown_template_params: Dict[str, Any] = PrivateAttr()
     # lute_template_cfg: TemplateConfig
 
     @root_validator(pre=False)
     def extra_fields_to_thirdparty(cls, values: Dict[str, Any]):
+        cls._unknown_template_params = {}
+        my_schema: Dict[str, Any] = model_schema(
+            cls, by_alias=True, ref_template=default_ref_template
+        )
+        param_schema_template: Dict[str, Any] = {
+            "title": "",
+            "description": "Unknown template parameters.",
+            "type": "object",
+            "properties": {
+                "params": "",
+                "type": "object",
+            },
+        }
+        new_values: Dict[str, Any] = {}
         for key in values:
             if key not in cls.__fields__:
-                values[key] = TemplateParameters(values[key])
-
-        return values
+                new_values[key] = TemplateParameters(values[key])
+                param_schema: Dict[str, Any] = param_schema_template.copy()
+                param_schema["title"] = key
+                param_schema["properties"]["params"] = values[key]
+                cls._unknown_template_params[key] = param_schema
+            else:
+                new_values[key] = values[key]
+        return new_values
 
 
 class TemplateConfig(BaseModel):

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -79,6 +79,7 @@ class AnalysisHeader(BaseModel):
         if not os.access(work_dir, os.W_OK):
             # Need write access for database, files etc.
             raise ValueError(f"Not write access for working directory: {work_dir}!")
+        os.environ["LUTE_WORK_DIR"] = work_dir
         return work_dir
 
     @validator("run", always=True)

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -534,7 +534,7 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
             ),
         )
         output_logging_dir: str = Field(
-            ".", description="Directory output log files will be placed"
+            "", description="Directory output log files will be placed"
         )
 
         # Dispatch settings: dispatch_
@@ -596,8 +596,8 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
                 "this value to be part of the background."
             ),
         )
-        spotfinder_threshold_dispersion_kernel_size: str = Field(
-            "6 6",
+        spotfinder_threshold_dispersion_kernel_size: Tuple[int, int] = Field(
+            (6, 6),
             description=(
                 "The size of the local area around the spot in which to "
                 "calculate the mean and variance. The kernel is given as a box "

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -26,10 +26,10 @@ from pydantic import (
     conint,
     validator,
 )
-from pydantic.schema import model_schema, default_ref_template  # Update `schema` method
 
-from ..db import read_latest_db_entry
-from .base import ThirdPartyParameters, TaskParameters, TemplateConfig
+from lute.io.db import read_latest_db_entry
+from lute.io.models.base import ThirdPartyParameters, TaskParameters, TemplateConfig
+from lute.io.models.validators import template_parameter_validator
 
 
 class IndexCrystFELParameters(ThirdPartyParameters):
@@ -571,6 +571,8 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
                 return values["output_output_dir"]
             return output
 
+    _set_phil_template_parameters = template_parameter_validator("phil_parameters")
+
     executable: str = Field(
         "/sdf/group/lcls/ds/tools/cctbx/conda_base/bin/mpirun",
         description="MPI executable.",
@@ -627,17 +629,6 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
             lute_template_cfg.output_path = values["phil_file"]
         return lute_template_cfg
 
-    @validator("phil_parameters", always=True)
-    def set_phil_template_parameters(
-        cls, phil_params: PhilParameters, values: Dict[str, Any]
-    ) -> None:
-        if phil_params is not None:
-            # Add as template parameters, i.e. add to __dict__ but not __fields__
-            # Schema information is updated by class method `schema`
-            for param, value in phil_params:
-                values[param] = value
-        return None
-
     @validator("in_files", always=True)
     def set_in_file(cls, in_file: str, values: Dict[str, Any]) -> str:
         if in_file == "":
@@ -659,36 +650,3 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
                     spec_line: str = f"{key}={value}\n"
                     f.write(spec_line)
         return None
-
-    @classmethod
-    def schema(
-        cls, by_alias: bool = True, ref_template: str = default_ref_template
-    ) -> Dict[str, Any]:
-        """Overload the base-class schema.
-
-        This class method is provided to overload the schema method provided by the
-        base class. We update a portion of the model schema with the schema
-        information of our model for this class' TemplateParameters. The schema
-        is used to access information about command-line arguments (flag_type) or
-        for understanding if a specific parameter is a result. Since
-        TemplateParameters are added after the fact, they are not present as fields
-        in the model and normally do not have any schema information.
-
-        This mechanism is only needed because this model is designed to provide
-        type checking of template parameters.
-        """
-        cached: Optional[Dict[str, Any]] = cls.__schema_cache__.get(
-            (by_alias, ref_template)
-        )
-        if cached is not None:
-            return cached
-        my_schema: Dict[str, Any] = model_schema(
-            cls, by_alias=by_alias, ref_template=ref_template
-        )
-        # Next two lines are the only difference vs base-class
-        template_schema: Dict[str, Any] = model_schema(
-            cls.PhilParameters, by_alias=by_alias, ref_template=ref_template
-        )
-        my_schema["properties"].update(template_schema["properties"])
-        cls.__schema_cache__[(by_alias, ref_template)] = my_schema
-        return my_schema

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -26,6 +26,7 @@ from pydantic import (
     conint,
     validator,
 )
+from pydantic.schema import model_schema, default_ref_template  # Update `schema` method
 
 from ..db import read_latest_db_entry
 from .base import ThirdPartyParameters, TaskParameters, TemplateConfig
@@ -542,6 +543,41 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
     def set_phil_template_parameters(
         cls, phil_params: PhilParameters, values: Dict[str, Any]
     ) -> None:
-        if phil_params is not None:
-            ...
+        for param, value in phil_params:
+            # Add as template parameters, i.e. add to __dict__ but not __fields__
+            # Schema information is updated by class method `schema`
+            values[param] = value
         return None
+
+    @classmethod
+    def schema(
+        cls, by_alias: bool = True, ref_template: str = default_ref_template
+    ) -> Dict[str, Any]:
+        """Overload the base-class schema.
+
+        This class method is provided to overload the schema method provided by the
+        base class. We update a portion of the model schema with the schema
+        information of our model for this class' TemplateParameters. The schema
+        is used to access information about command-line arguments (flag_type) or
+        for understanding if a specific parameter is a result. Since
+        TemplateParameters are added after the fact, they are not present as fields
+        in the model and normally do not have any schema information.
+
+        This mechanism is only needed because this model is designed to provide
+        type checking of template parameters.
+        """
+        cached: Optional[Dict[str, Any]] = cls.__schema_cache__.get(
+            (by_alias, ref_template)
+        )
+        if cached is not None:
+            return cached
+        my_schema: Dict[str, Any] = model_schema(
+            cls, by_alias=by_alias, ref_template=ref_template
+        )
+        # Next two lines are the only difference vs base-class
+        template_schema: Dict[str, Any] = model_schema(
+            cls.PhilParameters, by_alias=by_alias, ref_template=ref_template
+        )
+        my_schema["properties"].update(template_schema["properties"])
+        cls.__schema_cache__[(by_alias, ref_template)] = my_schema
+        return my_schema

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -512,6 +512,11 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
         description="Location of the input settings ('phil') file.",
         flag_type="",
     )
+    in_file: str = Field(
+        "",
+        description="Input file or glob of files.",
+        flag_type="",
+    )
     phil_parameters: Optional[PhilParameters] = Field(
         None,
         description="Optional template parameters to fill in a CCTBX phil file.",

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -579,7 +579,7 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
         flag_type="",
     )
     cctbx_executable: str = Field(
-        "/sdf/group/lcls/ds/tools/cctbx/build/bin/cctbx.xfel.process",
+        "/sdf/group/lcls/ds/tools/cctbx/build/bin/dials.stills_process",
         description="CCTBX indexing program (DIALS).",
         flag_type="",
     )
@@ -629,7 +629,7 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
             lute_template_cfg.output_path = values["phil_file"]
         return lute_template_cfg
 
-    @validator("in_files", always=True)
+    @validator("in_file", always=True)
     def set_in_file(cls, in_file: str, values: Dict[str, Any]) -> str:
         if in_file == "":
             exp: str = values["lute_config"].experiment

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -524,8 +524,14 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
         description="Template information for the cctbx_index file.",
     )
 
+    @validator("phil_file", always=True)
+    def set_default_phil_path(cls, phil_file: str, values: Dict[str, Any]) -> str:
+        if phil_file == "":
+            return f"{values['lute_config'].work_dir}/cctbx_index.phil"
+        return phil_file
+
     @validator("lute_template_cfg", always=True)
-    def set_phil_path(
+    def set_phil_template_path(
         cls, lute_template_cfg: TemplateConfig, values: Dict[str, Any]
     ) -> TemplateConfig:
         if lute_template_cfg.output_path == "":

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -494,11 +494,14 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
     """Parameters for indexing with cctbx.xfel."""
 
     class Config(ThirdPartyParameters.Config):
-        set_result: bool = True
+        set_result: bool = False
         """Whether the Executor should mark a specified parameter as a result."""
 
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
+
+        class Config(BaseModel.Config):
+            extra: str = "allow"
 
         # Generic output settings: output_
         output_output_dir: str = Field(

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -500,7 +500,62 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
-        ...
+        # Generic output settings: output_
+        output_output_dir: str = Field(
+            "",
+            description="Where to put output.",
+        )
+        output_composite_output: bool = Field(True, description="")
+        output_logging_dir: str = Field(".", description="")
+
+        # Dispatch settings: dispatch_
+        dispatch_index: bool = Field(True, description="Perform indexing?")
+        dispatch_refine: bool = Field(True, description="Perform refinement?")
+        dispatch_integrate: bool = Field(True, description="Perform integration?")
+
+        # Parallel processing parameters: mp_
+        mp_mpi_method: str = Field(
+            "mpi",  # *multiprocessing sge lsf pbs mpi
+            description="",
+        )
+
+        # Spotfinding parameters: spotfinder_
+        spotfinder_threshold_dispersion_gain: float = Field(1.6, description="")
+        spotfinder_threshold_dispersion_sigma_bkgnd: int = Field(2, description="")
+        spotfinder_threshold_dispersion_sigma_strong: int = Field(2, description="")
+        spotfinder_threshold_dispersion_global_thresh: int = Field(10, description="")
+        spotfinder_threshold_dispersion_kernel_size: int = Field(6, description="")
+        spotfinder_filter_min_spot_size: int = Field(3, description="")
+        spotfinder_filter_d_min: int = Field(
+            3, description=""
+        )  # What's a good default?
+
+        # Indexing parameters: indexing_
+        indexing_stills_refine_candidates_with_known_symmetry: bool = Field(
+            True, description=""
+        )
+        indexing_stills_refine_all_candidates: bool = Field(False, description="")
+        indexing_stills_nv_reject_outliers: bool = Field(False, description="")
+        indexing_known_symmetry_space_group: Optional[str] = Field(
+            None, description="Space group."
+        )
+        indexing_known_symmetry_unit_cell: Optional[str] = Field(
+            None, description="Unit cell."
+        )
+
+        # Integration parameters: integration_
+        integration_background_simple_outlier_plane_n_sigma: int = Field(
+            10, description=""
+        )
+        integration_summation_detector_gain: float = Field(1.0, description="")
+
+        # Profiling parameters: profile_
+        profile_gaussian_rs_centroid_definition: str = Field("com", description="")
+
+        # Refinement options: refinement_
+        refinement_reflections_outlier_algorithm: Optional[str] = Field(
+            None, description=""
+        )
 
     executable: str = Field(
         "/sdf/group/lcls/ds/tools/cctbx/build/bin/dials.stills_process",

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -14,7 +14,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Tuple
 
 from pydantic import (
     BaseModel,
@@ -503,60 +503,178 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
         class Config(BaseModel.Config):
             extra: str = "allow"
 
+        # Generic input settings: input_
+        input_reference_geometry: Optional[str] = Field(
+            None,
+            description=(
+                "Provide an models.expt file with exactly one detector model. Data "
+                "processing will use that geometry instead of the geometry found "
+                "in the image headers."
+            ),
+        )
+
+        # Generic geometry: geometry_
+        geometry_detector_panel_origin: Optional[Tuple[float, float, float]] = Field(
+            None,
+            description="Override the panel origin. Requires fast_axis and slow_axis.",
+        )
+
         # Generic output settings: output_
         output_output_dir: str = Field(
             "",
-            description="Where to put output.",
+            description="Directory output files will be placed",
         )
-        output_composite_output: bool = Field(True, description="")
-        output_logging_dir: str = Field(".", description="")
+        output_composite_output: bool = Field(
+            True,
+            description=(
+                "If True, save one set of experiment/reflection files per process, "
+                "where each is a concatenated list of all the successful events "
+                "examined by that process. If False, output a separate "
+                "experiment/reflection file per image (generates a lot of files)."
+            ),
+        )
+        output_logging_dir: str = Field(
+            ".", description="Directory output log files will be placed"
+        )
 
         # Dispatch settings: dispatch_
-        dispatch_index: bool = Field(True, description="Perform indexing?")
-        dispatch_refine: bool = Field(True, description="Perform refinement?")
-        dispatch_integrate: bool = Field(True, description="Perform integration?")
+        dispatch_index: bool = Field(
+            True,
+            description=(
+                "Attempt to index images. find_spots also needs to be True for "
+                "this to work"
+            ),
+        )
+        dispatch_refine: bool = Field(
+            False, description="If True, after indexing, refine the experimental models"
+        )
+        dispatch_integrate: bool = Field(
+            True,
+            description=(
+                "Integrate indexed images. Ignored if index=False or "
+                "find_spots=False"
+            ),
+        )
 
         # Parallel processing parameters: mp_
-        mp_mpi_method: str = Field(
+        mp_method: str = Field(
             "mpi",  # *multiprocessing sge lsf pbs mpi
-            description="",
+            description="The multiprocessing method to use",
         )
 
         # Spotfinding parameters: spotfinder_
-        spotfinder_threshold_dispersion_gain: float = Field(1.6, description="")
-        spotfinder_threshold_dispersion_sigma_bkgnd: int = Field(2, description="")
-        spotfinder_threshold_dispersion_sigma_strong: int = Field(2, description="")
-        spotfinder_threshold_dispersion_global_thresh: int = Field(10, description="")
-        spotfinder_threshold_dispersion_kernel_size: str = Field("6 6", description="")
-        spotfinder_filter_min_spot_size: int = Field(3, description="")
-        spotfinder_filter_d_min: int = Field(
-            3, description=""
-        )  # What's a good default?
+        spotfinder_lookup_mask: Optional[str] = Field(
+            None, description="The path to the mask file."
+        )
+        spotfinder_threshold_dispersion_gain: Optional[float] = Field(
+            None,
+            description=(
+                "Use a flat gain map for the entire detector to act as a "
+                "multiplier for the gain set by the format. Cannot be used in "
+                "conjunction with lookup.gain_map parameter."
+            ),
+        )
+        spotfinder_threshold_dispersion_sigma_bkgnd: float = Field(
+            6,
+            description=(
+                "The number of standard deviations of the index of dispersion "
+                "(variance / mean) in the local area below which the pixel "
+                "will be classified as background."
+            ),
+        )
+        spotfinder_threshold_dispersion_sigma_strong: float = Field(
+            3,
+            description=(
+                "The number of standard deviations above the mean in the local "
+                "area above which the pixel will be classified as strong."
+            ),
+        )
+        spotfinder_threshold_dispersion_global_threshold: float = Field(
+            0,
+            description=(
+                "The global threshold value. Consider all pixels less than "
+                "this value to be part of the background."
+            ),
+        )
+        spotfinder_threshold_dispersion_kernel_size: str = Field(
+            "6 6",
+            description=(
+                "The size of the local area around the spot in which to "
+                "calculate the mean and variance. The kernel is given as a box "
+                "of size (2 * nx + 1, 2 * ny + 1) centred at the pixel."
+            ),
+        )
+        spotfinder_filter_min_spot_size: Optional[int] = Field(
+            3,
+            description=(
+                "The minimum number of contiguous pixels for a spot to be "
+                "accepted by the filtering algorithm."
+            ),
+        )
+        spotfinder_filter_d_min: Optional[float] = Field(
+            None,
+            description=(
+                "The high resolution limit in Angstrom for a pixel to be "
+                "accepted by the filtering algorithm."
+            ),
+        )
 
         # Indexing parameters: indexing_
         indexing_stills_refine_candidates_with_known_symmetry: bool = Field(
-            True, description=""
+            False,
+            description=(
+                "If False, when choosing the best set of candidate basis "
+                "solutions, refine the candidates in the P1 setting. If True, "
+                "after indexing in P1, convert the candidates to the known "
+                "symmetry and apply the corresponding change of basis to the "
+                "indexed reflections."
+            ),
         )
-        indexing_stills_refine_all_candidates: bool = Field(False, description="")
+        indexing_stills_refine_all_candidates: bool = Field(
+            True,
+            description=(
+                "If False, no attempt is made to refine the model from initial "
+                "basis vector selection. The indexing solution with the best "
+                "RMSD is chosen."
+            ),
+        )
         indexing_known_symmetry_space_group: Optional[str] = Field(
-            None, description="Space group."
+            None, description="Target space group for indexing."
         )
         indexing_known_symmetry_unit_cell: Optional[str] = Field(
-            None, description="Unit cell."
+            None, description="Target unit cell for indexing."
         )
 
         # Integration parameters: integration_
         integration_background_simple_outlier_plane_n_sigma: int = Field(
-            10, description=""
+            10,
+            description=(
+                "The number of standard deviations above the threshold "
+                "plane to use in rejecting outliers from background "
+                "calculation."
+            ),
         )
-        integration_summation_detector_gain: float = Field(1.0, description="")
+        integration_summation_detector_gain: float = Field(
+            1.0,
+            description=(
+                "Multiplier for variances after integration of still images. See "
+                "Leslie 1999."
+            ),
+        )
 
         # Profiling parameters: profile_
-        profile_gaussian_rs_centroid_definition: str = Field("com", description="")
+        profile_gaussian_rs_centroid_definition: str = Field(
+            "com",
+            description="The centroid to use as beam divergence (centre of mass or s1)",
+        )
 
         # Refinement options: refinement_
         refinement_reflections_outlier_algorithm: Optional[str] = Field(
-            None, description=""
+            None,
+            description=(
+                "Outlier rejection algorithm. If auto is selected, the "
+                "algorithm is chosen automatically."
+            ),
         )
 
         @validator("output_output_dir", always=True)

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -543,10 +543,11 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
     def set_phil_template_parameters(
         cls, phil_params: PhilParameters, values: Dict[str, Any]
     ) -> None:
-        for param, value in phil_params:
+        if phil_params is not None:
             # Add as template parameters, i.e. add to __dict__ but not __fields__
             # Schema information is updated by class method `schema`
-            values[param] = value
+            for param, value in phil_params:
+                values[param] = value
         return None
 
     @classmethod

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -219,13 +219,115 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     """Parameters for merging with cctbx.xfel."""
 
     class Config(ThirdPartyParameters.Config):
-        set_result: bool = True
+        set_result: bool = False
         """Whether the Executor should mark a specified parameter as a result."""
 
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
-        ...
+        # Generic input settings: input_
+        input_path: str = Field(
+            "",
+            description="Input file(s).",
+        )
+        input_experiments_suffix: str = Field(
+            "_integrated.expt", description="Suffix appened to experiments."
+        )
+        input_reflections_suffix: str = Field(
+            "_integrated.refl", description="Suffix appened to experiments."
+        )
+        input_parallel_file_load_method: str = Field(
+            "uniform",  # *uniform node_memory
+            description="Parallel file loading method.",
+        )
+
+        # Filtering settings: filter_
+        filter_algorithm: str = Field(
+            "unit_cell",  # n_obs reindex resolution unit_cell report
+            description="",
+        )
+        filter_unit_cell_algorithm: str = Field(
+            "cluster", description=""  # range *value cluster
+        )
+        filter_unit_cell_cluster_covariance_file: str = Field(
+            "",  # $MODULES/$COV?
+            description="",
+        )
+        filter_unit_cell_cluster_covariance_component: int = Field(
+            0,
+            description="",
+        )
+        filter_unit_cell_cluster_covariance_mahalanobis: float = Field(
+            5.0,
+            description="",
+        )
+        filter_outlier_min_corr: float = Field(
+            -1.0,
+            description="",
+        )
+
+        # Selection settings: select_
+        select_algorithm: str = Field(
+            "significance_filter",
+            description="",
+        )
+        select_significance_filter_sigma: float = Field(
+            0.1,
+            description="",
+        )
+
+        # Scaling settings: scaling_
+        scaling_model: str = Field(
+            "",  # $MODULES/$COV?
+            description="",
+        )
+        scaling_resolution_scalar: float = Field(
+            0.993420862158964,
+            description="",
+        )
+
+        # Post-refinement: postrefinement_
+        postrefinement_enable: bool = Field(
+            True, description="Enable post-refinement processing?"
+        )
+        postrefinement_algorithm: str = Field("rs", description="")
+
+        # Merging: merging_
+        merging_d_min: int = Field(
+            3,  # What's a good default?
+            description="",
+        )
+        merging_merge_anomalous: bool = Field(False, description="")
+        merging_set_average_unit_cell: bool = Field(True, description="")
+        merging_error_model: str = Field(
+            "ev11", description=""  # ha14 *ev11 mm24 errors_from_sample_residuals
+        )
+
+        # Statistics: statistics_
+        statistics_n_bins: int = Field(20, description="")
+        statistics_report_ML: bool = Field(True, description="")
+        statistics_cciso_mtz_file: str = Field(
+            "",  # $H5_SIM_PATH/ground_truth.mtz
+            description="",
+        )
+        statistics_cciso_mtz_column_F: str = Field("F", description="")
+
+        # Output settings: output_
+        output_prefix: str = Field("", description="")
+        output_output_dir: str = Field(
+            "",
+            description="",
+        )
+        output_tmp_dir: str = Field(
+            "",
+            description="",
+        )
+        output_do_timing: bool = Field(True, description="")
+        output_log_level: int = Field(0, description="")
+        output_save_experiments_and_reflections: bool = Field(True, description="")
+
+        # Parallel processing settings: parallel_
+        parallel_a2a: int = Field(1, description="")
 
     executable: str = Field(
         "/sdf/group/lcls/ds/tools/cctbx/build/bin/cctbx.xfel.merge",

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -224,15 +224,7 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
-        compressor: Literal["qoz", "sz3"] = Field(
-            "qoz", description='Compression algorithm ("qoz" or "sz3")'
-        )
-        abs_error: float = Field(10.0, description="Absolute error bound")
-        bin_size: int = Field(2, description="Bin size")
-        roi_window_size: int = Field(
-            9,
-            description="Default window size",
-        )
+        ...
 
     executable: str = Field(
         "/sdf/group/lcls/ds/tools/cctbx/build/bin/cctbx.xfel.merge",
@@ -257,8 +249,14 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
         description="Template information for the cctbx_merge file.",
     )
 
+    @validator("phil_file", always=True)
+    def set_default_phil_path(cls, phil_file: str, values: Dict[str, Any]) -> str:
+        if phil_file == "":
+            return f"{values['lute_config'].work_dir}/cctbx_merge.phil"
+        return phil_file
+
     @validator("lute_template_cfg", always=True)
-    def set_phil_path(
+    def set_phil_template_path(
         cls, lute_template_cfg: TemplateConfig, values: Dict[str, Any]
     ) -> TemplateConfig:
         if lute_template_cfg.output_path == "":

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -23,6 +23,7 @@ import os
 from typing import Union, Optional, Dict, Any
 
 from pydantic import Field, validator, BaseModel
+from pydantic.schema import model_schema, default_ref_template  # Update `schema` method
 
 from .base import ThirdPartyParameters, TemplateConfig
 from ..db import read_latest_db_entry
@@ -267,9 +268,44 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     def set_phil_template_parameters(
         cls, phil_params: PhilParameters, values: Dict[str, Any]
     ) -> None:
-        if phil_params is not None:
-            ...
+        for param, value in phil_params:
+            # Add as template parameters, i.e. add to __dict__ but not __fields__
+            # Schema information is updated by class method `schema`
+            values[param] = value
         return None
+
+    @classmethod
+    def schema(
+        cls, by_alias: bool = True, ref_template: str = default_ref_template
+    ) -> Dict[str, Any]:
+        """Overload the base-class schema.
+
+        This class method is provided to overload the schema method provided by the
+        base class. We update a portion of the model schema with the schema
+        information of our model for this class' TemplateParameters. The schema
+        is used to access information about command-line arguments (flag_type) or
+        for understanding if a specific parameter is a result. Since
+        TemplateParameters are added after the fact, they are not present as fields
+        in the model and normally do not have any schema information.
+
+        This mechanism is only needed because this model is designed to provide
+        type checking of template parameters.
+        """
+        cached: Optional[Dict[str, Any]] = cls.__schema_cache__.get(
+            (by_alias, ref_template)
+        )
+        if cached is not None:
+            return cached
+        my_schema: Dict[str, Any] = model_schema(
+            cls, by_alias=by_alias, ref_template=ref_template
+        )
+        # Next two lines are the only difference vs base-class
+        template_schema: Dict[str, Any] = model_schema(
+            cls.PhilParameters, by_alias=by_alias, ref_template=ref_template
+        )
+        my_schema["properties"].update(template_schema["properties"])
+        cls.__schema_cache__[(by_alias, ref_template)] = my_schema
+        return my_schema
 
 
 class CompareHKLParameters(ThirdPartyParameters):

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -225,6 +225,9 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
+        class Config(BaseModel.Config):
+            extra: str = "allow"
+
         # Generic input settings: input_
         input_path: str = Field(
             "",

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -268,10 +268,11 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     def set_phil_template_parameters(
         cls, phil_params: PhilParameters, values: Dict[str, Any]
     ) -> None:
-        for param, value in phil_params:
+        if phil_params is not None:
             # Add as template parameters, i.e. add to __dict__ but not __fields__
             # Schema information is updated by class method `schema`
-            values[param] = value
+            for param, value in phil_params:
+                values[param] = value
         return None
 
     @classmethod

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -336,6 +336,11 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     _set_phil_template_parameters = template_parameter_validator("phil_parameters")
 
     executable: str = Field(
+        "/sdf/group/lcls/ds/tools/cctbx/conda_base/bin/mpirun",
+        description="MPI executable.",
+        flag_type="",
+    )
+    cctbx_executable: str = Field(
         "/sdf/group/lcls/ds/tools/cctbx/build/bin/cctbx.xfel.merge",
         description="CCTBX merge program.",
         flag_type="",

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -37,6 +37,10 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 
 # SFX
 #####
+CCTBXIndexer: Executor = Executor("IndexCCTBXXFEL")
+"""Runs crystallographic indexing using cctbx.xfel."""
+CCTBXIndexer.shell_source("/sdf/group/lcls/ds/tools/cctbx/setup.sh")
+
 CrystFELIndexer: Executor = Executor("IndexCrystFEL")
 """Runs crystallographic indexing using CrystFEL."""
 CrystFELIndexer.update_environment(
@@ -48,6 +52,11 @@ CrystFELIndexer.update_environment(
         )
     }
 )
+
+CCTBXMerger: Executor = Executor("MergeCCTBXXFEL")
+"""Runs crystallographic merging using cctbx.xfel."""
+CCTBXMerger.shell_source("/sdf/group/lcls/ds/tools/cctbx/setup.sh")
+
 PartialatorMerger: Executor = Executor("MergePartialator")
 """Runs crystallographic merging using CrystFEL's partialator."""
 
@@ -59,15 +68,15 @@ HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do
 
 DimpleSolver: Executor = Executor("DimpleSolve")
 """Solves a crystallographic structure using molecular replacement."""
-
 DimpleSolver.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+
 PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
 """Performs Bragg peak finding using the PyAlgos algorithm."""
 
 SHELXCRunner: Executor = Executor("RunSHELXC")
 """Runs CCP4 SHELXC - needed for crystallographic phasing."""
-
 SHELXCRunner.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+
 PeakFinderPsocake: Executor = Executor("FindPeaksPsocake")
 """Performs Bragg peak finding using psocake - *DEPRECATED*."""
 

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -393,6 +393,7 @@ class ThirdPartyTask(Task):
             msg: Message = Message(contents=self._formatted_command())
             self._report_to_executor(msg)
         LUTE_DEBUG_EXIT("LUTE_DEBUG_BEFORE_TPP_EXEC")
+        self._setup_env()
         os.execvp(file=self._cmd, args=self._args_list)
 
     def _formatted_command(self) -> str:
@@ -407,3 +408,11 @@ class ThirdPartyTask(Task):
         signal: str = "NO_PICKLE_MODE"
         msg: Message = Message(signal=signal)
         self._report_to_executor(msg)
+
+    def _setup_env(self) -> None:
+        new_env: Dict[str, str] = {}
+        for key, value in os.environ.items():
+            if "LUTE_TENV_" in key:
+                new_key: str = key[6:]
+                new_env[new_key] = value
+        os.environ = new_env

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -414,7 +414,7 @@ class ThirdPartyTask(Task):
         for key, value in os.environ.items():
             if "LUTE_TENV_" in key:
                 # Set if using a custom environment
-                new_key: str = key[6:]
+                new_key: str = key[10:]
                 new_env[new_key] = value
         if new_env != {}:
             # Is empty if using current environment

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -416,6 +416,4 @@ class ThirdPartyTask(Task):
                 # Set if using a custom environment
                 new_key: str = key[10:]
                 new_env[new_key] = value
-        if new_env != {}:
-            # Is empty if using current environment
-            os.environ = new_env
+        os.environ.update(new_env)

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -413,6 +413,9 @@ class ThirdPartyTask(Task):
         new_env: Dict[str, str] = {}
         for key, value in os.environ.items():
             if "LUTE_TENV_" in key:
+                # Set if using a custom environment
                 new_key: str = key[6:]
                 new_env[new_key] = value
-        os.environ = new_env
+        if new_env != {}:
+            # Is empty if using current environment
+            os.environ = new_env


### PR DESCRIPTION
# Description

This PR introduces initial support for CCTBX-based SFX processing.

A Task is provided to index with a rough outline for merge. A limited subset of parameters are supported through templating. Since this iteration provides all parameters as template parameters, the modified method of templating is used to support input validation on all the parameters.

Two bugs are addressed as well:
- A previously missed environment issue where changing the `Task` environment results in inability to run our code. The initial portion of `Task` code now runs in the same environment as the `Executor`. This is swapped out prior to `exec` for third-party `Task`s. First-party `Task`s are assumed to run in the same environment.
- A regression where the `Executor` result-from-parameter processing broke the ability to use templating for third-party configuration files. 

## Checklist
- [x] `IndexCCTBXXFELParameters` to provide the `Task` implementation for indexing.
- [x] `cctbx_index.phil`. Full default settings are included as well but are un-templated.
- [x] `CCTBXIndexer` and `CCTBXMerger` (outline) managed `Task`s.
- [x] Documentation updates, particularly to describe parameter validation when using templated parameters.

## PR Type:
- [x] New features/Enhancement

## Address issues:
- NA

# Testing

Tested against `mfxl1029722` using SLURM and Python submission. Both input files for indexing were created from the LUTE config YAML and parameter processing and/or template compilation.
```bash
/sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_slurm.sh -t CCTBXIndexer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --account=lcls:data --partition=milano --ntasks=120

python -B run_task.py -t CCTBXIndexer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```

Submission created a data specification file: `/sdf/scratch/users/d/dorlhiac/data_mfxl1029722_31.loc`
```bash
[dorlhiac@sdfiana001 /sdf/data/lcls/ds/mfx/mfxl1029722/scratch/tests]$> cat /sdf/scratch/users/d/dorlhiac/data_mfxl1029722_31.loc
experiment=mfxl1029722
run=31
detector_address=Rayonix
wavelength_offset=-0.004414643434400234
spectrum_eV_per_pixel=0.07523816551020232
spectrum_eV_offset=9723.778479641995
rayonix.bin_size=4
```

Main parameters were written to a `cctbx_index.phil` file in the same directory (omitted due to length).

Results are written to `/sdf/data/lcls/ds/mfx/mfxl1029722/scratch/tests`
```bash
[dorlhiac@sdfiana001 /sdf/data/lcls/ds/mfx/mfxl1029722/scratch/tests]$> ll *.refl
-rw-rw----+ 1 dorlhiac ps-data  348666 Aug 26 07:56 idx-0001_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 2237770 Aug 26 07:56 idx-0001_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  213112 Aug 26 07:56 idx-0002_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 1579690 Aug 26 07:56 idx-0002_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  523956 Aug 26 07:56 idx-0003_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 4772412 Aug 26 07:56 idx-0003_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data   67543 Aug 26 07:56 idx-0004_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data  755161 Aug 26 07:56 idx-0004_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  145928 Aug 26 07:56 idx-0005_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 1033550 Aug 26 07:56 idx-0005_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  485561 Aug 26 07:56 idx-0006_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 2699344 Aug 26 07:56 idx-0006_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  537065 Aug 26 07:56 idx-0007_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 3049807 Aug 26 07:56 idx-0007_integrated.refl
-rw-rw----+ 1 dorlhiac ps-data  350188 Aug 26 07:56 idx-0008_indexed.refl
-rw-rw----+ 1 dorlhiac ps-data 1266733 Aug 26 07:56 idx-0008_integrated.refl
```

All ranks completed successfully after about 1 minute:
```bash
[dorlhiac@sdfiana001 /sdf/data/lcls/ds/mfx/mfxl1029722/scratch/tests]$> tail log_rank0000.out

Sending stop to 88

Sending stop to 118

Sending stop to 115

All stops sent.

Total Time Taken = 63.145901 seconds
```

# Screenshots

