### PR TITLE
BUG Improve performance and reduce errors of user specified DAGs. Fix minor bugs

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,7 +1,8 @@
 %YAML 1.3
 ---
 title: "LUTE Task Configuration" # Include experiment description if desired
-experiment: "EXPL10000"
+experiment: "{{ $EXPERIMENT }}"
+run: "{{ $RUN }}"
 date: "2023/10/25"
 lute_version: 0.1      # Do not be change unless need to force older version
 task_timeout: 600

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -66,7 +66,7 @@ SLURM_ARGS=$@
 # Setup logfile names - $EXPERIMENT and $RUN_NUM will be available if ARP submitted
 # RUN_NUM is actually in format RUN_DATETIME
 RUN_TIME_ARR=(${RUN_NUM//_/ })
-RUN="${RUN_TIME_ARR[0]}"
+export RUN="${RUN_TIME_ARR[0]}"
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
 SLURM_ARGS+=" --output=${LOG_FILE}.out"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -252,7 +252,7 @@ class BaseExecutor(ABC):
         new_environment: Dict[str, str] = {}
         for key, value in tmp_environment.items():
             # Make sure LUTE vars are available
-            if "LUTE_" in key:
+            if "LUTE_" in key or key in ("RUN", "EXPERIMENT"):
                 new_environment[key] = value
             else:
                 new_environment[f"LUTE_TENV_{key}"] = value

--- a/lute/io/models/validators.py
+++ b/lute/io/models/validators.py
@@ -1,0 +1,42 @@
+"""Generic/reusable validators for parameter models.
+
+Functions:
+    template_parameter_validator: Prepare a model which accepts template
+        parameters for validation.
+"""
+
+__all__ = ["template_parameter_validator"]
+__author__ = "Gabriel Dorlhiac"
+
+from typing import Dict, Any, Optional
+
+from pydantic import validator
+
+
+def template_parameter_validator(template_params_name: str):
+    """Populates a TaskParameters model with a set of validated TemplateParameters.
+
+    This validator is intended for use with third-party Task's which use a
+    templated configuration file. The validated template parameters are passed
+    as a dictionary through a single parameter in the TaskParameters model. This
+    dictionary is typically actually a separate pydantic BaseModel defined either
+    within the TaskParameter class or externally. The other model provides the
+    initial validation of each individual template parameter.
+
+    This validator populates the TaskParameter model with the template parameters.
+    It then returns `None` for the initial parameter that held these parameters.
+    Returning None ensures that no attempt is made to pass the parameters on the
+    command-line/when launching the third-party Task.
+    """
+
+    def _template_parameter_validator(
+        cls, template_params: Optional[Any], values: Dict[str, Any]
+    ) -> None:
+        if template_params is not None:
+            for param, value in template_params:
+                values[param] = value
+        return None
+
+    return validator(template_params_name, always=True, allow_reuse=True)(
+        _template_parameter_validator
+    )

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -408,7 +408,6 @@ class JIDSlurmOperator(BaseOperator):
         logger.info(f"JobID {msg['tool_id']} successfully submitted!")
 
         jobs: List[Dict[str, Any]] = [msg]
-        time.sleep(10)  # Wait for job to queue.... FIXME
         logger.info("Checking for job completion.")
         while jobs[0].get("status") in ("RUNNING", "SUBMITTED"):
             jobs = self.rpc(

--- a/workflows/airflow/test_dynamic.py
+++ b/workflows/airflow/test_dynamic.py
@@ -52,7 +52,7 @@ def test_dynamic():
         if "dag_run" in context:
             wf: Dict[str, Any] = context["dag_run"].conf["workflow"]
             Variable.set(key="user_workflow", value=wf, serialize_json=True)
-            time.sleep(1)
+            time.sleep(3) # Make sure var gets set
             return wf
         return None
 

--- a/workflows/airflow/test_dynamic.py
+++ b/workflows/airflow/test_dynamic.py
@@ -12,10 +12,11 @@ definition and how it is parsed and passed along.
 
 from datetime import datetime
 import os
-import uuid
+import time
 from typing import Optional, Any, Dict, List
 
 from airflow.decorators import dag, task, task_group
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.models import Variable
 
 from lute.operators.jidoperators import JIDSlurmOperator
@@ -29,8 +30,6 @@ def create_links(
     op: Optional[JIDSlurmOperator] = None,
     task_list: List[JIDSlurmOperator] = [],
 ) -> JIDSlurmOperator:
-    print(wf_dict)
-    # return JIDSlurmOperator(task_id="BinaryTester", max_cores=5)
     slurm_params: str = wf_dict.get("slurm_params", "")
     new_op: JIDSlurmOperator = JIDSlurmOperator(
         task_id=wf_dict["task_name"], custom_slurm_params=slurm_params
@@ -42,7 +41,6 @@ def create_links(
         child_tasks: List[JIDSlurmOperator] = []
         for task in wf_dict["next"]:
             child_tasks.append(create_links(task, new_op, task_list))
-        # new_op.set_downstream(child_tasks)
         new_op >> child_tasks
         return new_op
 
@@ -52,9 +50,9 @@ def test_dynamic():
     @task
     def retrieve_workflow(**context):
         if "dag_run" in context:
-            print(context["dag_run"].conf["workflow"])
             wf: Dict[str, Any] = context["dag_run"].conf["workflow"]
             Variable.set(key="user_workflow", value=wf, serialize_json=True)
+            time.sleep(1)
             return wf
         return None
 
@@ -64,13 +62,14 @@ def test_dynamic():
             "user_workflow", default_var=None, deserialize_json=True
         )
         if wf_dict is not None:
-            print(wf_dict)
             task_list: List[JIDSlurmOperator] = []
             first_task: JIDSlurmOperator = create_links(wf_dict, task_list=task_list)
-        else:
-            tester: JIDSlurmOperator = JIDSlurmOperator(max_cores=2, task_id="Tester")
 
-    retrieve_workflow() >> user_workflow()
+    @task(trigger_rule=TriggerRule.ALL_DONE)
+    def delete_workflow(**context):
+        Variable.delete(key="user_workflow")
+
+    retrieve_workflow() >> user_workflow() >> delete_workflow()
 
 
 test_dynamic()


### PR DESCRIPTION
# Description

This PR improves behaviour of user-specified DAGs to reduce errors. **A major limitation is that you cannot run two different custom DAGs simultaneously.**

It also fixes some minor bugs related to environment variables introduced from incorporating CCTBX. Adds a forgotten untracked module.

## Checklist
- [x] Refresh workflow definition prior to running a new user-specified workflow.
- [x] Reduce need to run a user-specified workflow twice (or more) when changing the definition compared to a previous one.
- [x] Export `RUN` as an environment variable so it can be used in config YAML subsitution
- [x] Make `RUN` and `EXPERIMENT` available as-is even when using a custom third party environment (e.g. when variables are prepended with `LUTE_TENV_`)
- [x] Add `lute.io.models.validators` module which was mistakenly untracked.
- [x] Update `LCLS User` Airflow role permissions to support the necessary operations for these changes.

## PR Type:
- [x] Bug fix

## Address issues:
- NA

# Testing
Tested using two DAG definitions:
```bash
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat test.dag
task_name: Tester
slurm_params: ''
next:
- task_name: BinaryTester
  slurm_params: "--partition=milano --account=lcls:data --ntasks=5"
  next: []
- task_name: BinaryErrTester
  slurm_params: "--partition=milano --account=lcls:data --ntasks=5"
  next: []
- task_name: SocketTester
  slurm_params: ''
  next:
    - task_name: WriteTester
      slurm_params: ''
      next:
        - task_name: ReadTester
          slurm_params: ''
          next: []
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac]$> cat test2.dag
task_name: MultiNodeCommunicationTester
slurm_params: '--account=lcls:data --partition=milano --ntasks=5'
next: []
```

This can be run using this branch and the following command:
```bash
./lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -e prjxrai22 -r 1 -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --admin --debug --partition=milano --account=lcls:data --test -W /sdf/scratch/users/d/dorlhiac/test2.dag
```
The last argument should be switched between submission of `test.dag` and `test2.dag`.

User permissions have been updated so these commands can also be run without `--admin`.

# Screenshots
They cannot be run simultaneously. Left-most column is running `test.dag` while right-most column is running `test2.dag` (second screenshot).

Both DAGs run; however, the first DAG switches to start running the second DAG.
![image](https://github.com/user-attachments/assets/76c4c090-1bcf-4630-9986-5a5cbf9b1f5f)

The UI is no longer useful for monitoring if you are running two conflicting workflows at a time.
![image](https://github.com/user-attachments/assets/e4274c91-dc08-484c-82e4-b00f6bd2a694)

While running each workflow indepedently, the information is correctly populated.
![image](https://github.com/user-attachments/assets/1e734543-6bfd-4bc7-bc40-6e4c6c214d2a)


Historical information is also accessible while running a defined workflow. I.e. if you have previous DAG runs of the same workflow the UI will be updated and those runs can be accessed.
![image](https://github.com/user-attachments/assets/ac2b4330-d4ef-4f78-a25f-0a5c07785afb)

![image](https://github.com/user-attachments/assets/d88b3767-088b-40e4-8b17-18495807df2a)



