### PR TITLE
ENH Post-SmallData basic analysis summaries

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -98,14 +98,15 @@ SubmitSMD:
   #    save_lineout: True
 
 
-
-# FindOverlapXSS Configuration
-FindOverlapXSS:
+AnalyzeSmallDataXSS:
   # Detector selection - if left as "", will attempt to find a default
-  exp_config:
-    det_name: "Rayonix" # Detector to azimuthally integrate
-    ipm_var: "ipm_dg2" # ipm to use for x-ray intensity filtering
-    scan_var: "lxt"    # Scanned motor to use for overlap finding
+  smd_path: "/sdf/data/lcls/ds/xcs/xcsx1010322/hdf5/smalldata/xcsx1010322_Run0008.h5"
+  xss_detname: "epix10k2M"
+  ipm_var: "ipm5/sum" # ipm to use for x-ray intensity filtering
+  scan_var:
+    - "lxt"
+    - "lens_v"
+    - "lens_h"
   # Thresholds used for data filtering
   thresholds:
     min_Iscat: 10      # Minimum integrated scattering intensity

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -113,6 +113,25 @@ AnalyzeSmallDataXSS:
     min_Iscat: 10      # Minimum integrated scattering intensity
     min_ipm: 1000      # Minimum x-ray intensity at selected ipm
 
+AnalyzeSmallDataXAS:
+  # Detector selection - if left as "", will attempt to find a default
+  #smd_path: "/sdf/data/lcls/ds/xcs/xcsl1018322/hdf5/smalldata/xcsl1018322_Run0016.h5" # lxt_fast
+  smd_path: "/sdf/data/lcls/ds/xcs/xcsl1018322/hdf5/smalldata/xcsl1018322_Run0327.h5" # TR-XAS (ccm)
+  smd_path: "/sdf/data/lcls/ds/xcs/xcsl1018322/hdf5/smalldata/xcsl1018322_Run0018.h5" # lxe_opa
+  xas_detname: "epix_2"
+  xss_detname: "epix10k2M"
+  ipm_var: "ipm5/sum" # ipm to use for x-ray intensity filtering
+  scan_var:
+    - "lxt"
+    - "lxe_opa"
+    - "lxt_fast"
+  ccm: "epics/ccm_E"
+  ccm_set: "epicsUser/ccm_E_setpoint"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10      # Minimum integrated scattering intensity
+    min_ipm: 500       # Minimum x-ray intensity at selected ipm
+
 Test:
   float_var: 0.01
   str_var: "test"

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -52,7 +52,6 @@ AnalyzeSmallDataXES:
   # Motor scans to search for
   scan_var:
     - "lxt"
-    - "lxe_opa"
     - "lxt_fast"
   # Thresholds used for data filtering
   thresholds:

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -1,0 +1,65 @@
+%YAML 1.3
+---
+title: "LUTE Task Configuration" # Include experiment description if desired
+#experiment: ""
+#run: "{{ $RUN }}"
+date: "2023/10/25"
+lute_version: 0.1      # Do not be change unless need to force older version
+task_timeout: 600
+work_dir: "/sdf/scratch/users/d/dorlhiac"
+...
+---
+AnalyzeSmallDataXSS:
+  #smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm PV to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lens_v"
+    - "lens_h"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+
+AnalyzeSmallDataXAS:
+  #smd_path: ""
+  # Detector selection - scattering det used for normalization.
+  xas_detname: "epix_2"     # Name of detector with XAS signal
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lxe_opa"
+    - "lxt_fast"
+  ccm: "epics/ccm_E"
+  ccm_set: "epicsUser/ccm_E_setpoint"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+  #element: null       # For EXAFS -- currently unused
+
+AnalyzeSmallDataXES:
+  #smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection - scattering det used for normalization.
+  xes_detname: "epix_2"     # Name of detector with XAS signal
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lxe_opa"
+    - "lxt_fast"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 1000           # Minimum x-ray intensity at selected ipm
+  # Optional settings.
+  #invert_xes_axes: false   # Switch projection axis for spectrum. Default projects along 1
+  #rot_angle: null          # If not null, rotate images by N degrees before projection
+  #batch_size: 0            # If not 0, load images in batches of N. Helps OOM.
+...

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -643,7 +643,7 @@ class Executor(BaseExecutor):
 
         self.add_hook("task_cancelled", task_cancelled)
 
-        def task_result(self: Executor, msg: Message) -> None:
+        def task_result(self: Executor, msg: Message) -> bool:
             if isinstance(msg.contents, TaskResult):
                 self._analysis_desc.task_result = msg.contents
                 logger.info(self._analysis_desc.task_result.summary)
@@ -652,6 +652,8 @@ class Executor(BaseExecutor):
                 f"{self._analysis_desc.task_result.task_name} status": "COMPLETED",
             }
             post_elog_run_status(elog_data)
+
+            return True
 
         self.add_hook("task_result", task_result)
 
@@ -749,11 +751,11 @@ class Executor(BaseExecutor):
         if not os.path.isdir(full_path):
             os.makedirs(full_path)
 
-            path: str = f"{full_path}/report.html"
-            with open(f"{full_path}/report.html", "wb") as f:
-                f.write(plots.figures)
+        path: str = f"{full_path}/report.html"
+        with open(f"{full_path}/report.html", "wb") as f:
+            f.write(plots.figures)
 
-            return path
+        return path
 
     def _process_result_summary(self, summary: str) -> None: ...
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -102,6 +102,8 @@ class BaseExecutor(ABC):
 
         def task_result(self: Self, msg: Message): ...
 
+        def task_log(self: Self, msg: Message): ...
+
     def __init__(
         self,
         task_name: str,
@@ -651,6 +653,13 @@ class Executor(BaseExecutor):
             post_elog_run_status(elog_data)
 
         self.add_hook("task_result", task_result)
+
+        def task_log(self: Executor, msg: Message):
+            if isinstance(msg.contents, str):
+                # This should be log formatted already
+                print(msg.contents)
+
+        self.add_hook("task_log", task_log)
 
     def _task_loop(self, proc: subprocess.Popen) -> None:
         """Actions to perform while the Task is running.

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -373,6 +373,7 @@ class BaseExecutor(ABC):
             self._analysis_desc.task_result.task_status = TaskStatus.COMPLETED
             logger.debug(f"Task did not change from RUNNING status. Assume COMPLETED.")
             self.Hooks.task_done(self, msg=Message())
+        self.process_results()
         self._store_configuration()
         for comm in self._communicators:
             comm.clear_communicator()
@@ -380,8 +381,6 @@ class BaseExecutor(ABC):
         if self._analysis_desc.task_result.task_status == TaskStatus.FAILED:
             logger.info("Exiting after Task failure. Result recorded.")
             sys.exit(-1)
-
-        self.process_results()
 
     def _store_configuration(self) -> None:
         """Store configuration and results in the LUTE database."""
@@ -750,15 +749,11 @@ class Executor(BaseExecutor):
         if not os.path.isdir(full_path):
             os.makedirs(full_path)
 
-            # Preferred plots are pn.Tabs objects which save directly as html
-            # Only supported plot type that has "save" method - do not want to
-            # import plot modules here to do type checks.
-            if hasattr(plots.figures, "save"):
-                path: str = f"{full_path}/report.html"
-                plots.figures.save(path)
-                return path
-            else:
-                ...
+            path: str = f"{full_path}/report.html"
+            with open(f"{full_path}/report.html", "wb") as f:
+                f.write(plots.figures)
+
+            return path
 
     def _process_result_summary(self, summary: str) -> None: ...
 

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -65,6 +65,7 @@ LUTE_SIGNALS: Set[str] = {
     "TASK_DONE",
     "TASK_CANCELLED",
     "TASK_RESULT",
+    "TASK_LOG",
 }
 
 if __debug__:

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -53,7 +53,7 @@ import _io
 from typing_extensions import Self
 
 
-USE_ZMQ: bool = False
+USE_ZMQ: bool = True
 if USE_ZMQ:
     import zmq
 

--- a/lute/execution/logging.py
+++ b/lute/execution/logging.py
@@ -2,20 +2,47 @@
 
 import logging
 
-from lute.execution.ipc import PipeCommunicator, Message
+from lute.execution.ipc import SocketCommunicator, Message
 
-__all__ = ["PipeCommunicatorHandler", "STD_PYTHON_LOG_FORMAT"]
+__all__ = ["get_logger"]
 __author__ = "Gabriel Dorlhiac"
 
 STD_PYTHON_LOG_FORMAT: str = "%(levelname)s:%(name)s:%(message)s"
+LUTE_TASK_LOG_FORMAT: str = f"TASK_LOG -- %(levelname)s:%(name)s: %(message)s"
 
 
-class PipeCommunicatorHandler(logging.Handler):
+class SocketCommunicatorHandler(logging.Handler):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._communicator: PipeCommunicator = PipeCommunicator()
+        self._communicator: SocketCommunicator = SocketCommunicator()
+        self._communicator.delayed_setup()
 
     def emit(self, record: logging.LogRecord):
         formatted_message: str = self.format(record)
         msg: Message = Message(contents=formatted_message, signal="TASK_LOG")
         self._communicator.write(msg)
+
+
+def get_logger(name: str) -> logging.Logger:
+    for other_name, other_logger in logging.root.manager.loggerDict.items():
+        if "matplotlib" in other_name and not isinstance(
+            other_logger, logging.PlaceHolder
+        ):
+            other_logger.disabled = True
+        elif "numpy" in other_name and not isinstance(
+            other_logger, logging.PlaceHolder
+        ):
+            other_logger.setLevel(logging.CRITICAL)
+    logger: logging.Logger = logging.getLogger(name)
+    logger.propagate = False
+    handler: SocketCommunicatorHandler = SocketCommunicatorHandler()
+    formatter: logging.Formatter = logging.Formatter(LUTE_TASK_LOG_FORMAT)
+    handler.setFormatter(formatter)
+    logger.handlers = []
+    logger.addHandler(handler)
+    if __debug__:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    return logger

--- a/lute/execution/logging.py
+++ b/lute/execution/logging.py
@@ -1,0 +1,21 @@
+"""Custom loggers for Tasks."""
+
+import logging
+
+from lute.execution.ipc import PipeCommunicator, Message
+
+__all__ = ["PipeCommunicatorHandler", "STD_PYTHON_LOG_FORMAT"]
+__author__ = "Gabriel Dorlhiac"
+
+STD_PYTHON_LOG_FORMAT: str = "%(levelname)s:%(name)s:%(message)s"
+
+
+class PipeCommunicatorHandler(logging.Handler):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._communicator: PipeCommunicator = PipeCommunicator()
+
+    def emit(self, record: logging.LogRecord):
+        formatted_message: str = self.format(record)
+        msg: Message = Message(contents=formatted_message, signal="TASK_LOG")
+        self._communicator.write(msg)

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -218,11 +218,12 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     thresholds: Thresholds = Field(Thresholds())
     # analysis_flags: AnalysisFlags
 
+
 class AnalyzeSmallDataXASParameters(TaskParameters):
     """TaskParameter model for AnalyzeSmallDataXAS Task.
 
-    This Task does basic analysis of XSS data based on a SmallData HDF5 output
-    file. It calculates difference scattering and signal binned by various
+    This Task does basic analysis of XAS data based on a SmallData HDF5 output
+    file. It calculates difference absorption and signal binned by various
     scanned motors.
     """
 
@@ -241,7 +242,8 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         None, description="Name of the detector with absorption data."
     )
     xss_detname: Optional[str] = Field(
-        None, description="Name of the detector with scattering data, for normalization."
+        None,
+        description="Name of the detector with scattering data, for normalization.",
     )
     ipm_var: str = Field(
         description="Name of the IPM to use for X-Ray intensity filtering."
@@ -250,12 +252,9 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         None,
         description="Name of a scan variable or a list of scan variables to analyze. E.g. lxt, lens_h, etc.",
     )
-    ccm: str = Field(
-        description="Name of the PV for CCM position readback."
-    )
+    ccm: str = Field(description="Name of the PV for CCM position readback.")
     ccm_set: Optional[str] = Field(
-        None,
-        description="Name of the PV for the setpoint of the CCM."
+        None, description="Name of the PV for the setpoint of the CCM."
     )
     thresholds: Thresholds = Field(Thresholds())
     # analysis_flags: AnalysisFlags

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -183,11 +183,11 @@ class SubmitSMDParameters(ThirdPartyParameters):
 
 
 class AnalyzeSmallDataXSSParameters(TaskParameters):
-    """TaskParameter model for FindOverlapXSS Task.
+    """TaskParameter model for AnalyzeSmallDataXSS Task.
 
-    This Task determines spatial or temporal overlap between an optical pulse
-    and the FEL pulse based on difference scattering (XSS) signal. This Task
-    uses SmallData HDF5 files as a source.
+    This Task does basic analysis of XSS data based on a SmallData HDF5 output
+    file. It calculates difference scattering and signal binned by various
+    scanned motors.
     """
 
     class Thresholds(BaseModel):
@@ -214,6 +214,48 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     scan_var: Optional[Union[List[str], str]] = Field(
         None,
         description="Name of a scan variable or a list of scan variables to analyze. E.g. lxt, lens_h, etc.",
+    )
+    thresholds: Thresholds = Field(Thresholds())
+    # analysis_flags: AnalysisFlags
+
+class AnalyzeSmallDataXASParameters(TaskParameters):
+    """TaskParameter model for AnalyzeSmallDataXAS Task.
+
+    This Task does basic analysis of XSS data based on a SmallData HDF5 output
+    file. It calculates difference scattering and signal binned by various
+    scanned motors.
+    """
+
+    class Thresholds(BaseModel):
+        min_Iscat: float = Field(
+            10.0, description="Minimum scattering intensity to use for filtering."
+        )
+        min_ipm: float = Field(
+            1000.0, description="Minimum X-ray intensity to use for filtering."
+        )
+
+    smd_path: str = Field(
+        "", description="Path to the Small Data HDF5 file to analyze."
+    )
+    xas_detname: Optional[str] = Field(
+        None, description="Name of the detector with absorption data."
+    )
+    xss_detname: Optional[str] = Field(
+        None, description="Name of the detector with scattering data, for normalization."
+    )
+    ipm_var: str = Field(
+        description="Name of the IPM to use for X-Ray intensity filtering."
+    )
+    scan_var: Optional[Union[List[str], str]] = Field(
+        None,
+        description="Name of a scan variable or a list of scan variables to analyze. E.g. lxt, lens_h, etc.",
+    )
+    ccm: str = Field(
+        description="Name of the PV for CCM position readback."
+    )
+    ccm_set: Optional[str] = Field(
+        None,
+        description="Name of the PV for the setpoint of the CCM."
     )
     thresholds: Thresholds = Field(Thresholds())
     # analysis_flags: AnalysisFlags

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -9,7 +9,7 @@ Classes:
         XSS difference signal.
 """
 
-__all__ = ["SubmitSMDParameters", "FindOverlapXSSParameters"]
+__all__ = ["SubmitSMDParameters", "AnalyzeSmallDataXSSParameters"]
 __author__ = "Gabriel Dorlhiac"
 
 import os
@@ -182,7 +182,7 @@ class SubmitSMDParameters(ThirdPartyParameters):
     # getAutocorrParams: TemplateParameters = TemplateParameters({})
 
 
-class FindOverlapXSSParameters(TaskParameters):
+class AnalyzeSmallDataXSSParameters(TaskParameters):
     """TaskParameter model for FindOverlapXSS Task.
 
     This Task determines spatial or temporal overlap between an optical pulse
@@ -190,19 +190,30 @@ class FindOverlapXSSParameters(TaskParameters):
     uses SmallData HDF5 files as a source.
     """
 
-    class ExpConfig(BaseModel):
-        det_name: str
-        ipm_var: str
-        scan_var: Union[str, List[str]]
-
     class Thresholds(BaseModel):
-        min_Iscat: Union[int, float]
-        min_ipm: Union[int, float]
+        min_Iscat: float = Field(
+            10.0, description="Minimum scattering intensity to use for filtering."
+        )
+        min_ipm: float = Field(
+            1000.0, description="Minimum X-ray intensity to use for filtering."
+        )
 
     class AnalysisFlags(BaseModel):
         use_pyfai: bool = True
         use_asymls: bool = False
 
-    exp_config: ExpConfig
-    thresholds: Thresholds
-    analysis_flags: AnalysisFlags
+    smd_path: str = Field(
+        "", description="Path to the Small Data HDF5 file to analyze."
+    )
+    xss_detname: Optional[str] = Field(
+        None, description="Name of the detector with scattering data."
+    )
+    ipm_var: str = Field(
+        description="Name of the IPM to use for X-Ray intensity filtering."
+    )
+    scan_var: Optional[Union[List[str], str]] = Field(
+        None,
+        description="Name of a scan variable or a list of scan variables to analyze. E.g. lxt, lens_h, etc.",
+    )
+    thresholds: Thresholds = Field(Thresholds())
+    # analysis_flags: AnalysisFlags

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -9,7 +9,11 @@ Classes:
         XSS difference signal.
 """
 
-__all__ = ["SubmitSMDParameters", "AnalyzeSmallDataXSSParameters"]
+__all__ = [
+    "SubmitSMDParameters",
+    "AnalyzeSmallDataXSSParameters",
+    "AnalyzeSmallDataXASParameters",
+]
 __author__ = "Gabriel Dorlhiac"
 
 import os
@@ -257,4 +261,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         None, description="Name of the PV for the setpoint of the CCM."
     )
     thresholds: Thresholds = Field(Thresholds())
-    # analysis_flags: AnalysisFlags
+    element: Optional[bool] = Field(
+        None,
+        description="Element under investigation. Currently unused. For future EXAFS.",
+    )

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -32,6 +32,7 @@ from pydantic import (
 
 from lute.io.models.base import TaskParameters, ThirdPartyParameters, TemplateConfig
 from lute.io.db import read_latest_db_entry
+from lute.io.models.validators import validate_smd_path
 
 
 class SubmitSMDParameters(ThirdPartyParameters):
@@ -215,6 +216,8 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         use_pyfai: bool = True
         use_asymls: bool = False
 
+    _find_smd_path = validate_smd_path("smd_path")
+
     smd_path: str = Field(
         "", description="Path to the Small Data HDF5 file to analyze."
     )
@@ -234,28 +237,6 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     thresholds: Thresholds = Field(Thresholds())
     # analysis_flags: AnalysisFlags
 
-    @validator("smd_path", always=True)
-    def validate_producer_path(cls, smd_path: str, values: Dict[str, Any]) -> str:
-        if smd_path == "":
-            # Try from database first
-            hdf5_path: Optional[str] = read_latest_db_entry(
-                f"{values['lute_config'].work_dir}", "SubmitSMD", "result.payload"
-            )
-            if hdf5_path is not None:
-                return hdf5_path
-            else:
-                exp: str = values["lute_config"].experiment
-                run: str = str(values["lute_config"].run)
-                hutch: str = exp[:3]
-                hdf5_path: str = (
-                    f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/smalldata/{exp}_Run{run:04d}.h5"
-                )
-                if os.path.exists(hdf5_path):
-                    return hdf5_path
-                raise ValueError("No path provided for hdf5 and cannot auto-determine!")
-
-        return smd_path
-
 
 class AnalyzeSmallDataXASParameters(TaskParameters):
     """TaskParameter model for AnalyzeSmallDataXAS Task.
@@ -272,6 +253,8 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         min_ipm: float = Field(
             1000.0, description="Minimum X-ray intensity to use for filtering."
         )
+
+    _find_smd_path = validate_smd_path("smd_path")
 
     smd_path: str = Field(
         "", description="Path to the Small Data HDF5 file to analyze."
@@ -303,28 +286,6 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         description="Element under investigation. Currently unused. For future EXAFS.",
     )
 
-    @validator("smd_path", always=True)
-    def validate_producer_path(cls, smd_path: str, values: Dict[str, Any]) -> str:
-        if smd_path == "":
-            # Try from database first
-            hdf5_path: Optional[str] = read_latest_db_entry(
-                f"{values['lute_config'].work_dir}", "SubmitSMD", "result.payload"
-            )
-            if hdf5_path is not None:
-                return hdf5_path
-            else:
-                exp: str = values["lute_config"].experiment
-                run: str = str(values["lute_config"].run)
-                hutch: str = exp[:3]
-                hdf5_path: str = (
-                    f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/smalldata/{exp}_Run{run:04d}.h5"
-                )
-                if os.path.exists(hdf5_path):
-                    return hdf5_path
-                raise ValueError("No path provided for hdf5 and cannot auto-determine!")
-
-        return smd_path
-
 
 class AnalyzeSmallDataXESParameters(TaskParameters):
     """TaskParameter model for AnalyzeSmallDataXES Task.
@@ -341,6 +302,8 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
         min_ipm: float = Field(
             1000.0, description="Minimum X-ray intensity to use for filtering."
         )
+
+    _find_smd_path = validate_smd_path("smd_path")
 
     smd_path: str = Field(
         "", description="Path to the Small Data HDF5 file to analyze."
@@ -378,25 +341,3 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
         0,
         description="If non-zero load ROIs in batches. Slower but may help OOM errors.",
     )
-
-    @validator("smd_path", always=True)
-    def validate_producer_path(cls, smd_path: str, values: Dict[str, Any]) -> str:
-        if smd_path == "":
-            # Try from database first
-            hdf5_path: Optional[str] = read_latest_db_entry(
-                f"{values['lute_config'].work_dir}", "SubmitSMD", "result.payload"
-            )
-            if hdf5_path is not None:
-                return hdf5_path
-            else:
-                exp: str = values["lute_config"].experiment
-                run: str = str(values["lute_config"].run)
-                hutch: str = exp[:3]
-                hdf5_path: str = (
-                    f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/smalldata/{exp}_Run{run:04d}.h5"
-                )
-                if os.path.exists(hdf5_path):
-                    return hdf5_path
-                raise ValueError("No path provided for hdf5 and cannot auto-determine!")
-
-        return smd_path

--- a/lute/io/models/validators.py
+++ b/lute/io/models/validators.py
@@ -1,0 +1,42 @@
+"""Generic/reusable validators for parameter models.
+
+Functions:
+    template_parameter_validator: Prepare a model which accepts template
+        parameters for validation.
+"""
+
+__all__ = ["template_parameter_validator"]
+__author__ = "Gabriel Dorlhiac"
+
+from typing import Dict, Any, Optional
+
+from pydantic import validator
+
+
+def template_parameter_validator(template_params_name: str):
+    """Populates a TaskParameters model with a set of validated TemplateParameters.
+
+    This validator is intended for use with third-party Task's which use a
+    templated configuration file. The validated template parameters are passed
+    as a dictionary through a single parameter in the TaskParameters model. This
+    dictionary is typically actually a separate pydantic BaseModel defined either
+    within the TaskParameter class or externally. The other model provides the
+    initial validation of each individual template parameter.
+
+    This validator populates the TaskParameter model with the template parameters.
+    It then returns `None` for the initial parameter that held these parameters.
+    Returning None ensures that no attempt is made to pass the parameters on the
+    command-line/when launching the third-party Task.
+    """
+
+    def _template_parameter_validator(
+        cls, template_params: Optional[Any], values: Dict[str, Any]
+    ) -> None:
+        if template_params is not None:
+            for param, value in template_params:
+                values[param] = value
+        return None
+
+    return validator(template_params_name, always=True, allow_reuse=True)(
+        _template_parameter_validator
+    )

--- a/lute/io/models/validators.py
+++ b/lute/io/models/validators.py
@@ -5,12 +5,15 @@ Functions:
         parameters for validation.
 """
 
-__all__ = ["template_parameter_validator"]
+__all__ = ["template_parameter_validator", "validate_smd_path"]
 __author__ = "Gabriel Dorlhiac"
 
+import os
 from typing import Dict, Any, Optional
 
 from pydantic import validator
+
+from lute.io.db import read_latest_db_entry
 
 
 def template_parameter_validator(template_params_name: str):
@@ -40,3 +43,28 @@ def template_parameter_validator(template_params_name: str):
     return validator(template_params_name, always=True, allow_reuse=True)(
         _template_parameter_validator
     )
+
+
+def validate_smd_path(smd_path_name: str):
+    """Finds the path to a valid Smalldata file or raises an error."""
+
+    def _validate_smd_path(cls, smd_path: str, values: Dict[str, Any]) -> str:
+        if smd_path == "":
+            # Try from database first
+            hdf5_path: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "SubmitSMD", "result.payload"
+            )
+            if hdf5_path is not None:
+                return hdf5_path
+            else:
+                exp: str = values["lute_config"].experiment
+                run: int = int(values["lute_config"].run)
+                hutch: str = exp[:3]
+                hdf5_path = f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/smalldata/{exp}_Run{run:04d}.h5"
+                if os.path.exists(hdf5_path):
+                    return hdf5_path
+                raise ValueError("No path provided for hdf5 and cannot auto-determine!")
+
+        return smd_path
+
+    return validator(smd_path_name, always=True, allow_reuse=True)(_validate_smd_path)

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -38,6 +38,9 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
 """Process XSS results from a Small Data HDF5 file."""
 
+SmallDataXASAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
+"""Process XSS results from a Small Data HDF5 file."""
+
 # SFX
 #####
 CCTBXIndexer: Executor = Executor("IndexCCTBXXFEL")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -36,10 +36,13 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 """Runs the production of a smalldata HDF5 file."""
 
 SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
-"""Process XSS results from a Small Data HDF5 file."""
+"""Process scattering results from a Small Data HDF5 file."""
 
 SmallDataXASAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXAS")
-"""Process XSS results from a Small Data HDF5 file."""
+"""Process XAS results from a Small Data HDF5 file."""
+
+SmallDataXESAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXES")
+"""Process XES results from a Small Data HDF5 file."""
 
 # SFX
 #####

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -35,6 +35,9 @@ MultiNodeCommunicationTester: MPIExecutor = MPIExecutor("TestMultiNodeCommunicat
 SmallDataProducer: Executor = Executor("SubmitSMD")
 """Runs the production of a smalldata HDF5 file."""
 
+SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
+"""Process XSS results from a Small Data HDF5 file."""
+
 # SFX
 #####
 CCTBXIndexer: Executor = Executor("IndexCCTBXXFEL")
@@ -79,6 +82,3 @@ SHELXCRunner.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
 
 PeakFinderPsocake: Executor = Executor("FindPeaksPsocake")
 """Performs Bragg peak finding using psocake - *DEPRECATED*."""
-
-StreamFileConcatenator: Executor = Executor("ConcatenateStreamFiles")
-"""Concatenates results from crystallographic indexing of multiple runs."""

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -38,7 +38,7 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
 """Process XSS results from a Small Data HDF5 file."""
 
-SmallDataXASAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
+SmallDataXASAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXAS")
 """Process XSS results from a Small Data HDF5 file."""
 
 # SFX

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -71,6 +71,11 @@ def import_task(task_name: str) -> Type[Task]:
 
         return AnalyzeSmallDataXSS
 
+    if task_name == "AnalyzeSmallDataXAS":
+        from .smalldata import AnalyzeSmallDataXAS
+
+        return AnalyzeSmallDataXAS
+
     if task_name == "TestMultiNodeCommunication":
         from .mpi_test import TestMultiNodeCommunication
 

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -66,6 +66,11 @@ def import_task(task_name: str) -> Type[Task]:
 
         return ConcatenateStreamFiles
 
+    if task_name == "AnalyzeSmallDataXSS":
+        from .smalldata import AnalyzeSmallDataXSS
+
+        return AnalyzeSmallDataXSS
+
     if task_name == "TestMultiNodeCommunication":
         from .mpi_test import TestMultiNodeCommunication
 

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -76,6 +76,11 @@ def import_task(task_name: str) -> Type[Task]:
 
         return AnalyzeSmallDataXAS
 
+    if task_name == "AnalyzeSmallDataXES":
+        from .smalldata import AnalyzeSmallDataXES
+
+        return AnalyzeSmallDataXES
+
     if task_name == "TestMultiNodeCommunication":
         from .mpi_test import TestMultiNodeCommunication
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -1,0 +1,1225 @@
+"""Base classes for working with SmallData HDF5 files.
+
+Classes defined in this module provide an interface to extracting data from
+SmallData files and analyzing it. They are subclassed in the main `smalldata`
+module for implementation into runnable Tasks.
+
+Classes:
+    AnalyzeSmallData(Task): Analyze a smalldata file, with MPI support.
+"""
+
+__all__ = ["AnalyzeSmallData"]
+__author__ = "Gabriel Dorlhiac"
+
+import sys
+import logging
+from typing import List, Optional, Dict, Tuple, Union
+
+import h5py
+import holoviews as hv
+import numpy as np
+import panel as pn
+import matplotlib.pyplot as plt
+from mpi4py import MPI
+from scipy.signal import find_peaks
+from scipy.optimize import curve_fit
+
+from lute.execution.ipc import Message
+from lute.io.models.base import TaskParameters
+from lute.tasks.task import *
+from lute.tasks.dataclasses import ElogSummaryPlots
+from lute.tasks.math import gaussian, sigma_to_fwhm
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+if __debug__:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+
+class AnalyzeSmallData(Task):
+    """Base class for analyzing a SmallData HDF5 file with MPI support."""
+
+    _LARGE_DETNAMES: List[str] = ["epix10k2M", "Rayonix", "Jungfrau4M"]
+    _SMALL_DETNAMES: List[str] = ["epix_1", "epix_2"]
+
+    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+        super().__init__(params=params, use_mpi=use_mpi)
+        hv.extension("bokeh")
+        pn.extension()
+        self._mpi_comm: MPI.Intracomm = MPI.COMM_WORLD
+        self._mpi_rank: int = self._mpi_comm.Get_rank()
+        self._mpi_size: int = self._mpi_comm.Get_size()
+        try:
+            self._smd_h5: h5py.File = h5py.File(self._task_parameters.smd_path, "r")
+        except Exception:
+            if self._mpi_rank == 0:
+                logger.debug(f"Failed to open file: {self._task_parameters.smd_path}!")
+            self._mpi_comm.Barrier()
+            sys.exit(-1)
+
+        self._events_per_rank: np.ndarray[np.int]
+        self._start_indices_per_rank: np.ndarray[np.int]
+        if self._mpi_rank == 0:
+            self._total_num_events: int = len(self._smd_h5["event_time"][()])
+            quotient: int
+            remainder: int
+            quotient, remainder = divmod(self._total_num_events, self._mpi_size)
+            self._events_per_rank = np.array(
+                [
+                    quotient + 1 if rank < remainder else quotient
+                    for rank in range(self._mpi_size)
+                ]
+            )
+            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+            self._start_indices_per_rank[1:] = np.cumsum(self._events_per_rank[:-1])
+        else:
+            self._events_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+        self._mpi_comm.Bcast(self._events_per_rank, root=0)
+        self._mpi_comm.Bcast(self._start_indices_per_rank, root=0)
+        self._xss_detname: str
+        if self._task_parameters.xss_detname is None:
+            for key in self._smd_h5.keys():
+                if key in AnalyzeSmallData._LARGE_DETNAMES:
+                    self._xss_detname = key
+                    logger.debug(f"Assuming XSS detector is: {key}.")
+                    break
+            else:
+                logger.error("No XSS detname provided and could not determine detname!")
+        else:
+            self._xss_detname = self._task_parameters.xss_detname
+
+        # Basic RANK-LOCAL variables - Each rank holds a subset of data
+        ################################################################
+        self._num_events: int = self._events_per_rank[self._mpi_rank]
+        self._start_idx: int = self._start_indices_per_rank[self._mpi_rank]
+        self._stop_idx: int = self._start_idx + self._num_events
+        logger.debug(
+            f"Rank {self._mpi_rank}: Processing {self._num_events} events from "
+            f"event {self._start_idx}."
+        )
+
+        # Generic filtering variables
+        self._filter_dict: Dict[str, np.ndarray[np.float64]] = {}
+        self._xray_intensity: np.ndarray[np.float64]
+        self._integrated_intensity: np.ndarray[np.float64]
+
+        # Scan vars
+        self._scan_var_name: Optional[str] = None
+        self._scan_values: np.ndarray[np.float64]
+
+    def _pre_run(self) -> None: ...
+
+    def _run(self) -> None:
+        diff: np.ndarray[np.float64]
+        bins: np.ndarray[np.float64]
+        bins, diff, laser_on = self._calc_binned_difference()
+
+        def sum_diff(
+            diff0: np.ndarray[np.float64], diff1: np.ndarray[np.float64]
+        ) -> np.ndarray[np.float64]:
+            return diff0 + diff1
+
+        def laser_on_mean(
+            laser_on0: np.ndarray[np.float64], laser_on1: np.ndarray[np.float64]
+        ) -> np.ndarray[np.float64]:
+            return laser_on0.sum(axis=0) + laser_on1.sum(axis=0)
+
+        if self._mpi_size > 1:
+            diff = self._mpi_comm.reduce(diff, op=sum_diff)
+            laser_on = self._mpi_comm.reduce(laser_on, op=laser_on_mean)
+        else:
+            laser_on = np.nansum(laser_on, axis=0)
+
+        if self._mpi_rank == 0:
+            diff /= self._mpi_size
+            laser_on /= self._total_num_events
+            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+            plots: pn.Tabs = self.plot_all(laser_on, bins, diff, name)
+            plot_display_name: str
+            run: int = int(self._task_parameters.lute_config.run)
+            exp_run: str = f"{run:04d}_{name}_XSS"
+            if "lens" in name:
+                plot_display_name = f"lens_scans/{exp_run}"
+            else:
+                plot_display_name = f"time_scans/{exp_run}"
+
+            self._result.payload = ElogSummaryPlots(plot_display_name, plots)
+
+    def _post_run(self) -> None: ...
+
+    def _extract_standard_data(self) -> None:
+        """Setup up stored attributes by taking data from the smalldata hdf5 file."""
+
+        self._extract_az_int()
+        try:
+            self._xray_intensity = self._smd_h5[self._task_parameters.ipm_var][
+                self._start_idx : self._stop_idx
+            ]
+        except KeyError as e:
+            logger.error("ipm data not found! Check config!")
+        self._integrated_intensity = np.nansum(self._az_int, axis=(1, 2))
+        self._setup_std_filters()
+
+        if isinstance(self._task_parameters.scan_var, str):
+            scan_var: str = self._task_parameters.scan_var
+            try:
+                self._scan_values = self._smd_h5[f"scan/{scan_var}"][
+                    self._start_idx : self._stop_idx
+                ]
+                self._scan_var_name = scan_var
+            except KeyError as e:
+                logger.debug(f"Scan variable {scan_var} not found!")
+        elif isinstance(self._task_parameters.scan_var, list):
+            for scan_var in self._task_parameters.scan_var:
+                try:
+                    self._scan_values = self._smd_h5[f"scan/{scan_var}"][
+                        self._start_idx : self._stop_idx
+                    ]
+                    self._scan_var_name = scan_var
+                    break
+                except KeyError as e:
+                    logger.debug(f"Scan variable {scan_var} not found!")
+                    continue
+        if not hasattr(self, "_scan_values"):
+            # Create a set of scan values if none of the above scan
+            # variables are found, either lxt_fast or linear set.
+            try:
+                self._scan_values = self._smd_h5["enc/lasDelay"][
+                    self._start_idx : self._stop_idx
+                ]
+                self._scan_var_name = "lxt_fast"
+                logger.debug("Using scan variable lxt_fast")
+            except KeyError as e:
+                logger.debug("Scan variable lxt_fast not found!")
+                self._scan_values = np.linspace(
+                    self._start_idx, self._stop_idx, self._num_events
+                )
+                logger.debug(
+                    "No scans found, using linearly spaced data for _scan_values."
+                )
+
+    def _extract_az_int(self) -> None:
+        """Try to extract the azimuthal integration data from HDF5 file.
+
+        This internal method will search first to see if a detector has been
+        provided as the scattering detector. If not, it will attempt to guess
+        which detector to use. It will attempt to extract both the internal
+        integration data and PyFAI integrated data (which have different
+        interfaces). If both are present, it will only extract PyFAI data.
+        """
+        detname: str = self._xss_detname
+        try:
+            self._extract_az_int_smd_internal(detname)
+            logger.debug(
+                f"Extracted internal azimuthal integration data for {detname}."
+            )
+        except Exception:
+            try:
+                self._extract_az_int_pyfai(detname)
+                logger.debug(
+                    f"Extracted PyFAI azimuthal integration data for {detname}."
+                )
+            except Exception:
+                logger.error("No azimuthal integration data found.")
+                self._mpi_comm.Barrier()
+                sys.exit(-1)
+
+    def _extract_az_int_smd_internal(self, detname: str) -> None:
+        """Extract stored data from SmallData's azimuthal integration algorithm.
+
+        Args:
+            detname (str): The detector name to extract data for.
+        """
+
+        self._az_int = self._smd_h5[f"{detname}/azav_azav"][
+            self._start_idx : self._stop_idx
+        ]  # 3D
+        self._q_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_q"][()]
+        self._phi_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_phiVec"][()]
+
+    def _extract_az_int_pyfai(self, detname: str) -> None:
+        """Extract stored data from PyFAI's azimuthal integration algorithm.
+
+        Args:
+            detname (str): The detector name to extract data for.
+        """
+
+        self._az_int = self._smd_h5[f"{detname}/pyfai_azav"][
+            self._start_idx : self._stop_idx
+        ]  # 3D
+        self._q_vals = self._smd_h5[f"{detname}/pyfai_q"][()][0]
+        self._phi_vals = self._smd_h5[f"{detname}/pyfai_az"][()][0]
+
+    def _setup_std_filters(self) -> None:
+        """Setup the individual standard event filters.
+
+        Sets up light status (X-ray and laser) filters, and adjustable filters
+        based on, e.g., thresholds.
+        """
+        # For filtering based on event type
+        self._filter_dict["xray on"] = (
+            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 1
+        )
+        self._filter_dict["laser on"] = (
+            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 1
+        )
+
+        self._filter_dict["xray off"] = (
+            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 0
+        )
+        self._filter_dict["laser off"] = (
+            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 0
+        )
+
+        # Create scattering and ipm thresholds for first time
+        self._update_filters()
+
+    def _update_filters(self) -> None:
+        """Update stored event filters that are based on adjustable parameters.
+
+        E.g. update the minimum scattering intensity to use in analyses.
+        """
+        scattering_thresh: float = self._task_parameters.thresholds.min_Iscat
+        ipm_thresh: float = self._task_parameters.thresholds.min_ipm
+        self._filter_dict["total scattering"] = (
+            self._integrated_intensity > scattering_thresh
+        )
+        if hasattr(self, "_xray_intensity"):
+            self._filter_dict["ipm"] = self._xray_intensity > ipm_thresh
+        else:
+            self._filter_dict["ipm"] = np.ones([self._num_events], dtype=bool)
+
+    def _calc_norm_by_qrange(
+        self, q_limits: Tuple[float, float] = (0.9, 3.5)
+    ) -> np.ndarray[np.float64]:
+        """Calculate a normalization factor by averaging over a range of Q values.
+
+        Args:
+            q_limits (Tuple[float, float]): The lower and upper limit of the
+                Q-range to average.
+
+        Returns:
+            norm (np.ndarray[np.float64]): The 2D norm with shape
+                (num_events, num_phi)
+        """
+        norm_range: np.array = self._q_vals > q_limits[0]
+        norm_range &= self._q_vals < q_limits[1]
+        return np.nanmean(self._az_int[..., norm_range], axis=-1)
+
+    def _calc_norm_by_max(self) -> np.ndarray[np.float64]:
+        """Calculate a normalization factor by taking the maximum of each profile.
+
+        Returns:
+        norm (np.ndarray[np.float64]): The 1D norm with shape (num_events)
+        """
+        return np.nanmax(self._az_int, axis=(1, 2))
+
+    def _calc_1d_water_norm(self) -> np.ndarray[np.float64]:
+        """Calculate normalization factors by integrating the water ring.
+        https://www.osti.gov/servlets/purl/1760438 says to use 1.5-3.5 A-1
+        """
+        # _ = self.find_solvent_argmax(self.scattering_laser_on_mean)
+        # min_q_idx: int = self._solvent_peak_idx - 10
+        # max_q_idx: int = self._solvent_peak_idx + 1
+        # return np.nanmean(
+        #    self.calc_norm_by_qrange((self.q_vals[min_q_idx], self.q_vals[max_q_idx])),
+        #    axis=-1,
+        # )
+        return np.nanmean(self._calc_norm_by_qrange((1.5, 3.5)), axis=-1)
+
+    def _aggregate_filters(
+        self, filter_vars: str = ("xray on, laser on, total scattering, ipm")
+    ) -> np.ndarray[np.bool_]:
+        """Combine a number of possible data filters.
+
+        Takes a string of filters to be applied in the order specified. The
+        order matters for some filters, e.g. if "percentage" is selected it
+        should be applied after total scattering. See below for a list of
+        filters.
+
+        Possible filters:
+            "xray on": Take shots where X-rays are on,
+            "xray off": Take shots where X-rays are off,
+            "laser on": Take shots where laser is on,
+            "laser off": Take shots where laser is off,
+            "ipm": Take shots with X-ray intensity above a value (ipm value),
+            "total scattering": Take shots with minimum integrated scattering,
+            "percentage": Extract this percentage of data centered on the max
+                scattering intensity. Should be applied after total scatteirng.
+                E.g. Include 50% of shots centered around the Q-value with
+                maximum scattering.
+
+        Args:
+            filter_vars (str): A string of comma-seperated filters to apply,
+                taken from the list above. E.g. "xray on, laser on".
+
+        Returns:
+            total_filter (np.ndarray[np.bool]): A 1D boolean array with a shape
+                of (num_events) which can be used to index and filter a data array.
+        """
+        logger.debug("XSS Analysis: aggregate_filters")
+        filters: List[str] = [f.strip() for f in filter_vars.split(",")]
+        total_filter: np.ndarray = np.ones([self._num_events], dtype=bool)
+
+        for data_filter in filters:
+            logger.debug(f"Filter: {data_filter}")
+            try:
+                total_filter &= self._filter_dict[data_filter]
+            except KeyError as e:
+                logger.debug(
+                    f"Unrecognized filter requested: {data_filter}. "
+                    "Ignoring and continuing processing."
+                )
+                continue
+
+        return total_filter
+
+    def _calc_dark_mean(
+        self, profiles: np.ndarray[np.float64]
+    ) -> np.ndarray[np.float64]:
+        """Calculate the dark (X-ray off) mean of a set of XSS profiles.
+
+        Args:
+            profiles (np.ndarray[np.float64]): Set of profiles to calculate the
+                dark mean from. Shape: (n_events, q_bins)
+        Returns:
+            dark_mean (np.ndarray[np.float64]): The calculated dark mean.
+                Shape: (q_bins)
+        """
+        dark_mean: np.ndarray[np.float64]
+        try:
+            dark_mean = np.nanmean(profiles[self._filter_dict["xray off"]], axis=0)
+            dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
+            dark_mean /= self._mpi_size
+        except KeyError:
+            logger.debug(
+                "No X-ray off event information for filtering. "
+                "Dark mean will be all zeros."
+            )
+            dark_mean = np.zeros([self._num_events])
+        return dark_mean
+
+    def _calc_binned_difference_xss(
+        self,
+    ) -> Tuple[np.ndarray[np.float], np.ndarray[np.float64], np.ndarray[np.float64]]:
+        """Calculate the binned difference.
+
+        Calculates the 1D difference scattering for each bin of a scan variable.
+        Final difference shape is 2D: (q_bins, scan_bins). Also returns bins and
+        the laser on profiles.
+
+        Returns:
+            bins (np.ndarray[np.float64]): 1D array of scan bins used.
+
+            diff (np.ndarray[np.float64]): 2D binned difference scattering of shape
+                (q_bins, scan_bins)
+
+            laser_on (np.ndarray[np.float64]): 2D laser on scattering profiles
+                of shape (n_events_las_on, q_bins)
+        """
+        logger.debug("XSS Analysis: profiles_1d")
+        profiles: np.ndarray[np.float64, np.float64] = np.nansum(self._az_int, axis=1)
+        dark_mean: np.ndarray[np.float64] = self._calc_dark_mean(profiles)
+        if len(np.unique(dark_mean)) > 1:
+            # Can be len == 1 if all nan
+            profiles -= dark_mean
+        norm: np.ndarray[np.float64] = self._calc_norm_by_qrange()
+        profiles = (profiles.T / np.nanmean(norm, axis=-1).T).T
+        del dark_mean
+        del norm
+
+        filter_las_on: np.ndarray[np.float64] = self._aggregate_filters()
+        filter_las_off: np.ndarray[np.float64] = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+
+        bins: np.ndarray[np.float64] = self._calc_scan_bins()
+        binned_on: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        binned_off: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        scanvals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
+        scanvals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
+
+        idx: int
+        scan_bin: float
+        for idx, scan_bin in enumerate(bins):
+            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
+                if idx == len(bins) - 1:
+                    continue
+                mask_on: np.ndarray[np.bool_] = (scanvals_las_on >= scan_bin) * (
+                    scanvals_las_on < bins[idx + 1]
+                )
+                mask_off: np.ndarray[np.bool_] = (scanvals_las_off >= scan_bin) * (
+                    scanvals_las_off < bins[idx + 1]
+                )
+                binned_on[:, idx] = np.nanmean(profiles[filter_las_on][mask_on], axis=0)
+                binned_off[:, idx] = np.nanmean(
+                    profiles[filter_las_off][mask_off], axis=0
+                )
+            else:
+                binned_on[:, idx] = np.nanmean(
+                    profiles[filter_las_on][(scanvals_las_on == scan_bin)], axis=0
+                )
+                binned_off[:, idx] = np.nanmean(
+                    profiles[filter_las_off][(scanvals_las_off == scan_bin)], axis=0
+                )
+        diff: np.ndarray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
+            binned_off
+        )
+        return bins, diff, profiles[filter_las_on]
+
+    def _find_solvent_argmax(self, corrected_profile: np.ndarray) -> int:
+        """Find the index of the solvent ring maximum.
+
+        Currently just a hack around SciPy find_peaks.
+
+        Args:
+            corrected_profile (np.ndarray[np.float64]): 1D normalized and dark
+                mean corrected, laser on, scattering profile.
+
+        Returns:
+            peak_idx (int): The index where the solvent maximum is located.
+        """
+        res: Tuple[np.ndarray, Dict[str, np.ndarray]] = find_peaks(corrected_profile, 1)
+        try:
+            peak_indices: np.ndarray = res[0]
+            peak_heights: np.ndarray = res[1]["peak_heights"]
+        except KeyError as e:
+            logger.debug("No peaks found")
+            return np.argmax(corrected_profile)
+
+        peak_idx: int = peak_indices[
+            np.argmax(peak_heights)
+        ]  # peak_indices[0]  # peak_indices[peak_select - 1]
+        self._solvent_peak_idx = peak_idx
+        return peak_idx
+
+    def _fit_overlap(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        guess: Optional[List[float]] = None,
+    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]:
+        """Fit overlap based on scattering difference signal to a Gaussian.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            guess (Optional[List[float]]): A list of initial parameter guesses
+                for Gaussian fit in the order (amplitude, x0, sigma, background
+                offset)
+
+        Returns:
+            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+                Q value used for calculating the overlap.
+
+            opt (np.ndarray[np.float64]): Optimized parameters.
+
+            res (np.ndarray[np.float64]): Covariances.
+        """
+        logger.debug("XSS Analysis: fit_overlap")
+        Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]
+        max_pt: int = self._find_solvent_argmax(laser_on)
+        try:
+            idx_peak_q: int = max_pt + 10
+        except IndexError as e:
+            logger.debug(f"{e}: No non-nan values found.")
+            idx_peak_q: int = 15
+
+        raw_curve: np.ndarray = diff[idx_peak_q]
+        if not guess:
+            max_val: int = raw_curve.max()
+            min_val: int = raw_curve.min()
+            # guess = [amplitude, center, stddev, bkgnd]
+            guess = [0, 0, 0, 0]
+            x0: float
+            if max_val > np.abs(min_val):
+                x0 = bins[raw_curve.argmax()]
+                guess[0] = max_val
+            else:
+                x0 = bins[raw_curve.argmin()]
+                guess[0] = min_val
+            guess[1] = x0
+            guess[2] = np.abs(bins[-1] - bins[0]) / 20
+            guess[3] = np.min(raw_curve)
+        try:
+            opt, res = curve_fit(gaussian, bins, raw_curve, p0=guess, maxfev=999999)
+        except ValueError as e:
+            logger.debug(f"{e}:\n No non-nan values...")
+            opt = guess
+            res = None
+
+        return raw_curve, opt, res
+
+    def _fit_convolution_fwhm(
+        self, trace: np.ndarray, bins: np.ndarray[np.float_]
+    ) -> float:
+        """Calculate the FWHM of a convolution signal.
+
+        Args:
+            trace (np.ndarray[np.float64]): 1D convolution trace.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used.
+
+        Returns:
+            fwhm (float): Calculated FWHM.
+        """
+        from scipy.interpolate import UnivariateSpline
+
+        x = np.linspace(0, len(trace) - 1, len(trace))
+        spline = UnivariateSpline(x, (trace - np.max(trace) / 2), s=0)
+        roots = spline.roots()
+        if len(roots) == 2:
+            lb, rb = roots
+            fwhm = rb - lb
+        else:
+            max_val: int = trace.max()
+            min_val: int = trace.min()
+            guess: List[Union[float, int]] = [0, 0, 0, 0]
+            x0: Union[float, int]
+            if max_val > np.abs(min_val):
+                x0 = bins[trace.argmax()]
+                guess[0] = max_val
+            else:
+                x0 = bins[trace.argmin()]
+                guess[0] = min_val
+            guess[1] = x0
+            guess[2] = np.abs(bins[-1] - bins[0]) / 20
+            guess[3] = np.min(trace)
+            opt, res = curve_fit(
+                gaussian, bins, np.nan_to_num(trace), p0=guess, maxfev=999999
+            )
+            fwhm = sigma_to_fwhm(opt[2])
+        return fwhm
+
+    def _convolution_fit(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> Tuple[np.ndarray, np.ndarray, int, float]:
+        """Fits a time scan through convolution with Heaviside kernel.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+        Returns:
+            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+                Q value used for calculating the overlap.
+
+            trace (np.ndarray[np.float64]): 1D convolution trace.
+
+            center (int): The index of the center from the convolution.
+
+            fwhm (float): Width of the convlution signal (fwhm).
+        """
+        from scipy.signal import fftconvolve
+
+        logger.debug("XSS Analysis: convolution_fit")
+        results: List[Tuple] = []
+        max_pt: int = self._find_solvent_argmax(laser_on)
+        raw_curve: np.ndarray = np.nan_to_num(diff[max_pt + 10])
+        npts: int = len(raw_curve)
+        kernel: np.ndarray = np.zeros([npts])
+        kernel[: npts // 2] = 1
+        trace: np.ndarray = fftconvolve(raw_curve, kernel, mode="same")
+        center: int = trace.argmax()
+        fwhm: float = self._fit_convolution_fwhm(trace, bins)
+        return raw_curve, trace, center, fwhm
+
+    # Plots
+    ############################################################################
+
+    def plot_avg_xss(
+        self,
+        laser_on: np.ndarray[np.float64],
+        q_vals: np.ndarray[np.float64],
+        phis: np.ndarray[np.float64],
+    ) -> plt.Figure: ...
+
+    def plot_difference_xss_hv(
+        self,
+        bins: np.ndarray[np.float64],
+        q_vals: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        scan_var_name: str,
+    ) -> pn.GridSpec:
+        """Plot the binned difference scattering.
+
+        Args:
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            q_vals (np.ndarray[np.float64]): 1D set of Q bins.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            scan_var_name (str): Name of the scan variable (for titles, etc.).
+
+        Returns:
+            plot (pn.GridSpec): Plotted binned difference.
+        """
+        grid: pn.GridSpec = pn.GridSpec(name="Difference Profiles")
+        xdim: hv.core.dimension.Dimension = hv.Dimension(
+            ("scan_var", f"Scan Var {scan_var_name}")
+        )
+        ydim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
+        diff_img: hv.Image = hv.Image(
+            (bins, q_vals, diff.T),
+            kdims=[xdim, ydim],
+        ).opts(shared_axes=False)
+        contours = diff_img + hv.operation.contours(diff_img, levels=5)
+        contours.opts(
+            hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
+        ).opts(shared_axes=False)
+        grid[:2, :2] = contours
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", f"Q"))
+        ydim: hv.core.dimension.Dimension = hv.Dimension(("dS", "dS"))
+        diff_curves: hv.Overlay
+        # diff_curves = hv.Curve((q_vals, diff[:, 0]))
+        # for i, _ in enumerate(bins):
+        #    if i == 0:
+        #        continue
+        #    else:
+        #        diff_curves *= hv.Curve(
+        #            (
+        #                q_vals,
+        #                diff[:, i],
+        #            )
+        #        ).opts(xlabel=xdim.label, ylabel=ydim.label)
+
+        # grid[2:4, :] = diff_curves.opts(shared_axes=False)
+        return grid
+
+    def plot_xss_overlap_fit(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> plt.Figure:
+        """Plot the overlap fit to a slice of the binned difference.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+        Returns:
+            plot (plt.Figure): Plotted overlap fit.
+        """
+        logger.debug("XSS Analysis: plot_overlap_fit")
+        fig, ax = plt.subplots(1, 1, figsize=(6, 3), dpi=200)
+        if self._scan_var_name is not None and "lxt" in self._scan_var_name:
+            raw_curve: np.ndarray[np.float64]
+            trace: np.ndarray[np.float64]
+            center: int
+            fwhm: float
+            raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
+            msg: str = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {bins[center]}\n"
+                f"FWHM: {fwhm}"
+            )
+            logger.info(msg)
+            ax.plot(bins, raw_curve, label="Raw")
+            ax2 = ax.twinx()
+            ax2.plot(bins, trace, color="orange", label="Convolution")
+            ax.set_title(msg)
+            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
+            ax.set_ylabel(r"$\Delta$S")
+            plt.legend(loc=0, frameon=False)
+        else:
+            raw_curve: np.ndarray[np.float64]
+            opt: np.ndarray[np.float64]
+            raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
+            msg: str = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {opt[1]}\n"
+                f"FWHM: {sigma_to_fwhm(opt[2])}"
+            )
+            logger.info(msg)
+            ax.plot(bins, raw_curve)
+            ax.plot(bins, gaussian(bins, *opt))
+            ax.set_title(msg)
+            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
+            ax.set_ylabel(r"$\Delta$S")
+        fig.tight_layout()
+        return fig
+
+    def plot_all_xss(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        scan_var_name: str,
+    ) -> pn.Tabs:
+        """Plot all relevant scattering plots.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            scan_var_name (str): Name of the scan variable (for titles, etc.).
+
+        Returns:
+            plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
+        """
+        logger.debug("XSS Analysis: plot_all")
+        # avg_fig = self.plot_avg_xss()
+        overlap_fig = self.plot_xss_overlap_fit(laser_on, bins, diff)
+
+        # avg_grid = pn.GridSpec(name="TR X-ray Scattering")
+        # avg_grid[:2, :2] = avg_fig
+
+        diff_grid = self.plot_difference_xss_hv(laser_on, bins, diff, scan_var_name)
+        overlap_grid = pn.GridSpec(name="Overlap Fit")
+        overlap_grid[:2, :2] = overlap_fig
+
+        tabbed_display = pn.Tabs(diff_grid)
+        tabbed_display.append(overlap_grid)
+        # tabbed_display.append(avg_grid)
+
+        return tabbed_display
+
+    def plot_all_xas(
+        self,
+        laser_on: np.ndarray[np.float64],
+        laser_off: np.ndarray[np.float64],
+        ccm_bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> pn.Tabs:
+        """Plot XAS and optionally EXAFS
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                absorption spectrum.
+
+            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+                absorption spectrum.
+
+            ccm_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 1D difference absorption.
+
+        Returns:
+            plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
+        """
+        std_xas_grid: pn.GridSpec = self.plot_std_xas_hv(
+            laser_on, laser_off, ccm_bins, diff
+        )
+        tabs: pn.Tabs = pn.Tabs(std_xas_grid)
+        if (
+            hasattr(self._task_parameters, "analyze_exafs")
+            and self._task_parameters.analyze_exafs
+        ):
+            ...
+            # exafs_grid: pn.GridSpec = self.plot_exafs_hv()
+            # tabs.append(exafs_grid)
+
+        return tabs
+
+    def plot_std_xas_hv(
+        self,
+        laser_on: np.ndarray[np.float64],
+        laser_off: np.ndarray[np.float64],
+        ccm_bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> pn.GridSpec:
+        """Plot relevant XAS plots.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                absorption spectrum.
+
+            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+                absorption spectrum.
+
+            ccm_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 1D difference absorption.
+
+        Returns:
+            plot (pn.GridSpec): Laser on/off and difference XAS plots.
+        """
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("ccm_E", "Energy"))
+        ydim: hv.core.dimension.Dimension = hv.Dimension(("A", "A"))
+
+        on_pts: hv.Points = hv.Points(
+            (ccm_bins, laser_on), kdims=[xdim, ydim], label="Laser on"
+        ).opts(size=5, color="green")
+        on_curve: hv.Curve = hv.Curve((ccm_bins, laser_on), kdims=[xdim, ydim]).opts(
+            color="green"
+        )
+        off_pts: hv.Points = hv.Points(
+            (ccm_bins, laser_off), kdims=[xdim, ydim], label="Laser off"
+        ).opts(size=5, color="orange")
+        off_curve: hv.Curve = hv.Curve((ccm_bins, laser_off), kdims=[xdim, ydim]).opts(
+            color="orange"
+        )
+        xas_plots = on_pts * on_curve * off_pts * off_curve
+
+        ydim = hv.Dimension(("diff A", "dA/dE"))
+
+        diff_pts: hv.Points = hv.Points((ccm_bins, diff), kdims=[xdim, ydim]).opts(
+            size=5
+        )
+        diff_curve: hv.Curve = hv.Curve((ccm_bins, diff), kdims=[xdim, ydim])
+        diff_plot: hv.Overlay = hv.Overlay([diff_pts, diff_curve])
+
+        grid: pn.GridSpec = pn.GridSpec(name="XAS")
+        grid[:2, :2] = xas_plots
+        grid[2:4, :2] = diff_plot
+        return grid
+
+    def plot_xas_scan_hv(self) -> Optional[pn.Tabs]:
+        """Plot scan data.
+
+        Currently handles lxe_opa power titration and t0 (lxt_fast) XAS scans.
+        """
+        if self.scan_var_name is None:
+            logger.info("Skipping scan plots - requested scan variables not found.")
+            return None
+        if "lxe_opa" in self._scan_var_name:
+            return self.plot_xas_power_titration_scan()
+        elif "lxt_fast" in self._scan_var_name:
+            return self.plot_xas_lxt_fast_scan()
+
+    def plot_xas_lxt_fast_scan(self) -> pn.Tabs:
+        """Produce a plot of an lxt_fast scan for time zero."""
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("lxt_fast", "lxt_fast"))
+        ydim: hv.core.dimension.Dimension = hv.Dimension(
+            ("Normalized A", "Normalized A")
+        )
+
+        bin_centers: np.ndarray[np.float_] = (
+            self.lxt_fast_bin_edges[:-1] + self.lxt_fast_bin_edges[1:]
+        ) / 2
+
+        on_pts: hv.Points = hv.Points(
+            (bin_centers, on), kdims=[xdim, ydim], label="Laser on"
+        ).opts(size=5, color="blue")
+        on_curve: hv.Curve = hv.Curve((bin_centers, on), kdims=[xdim, ydim]).opts(
+            color="blue"
+        )
+        off_pts: hv.Points = hv.Points(
+            (bin_centers, off), kdims=[xdim, ydim], label="Laser off"
+        ).opts(size=5, color="orange")
+        off_curve: hv.Curve = hv.Curve((bin_centers, off), kdims=[xdim, ydim]).opts(
+            color="orange"
+        )
+        xas_plots: hv.Overlay = on_pts * on_curve * off_pts * off_curve
+
+        ydim = hv.Dimension(("diff A", "diff A"))
+        diff_pts: hv.Points = hv.Points(
+            (bin_centers, diff),
+            kdims=[xdim, ydim],
+            label="Laser on - Laser off",
+        ).opts(size=5, color="green")
+        diff_curve: hv.Curve = hv.Curve((bin_centers, diff), kdims=[xdim, ydim]).opts(
+            color="green"
+        )
+        diff_plot: hv.Overlay = diff_pts * diff_curve
+
+        grid: pn.GridSpec = pn.GridSpec(name="lxt_fast T0 scan")
+        grid[:2, :2] = xas_plots.opts(axiswise=True, shared_axes=False)
+        grid[:2, 2:4] = diff_plot.opts(axiswise=True, shared_axes=False)
+        tabs: pn.Tabs = pn.Tabs(grid)
+        return tabs
+
+    def plot_xas_power_titration_scan(self) -> pn.Tabs:
+        """Produce a plot of the lxe_opa power titration."""
+        on: np.ndarray[np.float_]
+        off: np.ndarray[np.float_]
+        diff: np.ndarray[np.float_]
+        on, off, diff = self.power_titration_binned_xas
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("lxe_opa", "lxe_opa"))
+        ydim: hv.core.dimension.Dimension = hv.Dimension(
+            ("Normalized A", "Normalized A")
+        )
+
+        on_pts: hv.Points = hv.Points(
+            (self.power_titration_bins, on), kdims=[xdim, ydim], label="Laser on"
+        ).opts(size=5, color="blue")
+        on_curve: hv.Curve = hv.Curve(
+            (self.power_titration_bins, on), kdims=[xdim, ydim]
+        ).opts(color="blue")
+        off_pts: hv.Points = hv.Points(
+            (self.power_titration_bins, off), kdims=[xdim, ydim], label="Laser off"
+        ).opts(size=5, color="orange")
+        off_curve: hv.Curve = hv.Curve(
+            (self.power_titration_bins, off), kdims=[xdim, ydim]
+        ).opts(color="orange")
+        xas_plots: hv.Overlay = on_pts * on_curve * off_pts * off_curve
+
+        ydim = hv.Dimension(("diff A", "diff A"))
+        diff_pts: hv.Points = hv.Points(
+            (self.power_titration_bins, diff),
+            kdims=[xdim, ydim],
+            label="Laser on - Laser off",
+        ).opts(size=5, color="green")
+        diff_curve: hv.Curve = hv.Curve(
+            (self.power_titration_bins, diff), kdims=[xdim, ydim]
+        ).opts(color="green")
+        diff_plot: hv.Overlay = diff_pts * diff_curve
+
+        grid: pn.GridSpec = pn.GridSpec(name="Power Titration")
+        grid[:2, :2] = xas_plots.opts(axiswise=True, shared_axes=False)
+        grid[:2, 2:4] = diff_plot.opts(axiswise=True, shared_axes=False)
+        tabs: pn.Tabs = pn.Tabs(grid)
+        return tabs
+
+    # XAS
+    ############################################################################
+    def _extract_xas(self, detname: str) -> None:
+        """Extract XAS specific data."""
+        self._xas_raw = self._smd_h5[f"{detname}/ROI_0_sum"][
+            self._start_idx : self._stop_idx
+        ]
+        self._ccm_E = self._smd_h5[self._task_parameters.ccm][
+            self._start_idx : self._stop_idx
+        ]
+        if self._task_parameters.ccm_set is not None:
+            try:
+                self._ccm_E_set_pt = self._smd_h5[self._task_parameters.ccm_set][
+                    self._start_idx : self._stop_idx
+                ]
+            except KeyError:
+                logger.error("No ccm_E_setpoint data. Will use fallback binning.")
+        self._element: Optional[str] = self._task_parameters.element
+
+    def _calc_binned_difference_xas(
+        self,
+    ) -> Tuple[np.ndarray[np.float], np.ndarray[np.float64], np.ndarray[np.float64]]:
+        filter_las_on: np.ndarray = self._aggregate_filters()
+        filter_las_off: np.ndarray = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+        norm: np.ndarray[np.float_] = self._calc_1d_water_norm()
+        if (norm < 0).any():
+            norm = self._xray_intensity
+        xas_norm: np.ndarray[np.float_] = self._xas_raw / norm
+
+        nbins: int
+        b_edges: np.ndarray[np.float_]
+        if self._ccm_E_set_pt is not None:
+            # nbins = len(self.ccm_E_set_pt)
+            nbins, b_edges = self._calc_ccm_bins_by_set_pt()
+        else:
+            nbins, b_edges = self._calc_ccm_bins_by_unique()
+
+        xas_laser_on: np.ndarray = np.zeros(nbins)
+        xas_laser_off: np.ndarray = np.zeros(nbins)
+        # bins are [lower, upper) except for last which is [lower, upper]
+        # _, b_edges = np.histogram(self.ccm_E_unique, bins=nbins)
+        bins: np.ndarray = np.zeros([nbins])
+        i: int = 0
+        while i < nbins:  # - win_size + 1
+            win = b_edges[i : i + 2]
+            bins[i] = win.mean()
+            i += 1
+
+        for i in range(nbins):
+            lower: int = b_edges[i]
+            upper: int = b_edges[i + 1]
+            # Prepare CCM_E bin
+            energy_filt: np.ndarray
+            if i == nbins - 1:
+                # upper edge inclusive bin
+                energy_filt = self._ccm_E <= upper
+            else:
+                energy_filt = self._ccm_E < upper
+            energy_filt &= self._ccm_E >= lower
+            full_filt_on = filter_las_on & energy_filt
+            full_filt_off = filter_las_off & energy_filt
+            xas_laser_on[i] = np.nanmean(xas_norm[full_filt_on])
+            xas_laser_off[i] = np.nanmean(xas_norm[full_filt_off])
+
+        return (
+            bins,
+            np.nan_to_num(xas_laser_on),
+            np.nan_to_num(xas_laser_off),
+            np.nan_to_num(xas_laser_on - xas_laser_off),
+        )
+
+    def _calc_power_titration_binned_xas(
+        self,
+    ) -> Tuple[np.ndarray[np.float_], np.ndarray[np.float_], np.ndarray[np.float_]]:
+        filter_las_on: np.ndarray = self._aggregate_filters()
+        filter_las_off: np.ndarray = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+        norm: np.ndarray[np.float_] = self._xray_intensity
+        normed_xas: np.ndarray[np.float_] = self._xas_raw / norm
+        normed_xas_las_on: np.ndarray[np.float_] = normed_xas[filter_las_on]
+        normed_xas_las_off: np.ndarray[np.float_] = normed_xas[filter_las_off]
+
+        scan_vals_las_on: np.ndarray[np.float_] = self._scan_values[filter_las_on]
+        scan_vals_las_off: np.ndarray[np.float_] = self._scan_values[filter_las_off]
+        bins: np.ndarray[np.float64] = self._calc_power_titration_bins()
+        binned_xas_las_on: np.ndarray[np.float_] = np.zeros(len(bins))
+        binned_xas_las_off: np.ndarray[np.float_] = np.zeros(len(bins))
+
+        for idx, scan_bin in enumerate(bins):
+            binned_xas_las_on[idx] = np.mean(
+                normed_xas_las_on[scan_vals_las_on == scan_bin]
+            )
+            binned_xas_las_off[idx] = np.mean(
+                normed_xas_las_off[scan_vals_las_off == scan_bin]
+            )
+
+        diff: np.ndarray[np.float_] = binned_xas_las_on - binned_xas_las_off
+        return (binned_xas_las_on, binned_xas_las_off, diff)
+
+    def _calc_t0_binned_xas(
+        self,
+    ) -> Tuple[np.ndarray[np.float_], np.ndarray[np.float_], np.ndarray[np.float_]]:
+        filter_las_on: np.ndarray = self.aggregate_filters()
+        filter_las_off: np.ndarray = self.aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+        norm: np.ndarray[np.float_] = self.xray_intensity
+        normed_xas: np.ndarray[np.float_] = self.xas_raw / norm
+        normed_xas_las_on: np.ndarray[np.float_] = normed_xas[filter_las_on]
+        normed_xas_las_off: np.ndarray[np.float_] = normed_xas[filter_las_off]
+
+        scan_vals_las_on: np.ndarray[np.float_] = self.scan_values[filter_las_on]
+        scan_vals_las_off: np.ndarray[np.float_] = self.scan_values[filter_las_off]
+        binned_xas_las_on: np.ndarray[np.float_] = np.zeros(
+            len(self.lxt_fast_bin_edges) - 1
+        )
+        binned_xas_las_off: np.ndarray[np.float_] = np.zeros(
+            len(self.lxt_fast_bin_edges) - 1
+        )
+
+        for idx, scan_bin_edge in enumerate(self.lxt_fast_bin_edges):
+            if idx == len(self.lxt_fast_bin_edges) - 1:
+                continue
+            mask_on: np.ndarray[np.float_] = (scan_vals_las_on >= scan_bin_edge) * (
+                scan_vals_las_on < self.lxt_fast_bin_edges[idx + 1]
+            )
+            mask_off: np.ndarray[np.float_] = (scan_vals_las_off >= scan_bin_edge) * (
+                scan_vals_las_off < self.lxt_fast_bin_edges[idx + 1]
+            )
+            binned_xas_las_on[idx] = np.mean(normed_xas_las_on[mask_on])
+            binned_xas_las_off[idx] = np.mean(normed_xas_las_off[mask_off])
+
+        diff: np.ndarray[np.float_] = binned_xas_las_on - binned_xas_las_off
+        return (binned_xas_las_on, binned_xas_las_off, diff)
+
+    # Binning
+    ############################################################################
+    def _calc_ccm_bins_by_set_pt(self) -> np.ndarray[np.float64]:
+        """Caculate bin edges based on the provided CCM_E set points."""
+        if self._ccm_E_set_pt is not None:
+            all_set_pts: np.ndarray[np.float64] = np.zeros(
+                np.sum(self._events_per_rank), dtype=np.float64
+            )
+            self._mpi_comm.Allgatherv(
+                self._ccm_E_set_pt,
+                [
+                    all_set_pts,
+                    self._events_per_rank,
+                    self._start_indices_per_rank,
+                    MPI.DOUBLE,
+                ],
+            )
+            bin_centers: np.ndarray[np.float64] = np.sort(np.unique(all_set_pts))
+            nbins: int = len(bin_centers)
+        else:
+            raise RuntimeError("Set points not provided/not found!")
+
+        edges: np.ndarray[np.float_] = np.empty(nbins + 1)
+        edges[1:-1] = (bin_centers[1:] + bin_centers[:-1]) / 2
+        # How to handle the ends?
+        # Lower bin inclusive, upper not (except last)
+        edges[0] = np.min(bin_centers)
+        edges[-1] = np.max(bin_centers)
+
+        return nbins, edges
+
+    def _calc_ccm_bins_by_unique(self, nbins: int = 50) -> np.ndarray[np.float64]:
+        """Calculate bin edges based on unique CCM_E recorded values.
+
+        Args:
+            nbins (int): Number of bins to create. 50-100 is empirically useful.
+
+        Returns:
+            nbins (int): Number of bins.
+
+            b_edges (np.ndarray[np.float64]): Bin edges.
+        """
+        all_ccm_values: np.ndarray[np.float64] = np.zeros(
+            np.sum(self._events_per_rank), dtype=np.float64
+        )
+        self._mpi_comm.Allgatherv(
+            self._ccm_E,
+            [
+                all_ccm_values,
+                self._events_per_rank,
+                self._start_indices_per_rank,
+                MPI.DOUBLE,
+            ],
+        )
+        unique: np.ndarray[np.float64] = np.unique(all_ccm_values)
+        del all_ccm_values
+        nbins = np.min([nbins, len(unique)])
+        b_edges = np.histogram_bin_edges(unique, bins=nbins)
+        return nbins, b_edges
+
+    def _calc_scan_bins(self, nbins: int = 51) -> np.ndarray[np.float64]:
+        """Calculate a set of scan bins.
+
+        Returns:
+            scan_bins (np.ndarray[np.float64]): 1D set of scan bins.
+        """
+        # Create a full set of scan values
+        all_scan_values: np.ndarray[np.float64] = np.zeros(
+            np.sum(self._events_per_rank), dtype=np.float64
+        )
+        self._mpi_comm.Allgatherv(
+            self._scan_values,
+            [
+                all_scan_values,
+                self._events_per_rank,
+                self._start_indices_per_rank,
+                MPI.DOUBLE,
+            ],
+        )
+        logger.debug("XSS Analysis: time_bins")
+        scan_bins: np.ndarray[np.float64]
+        if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
+            scan_bins = np.histogram_bin_edges(np.unique(all_scan_values))
+        else:
+            scan_bins = np.unique(all_scan_values)
+        return scan_bins

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -594,11 +594,22 @@ class AnalyzeSmallData(Task):
     def _calc_binned_difference_xas(
         self,
     ) -> Tuple[
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
+        Optional[np.ndarray[np.float64]],
+        Optional[np.ndarray[np.float64]],
+        Optional[np.ndarray[np.float64]],
+        Optional[np.ndarray[np.float64]],
     ]:
+        nbins: int
+        b_edges: np.ndarray[np.float64]
+        if self._ccm_E_set_pt is not None:
+            # nbins = len(self.ccm_E_set_pt)
+            nbins, b_edges = self._calc_ccm_bins_by_set_pt()
+        else:
+            nbins, b_edges = self._calc_ccm_bins_by_unique()
+
+        if nbins <= 2:
+            return None, None, None, None
+
         filter_las_on: np.ndarray = self._aggregate_filters()
         filter_las_off: np.ndarray = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
@@ -607,14 +618,6 @@ class AnalyzeSmallData(Task):
         if (norm < 0).any():
             norm = self._xray_intensity
         xas_norm: np.ndarray[np.float64] = self._xas_raw / norm
-
-        nbins: int
-        b_edges: np.ndarray[np.float64]
-        if self._ccm_E_set_pt is not None:
-            # nbins = len(self.ccm_E_set_pt)
-            nbins, b_edges = self._calc_ccm_bins_by_set_pt()
-        else:
-            nbins, b_edges = self._calc_ccm_bins_by_unique()
 
         xas_laser_on: np.ndarray = np.zeros(nbins)
         xas_laser_off: np.ndarray = np.zeros(nbins)

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -25,12 +25,18 @@ from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 
 from lute.execution.ipc import Message
+from lute.execution.logging import PipeCommunicatorHandler, STD_PYTHON_LOG_FORMAT
 from lute.io.models.base import TaskParameters
 from lute.tasks.task import *
 from lute.tasks.dataclasses import ElogSummaryPlots
 from lute.tasks.math import gaussian, sigma_to_fwhm
 
 logger: logging.Logger = logging.getLogger(__name__)
+handler: PipeCommunicatorHandler = PipeCommunicatorHandler()
+formatter: logging.Formatter = logging.Formatter(STD_PYTHON_LOG_FORMAT)
+handler.setFormatter(formatter)
+logger.handlers.clear()
+logger.addHandler(handler)
 
 if __debug__:
     logger.setLevel(logging.DEBUG)

--- a/lute/tasks/dataclasses.py
+++ b/lute/tasks/dataclasses.py
@@ -118,7 +118,6 @@ class ElogSummaryPlots:
             self.figures.save(f)
             f.seek(0)
             self.figures = f.read()
-            print(self.figures, flush=True)
 
 
 @dataclass

--- a/lute/tasks/math.py
+++ b/lute/tasks/math.py
@@ -1,0 +1,52 @@
+"""Utility math functions which can be shared between Tasks.
+
+Functions:
+    gaussian(x_vals, amp, x0, sigma, bkgnd): Calculate a 1D Gaussian distirbution.
+
+    sigma_to_fwhm(sigma): Convert the standard deviation of a Gaussian to Full
+        Width at Half Maximum (FWHM).
+"""
+
+__all__ = ["gaussian", "sigma_to_fwhm"]
+__author__ = "Gabriel Dorlhiac"
+
+import numpy as np
+
+
+def gaussian(
+    x_vals: np.ndarray[np.float64], amp: float, x0: float, sigma: float, bkgnd: float
+) -> np.ndarray[np.float64]:
+    """1D Gaussian distribution with specified parameters.
+
+    Args:
+        x_vals (np.ndarray[np.float64]): Values over which to calculate the
+            distribution.
+
+        amp (float): Amplitude of the distribution.
+
+        x0 (float): Center (mean) of the distribution
+
+        sigma (float): Standard deviation of the distribution.
+
+        bkgnd (float | np.ndarray[np.float64]): Background/noise. Constant
+            offset (float) or an array of offsets of the same length as `x_vals`.
+
+    Returns:
+        distribution (np.ndarray[np.float64]): Calculated Gaussian distribution
+            based on given parameters. Same shape as x_vals.
+    """
+    numerator = -((x_vals - x0) ** 2)
+    return amp * np.exp(numerator / (2 * sigma**2)) + bkgnd
+
+
+def sigma_to_fwhm(sigma: float) -> float:
+    """Convert the standard deviation of a Gaussian to Full Width Half Max.
+
+    Args:
+        sigma (float): Standard deviation of a Gaussian.
+
+    Returns:
+        fhwm (float): Full width at half max of a Gaussian.
+    """
+    constant: float = (8 * np.log(2)) ** 0.5
+    return sigma * constant

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -1,0 +1,845 @@
+"""Tasks for working with SmallData HDF5 files.
+
+Classes defined in this module provide an interface to extracting data from
+SmallData files and analyzing it.
+
+Classes:
+    AnalyzeSmallDataXSS(Task): Analyze scattering data for a single detector in
+        a SmallData file.
+"""
+
+__all__ = ["AnalyzeSmallDataXSS"]
+__author__ = "Gabriel Dorlhiac"
+
+import sys
+import logging
+from typing import List, Optional, Dict, Tuple, Union
+
+import h5py
+import holoviews as hv
+import numpy as np
+import panel as pn
+import matplotlib.pyplot as plt
+from mpi4py import MPI
+from scipy.signal import find_peaks
+from scipy.optimize import curve_fit
+
+from lute.execution.ipc import Message
+from lute.io.models.base import *
+from lute.tasks.task import *
+from lute.tasks.dataclasses import ElogSummaryPlots
+from lute.tasks.math import gaussian, sigma_to_fwhm
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+if __debug__:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+
+class AnalyzeSmallDataXSS(Task):
+    """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
+
+    _LARGE_DETNAMES: List[str] = ["epix10k2M", "Rayonix", "Jungfrau4M"]
+    _SMALL_DETNAMES: List[str] = ["epix_1", "epix_2"]
+
+    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+        super().__init__(params=params, use_mpi=use_mpi)
+        hv.extension("bokeh")
+        pn.extension()
+        self._mpi_comm: MPI.Intracomm = MPI.COMM_WORLD
+        self._mpi_rank: int = self._mpi_comm.Get_rank()
+        self._mpi_size: int = self._mpi_comm.Get_size()
+        try:
+            self._smd_h5: h5py.File = h5py.File(self._task_parameters.smd_path, "r")
+        except Exception:
+            if self._mpi_rank == 0:
+                logger.debug(f"Failed to open file: {self._task_parameters.smd_path}!")
+            self._mpi_comm.Barrier()
+            sys.exit(-1)
+
+        self._events_per_rank: np.ndarray[np.int]
+        self._start_indices_per_rank: np.ndarray[np.int]
+        if self._mpi_rank == 0:
+            self._total_num_events: int = len(self._smd_h5["event_time"][()])
+            quotient: int
+            remainder: int
+            quotient, remainder = divmod(self._total_num_events, self._mpi_size)
+            self._events_per_rank = np.array(
+                [
+                    quotient + 1 if rank < remainder else quotient
+                    for rank in range(self._mpi_size)
+                ]
+            )
+            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+            self._start_indices_per_rank[1:] = np.cumsum(self._events_per_rank[:-1])
+        else:
+            self._events_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
+        self._mpi_comm.Bcast(self._events_per_rank, root=0)
+        self._mpi_comm.Bcast(self._start_indices_per_rank, root=0)
+        self._xss_detname: str
+        if self._task_parameters.xss_detname is None:
+            for key in self._smd_h5.keys():
+                if key in AnalyzeSmallData._LARGE_DETNAMES:
+                    self._xss_detname = key
+                    logger.debug(f"Assuming XSS detector is: {key}.")
+                    break
+            else:
+                logger.error("No XSS detname provided and could not determine detname!")
+                self._mpi_comm.Barrier()
+                sys.exit(-1)
+        else:
+            self._xss_detname = self._task_parameters.xss_detname
+
+        # Basic RANK-LOCAL variables - Each rank holds a subset of data
+        ################################################################
+        self._num_events: int = self._events_per_rank[self._mpi_rank]
+        self._start_idx: int = self._start_indices_per_rank[self._mpi_rank]
+        self._stop_idx: int = self._start_idx + self._num_events
+        logger.debug(
+            f"Rank {self._mpi_rank}: Processing {self._num_events} events from "
+            f"event {self._start_idx}."
+        )
+
+        # Generic filtering variables
+        self._filter_dict: Dict[str, np.ndarray[np.float64]] = {}
+
+        # Azimuthal integration variables
+        self._az_int: np.ndarray[np.float64, np.float64, np.float64]
+        self._q_vals: np.ndarray[np.float64]
+        self._phi_vals: np.ndarray[np.float64]
+        self._integrated_intensity: np.ndarray[np.float64]
+        self._xray_intensity: np.ndarray[np.float64]
+
+        # Scan vars
+        self._scan_var_name: Optional[str] = None
+        self._scan_values: np.ndarray[np.float64]
+
+    def _pre_run(self) -> None:
+        self._extract_data()
+
+    def _run(self) -> None:
+        diff: np.ndarray[np.float64]
+        bins: np.ndarray[np.float64]
+        bins, diff, laser_on = self._calc_binned_difference_xss()
+
+        def sum_diff(
+            diff0: np.ndarray[np.float64], diff1: np.ndarray[np.float64]
+        ) -> np.ndarray[np.float64]:
+            return diff0 + diff1
+
+        def laser_on_mean(
+            laser_on0: np.ndarray[np.float64], laser_on1: np.ndarray[np.float64]
+        ) -> np.ndarray[np.float64]:
+            return laser_on0.sum(axis=0) + laser_on1.sum(axis=0)
+
+        if self._mpi_size > 1:
+            diff = self._mpi_comm.reduce(diff, op=sum_diff)
+            laser_on = self._mpi_comm.reduce(laser_on, op=laser_on_mean)
+        else:
+            laser_on = np.nansum(laser_on, axis=0)
+
+        if self._mpi_rank == 0:
+            diff /= self._mpi_size
+            laser_on /= self._total_num_events
+            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+            plots: pn.Tabs = self.plot_all(laser_on, bins, diff, name)
+            plot_display_name: str
+            run: int = int(self._task_parameters.lute_config.run)
+            exp_run: str = f"{run:04d}_{name}_XSS"
+            if "lens" in name:
+                plot_display_name = f"lens_scans/{exp_run}"
+            else:
+                plot_display_name = f"time_scans/{exp_run}"
+
+            self._result.payload = ElogSummaryPlots(plot_display_name, plots)
+
+    def _post_run(self) -> None: ...
+
+    # Azimuthal integration data
+    # Extracts: azav (2D), q_values (1D), phi values (1D)
+    ############################################################################
+    def _extract_data(self) -> None:
+        """Setup up stored attributes by taking data from the smalldata hdf5 file."""
+
+        logger.debug("XSS Analysis: extract_data")
+
+        self._extract_az_int()
+        try:
+            self._xray_intensity = self._smd_h5[self._task_parameters.ipm_var][
+                self._start_idx : self._stop_idx
+            ]
+        except KeyError as e:
+            logger.error("ipm data not found! Check config!")
+        self._integrated_intensity = np.nansum(self._az_int, axis=(1, 2))
+        self._setup_std_filters()
+
+        if isinstance(self._task_parameters.scan_var, str):
+            scan_var: str = self._task_parameters.scan_var
+            try:
+                self._scan_values = self._smd_h5[f"scan/{scan_var}"][
+                    self._start_idx : self._stop_idx
+                ]
+                self._scan_var_name = scan_var
+            except KeyError as e:
+                logger.debug(f"Scan variable {scan_var} not found!")
+        elif isinstance(self._task_parameters.scan_var, list):
+            for scan_var in self._task_parameters.scan_var:
+                try:
+                    self._scan_values = self._smd_h5[f"scan/{scan_var}"][
+                        self._start_idx : self._stop_idx
+                    ]
+                    self._scan_var_name = scan_var
+                    break
+                except KeyError as e:
+                    logger.debug(f"Scan variable {scan_var} not found!")
+                    continue
+        if not hasattr(self, "_scan_values"):
+            # Create a set of scan values if none of the above scan
+            # variables are found, either lxt_fast or linear set.
+            try:
+                self._scan_values = self._smd_h5["enc/lasDelay"][
+                    self._start_idx : self._stop_idx
+                ]
+                self._scan_var_name = "lxt_fast"
+                logger.debug("Using scan variable lxt_fast")
+            except KeyError as e:
+                logger.debug("Scan variable lxt_fast not found!")
+                self._scan_values = np.linspace(
+                    self._start_idx, self._stop_idx, self._num_events
+                )
+                logger.debug(
+                    "No scans found, using linearly spaced data for _scan_values."
+                )
+
+    def _extract_az_int(self) -> None:
+        """Try to extract the azimuthal integration data from HDF5 file.
+
+        This internal method will search first to see if a detector has been
+        provided as the scattering detector. If not, it will attempt to guess
+        which detector to use. It will attempt to extract both the internal
+        integration data and PyFAI integrated data (which have different
+        interfaces). If both are present, it will only extract PyFAI data.
+        """
+        detname: str = self._xss_detname
+        try:
+            self._extract_az_int_smd_internal(detname)
+            logger.debug(
+                f"Extracted internal azimuthal integration data for {detname}."
+            )
+        except Exception:
+            try:
+                self._extract_az_int_pyfai(detname)
+                logger.debug(
+                    f"Extracted PyFAI azimuthal integration data for {detname}."
+                )
+            except Exception:
+                logger.error("No azimuthal integration data found.")
+                self._mpi_comm.Barrier()
+                sys.exit(-1)
+
+    def _extract_az_int_smd_internal(self, detname: str) -> None:
+        """Extract stored data from SmallData's azimuthal integration algorithm.
+
+        Args:
+            detname (str): The detector name to extract data for.
+        """
+
+        self._az_int = self._smd_h5[f"{detname}/azav_azav"][
+            self._start_idx : self._stop_idx
+        ]  # 3D
+        self._q_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_q"][()]
+        self._phi_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_phiVec"][()]
+
+    def _extract_az_int_pyfai(self, detname: str) -> None:
+        """Extract stored data from PyFAI's azimuthal integration algorithm.
+
+        Args:
+            detname (str): The detector name to extract data for.
+        """
+
+        self._az_int = self._smd_h5[f"{detname}/pyfai_azav"][
+            self._start_idx : self._stop_idx
+        ]  # 3D
+        self._q_vals = self._smd_h5[f"{detname}/pyfai_q"][()][0]
+        self._phi_vals = self._smd_h5[f"{detname}/pyfai_az"][()][0]
+
+    def _setup_std_filters(self) -> None:
+        """Setup the individual standard event filters.
+
+        Sets up light status (X-ray and laser) filters, and adjustable filters
+        based on, e.g., thresholds.
+        """
+        # For filtering based on event type
+        self._filter_dict["xray on"] = (
+            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 1
+        )
+        self._filter_dict["laser on"] = (
+            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 1
+        )
+
+        self._filter_dict["xray off"] = (
+            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 0
+        )
+        self._filter_dict["laser off"] = (
+            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 0
+        )
+
+        # Create scattering and ipm thresholds for first time
+        self._update_filters()
+
+    def _update_filters(self) -> None:
+        """Update stored event filters that are based on adjustable parameters.
+
+        E.g. update the minimum scattering intensity to use in analyses.
+        """
+        scattering_thresh: float = self._task_parameters.thresholds.min_Iscat
+        ipm_thresh: float = self._task_parameters.thresholds.min_ipm
+        self._filter_dict["total scattering"] = (
+            self._integrated_intensity > scattering_thresh
+        )
+        if hasattr(self, "_xray_intensity"):
+            self._filter_dict["ipm"] = self._xray_intensity > ipm_thresh
+        else:
+            self._filter_dict["ipm"] = np.ones([self._num_events], dtype=bool)
+
+    def _calc_norm_by_qrange(
+        self, q_limits: Tuple[float, float] = (0.9, 3.5)
+    ) -> np.ndarray[np.float64]:
+        """Calculate a normalization factor by averaging over a range of Q values.
+
+        Args:
+            q_limits (Tuple[float, float]): The lower and upper limit of the
+                Q-range to average.
+
+        Returns:
+            norm (np.ndarray[np.float64]): The 2D norm with shape
+                (num_events, num_phi)
+        """
+        norm_range: np.array = self._q_vals > q_limits[0]
+        norm_range &= self._q_vals < q_limits[1]
+        return np.nanmean(self._az_int[..., norm_range], axis=-1)
+
+    def _calc_norm_by_max(self) -> np.ndarray[np.float64]:
+        """Calculate a normalization factor by taking the maximum of each profile.
+
+        Returns:
+        norm (np.ndarray[np.float64]): The 1D norm with shape (num_events)
+        """
+        return np.nanmax(self._az_int, axis=(1, 2))
+
+    def _aggregate_filters(
+        self, filter_vars: str = ("xray on, laser on, total scattering, ipm")
+    ) -> np.ndarray[np.bool_]:
+        """Combine a number of possible data filters.
+
+        Takes a string of filters to be applied in the order specified. The
+        order matters for some filters, e.g. if "percentage" is selected it
+        should be applied after total scattering. See below for a list of
+        filters.
+
+        Possible filters:
+            "xray on": Take shots where X-rays are on,
+            "xray off": Take shots where X-rays are off,
+            "laser on": Take shots where laser is on,
+            "laser off": Take shots where laser is off,
+            "ipm": Take shots with X-ray intensity above a value (ipm value),
+            "total scattering": Take shots with minimum integrated scattering,
+            "percentage": Extract this percentage of data centered on the max
+                scattering intensity. Should be applied after total scatteirng.
+                E.g. Include 50% of shots centered around the Q-value with
+                maximum scattering.
+
+        Args:
+            filter_vars (str): A string of comma-seperated filters to apply,
+                taken from the list above. E.g. "xray on, laser on".
+
+        Returns:
+            total_filter (np.ndarray[np.bool]): A 1D boolean array with a shape
+                of (num_events) which can be used to index and filter a data array.
+        """
+        logger.debug("XSS Analysis: aggregate_filters")
+        filters: List[str] = [f.strip() for f in filter_vars.split(",")]
+        total_filter: np.ndarray = np.ones([self._num_events], dtype=bool)
+
+        for data_filter in filters:
+            logger.debug(f"Filter: {data_filter}")
+            try:
+                total_filter &= self._filter_dict[data_filter]
+            except KeyError as e:
+                logger.debug(
+                    f"Unrecognized filter requested: {data_filter}. "
+                    "Ignoring and continuing processing."
+                )
+                continue
+
+        return total_filter
+
+    def _calc_dark_mean(
+        self, profiles: np.ndarray[np.float64]
+    ) -> np.ndarray[np.float64]:
+        """Calculate the dark (X-ray off) mean of a set of XSS profiles.
+
+        Args:
+            profiles (np.ndarray[np.float64]): Set of profiles to calculate the
+                dark mean from. Shape: (n_events, q_bins)
+        Returns:
+            dark_mean (np.ndarray[np.float64]): The calculated dark mean.
+                Shape: (q_bins)
+        """
+        dark_mean: np.ndarray[np.float64]
+        try:
+            dark_mean = np.nanmean(profiles[self._filter_dict["xray off"]], axis=0)
+            dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
+            dark_mean /= self._mpi_size
+        except KeyError:
+            logger.debug(
+                "No X-ray off event information for filtering. "
+                "Dark mean will be all zeros."
+            )
+            dark_mean = np.zeros([self._num_events])
+        return dark_mean
+
+    def _calc_scan_bins(self) -> np.ndarray[np.float64]:
+        """Calculate a set of scan bins.
+
+        Returns:
+            scan_bins (np.ndarray[np.float64]): 1D set of scan bins.
+        """
+        # Create a full set of scan values
+        self._all_scan_values: np.ndarray[np.float64] = np.zeros(
+            np.sum(self._events_per_rank), dtype=np.float64
+        )
+        self._mpi_comm.Gatherv(
+            self._scan_values,
+            [
+                self._all_scan_values,
+                self._events_per_rank,
+                self._start_indices_per_rank,
+                MPI.DOUBLE,
+            ],
+            root=0,
+        )
+        logger.debug("XSS Analysis: time_bins")
+        scan_bins: np.ndarray[np.float64]
+        if self._mpi_rank == 0:
+            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
+                nbins: int = 70  # 200
+                _, edges = np.histogram(np.unique(self._all_scan_values), bins=nbins)
+                scan_bins = edges
+            else:
+                scan_bins = np.unique(self._all_scan_values)
+        else:
+            scan_bins = None
+        scan_bins = self._mpi_comm.bcast(scan_bins, root=0)
+        return scan_bins
+
+    def _calc_binned_difference_xss(
+        self,
+    ) -> Tuple[np.ndarray[np.float], np.ndarray[np.float64], np.ndarray[np.float64]]:
+        """Calculate the binned difference.
+
+        Calculates the 1D difference scattering for each bin of a scan variable.
+        Final difference shape is 2D: (q_bins, scan_bins). Also returns bins and
+        the laser on profiles.
+
+        Returns:
+            bins (np.ndarray[np.float64]): 1D array of scan bins used.
+
+            diff (np.ndarray[np.float64]): 2D binned difference scattering of shape
+                (q_bins, scan_bins)
+
+            laser_on (np.ndarray[np.float64]): 2D laser on scattering profiles
+                of shape (n_events_las_on, q_bins)
+        """
+        logger.debug("XSS Analysis: profiles_1d")
+        profiles: np.ndarray[np.float64, np.float64] = np.nansum(self._az_int, axis=1)
+        dark_mean: np.ndarray[np.float64] = self._calc_dark_mean(profiles)
+        if len(np.unique(dark_mean)) > 1:
+            # Can be len == 1 if all nan
+            profiles -= dark_mean
+        norm: np.ndarray[np.float64] = self._calc_norm_by_qrange()
+        profiles = (profiles.T / np.nanmean(norm, axis=-1).T).T
+        del dark_mean
+        del norm
+
+        filter_las_on: np.ndarray[np.float64] = self._aggregate_filters()
+        filter_las_off: np.ndarray[np.float64] = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+
+        bins: np.ndarray[np.float64] = self._calc_scan_bins()
+        binned_on: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        binned_off: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        scanvals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
+        scanvals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
+
+        idx: int
+        scan_bin: float
+        for idx, scan_bin in enumerate(bins):
+            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
+                if idx == len(bins) - 1:
+                    continue
+                mask_on: np.ndarray[np.bool_] = (scanvals_las_on >= scan_bin) * (
+                    scanvals_las_on < bins[idx + 1]
+                )
+                mask_off: np.ndarray[np.bool_] = (scanvals_las_off >= scan_bin) * (
+                    scanvals_las_off < bins[idx + 1]
+                )
+                binned_on[:, idx] = np.nanmean(profiles[filter_las_on][mask_on], axis=0)
+                binned_off[:, idx] = np.nanmean(
+                    profiles[filter_las_off][mask_off], axis=0
+                )
+            else:
+                binned_on[:, idx] = np.nanmean(
+                    profiles[filter_las_on][(scanvals_las_on == scan_bin)], axis=0
+                )
+                binned_off[:, idx] = np.nanmean(
+                    profiles[filter_las_off][(scanvals_las_off == scan_bin)], axis=0
+                )
+        diff: np.ndarray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
+            binned_off
+        )
+        return bins, diff, profiles[filter_las_on]
+
+    def _find_solvent_argmax(self, corrected_profile: np.ndarray) -> int:
+        """Find the index of the solvent ring maximum.
+
+        Currently just a hack around SciPy find_peaks.
+
+        Args:
+            corrected_profile (np.ndarray[np.float64]): 1D normalized and dark
+                mean corrected, laser on, scattering profile.
+
+        Returns:
+            peak_idx (int): The index where the solvent maximum is located.
+        """
+        res: Tuple[np.ndarray, Dict[str, np.ndarray]] = find_peaks(corrected_profile, 1)
+        try:
+            peak_indices: np.ndarray = res[0]
+            peak_heights: np.ndarray = res[1]["peak_heights"]
+        except KeyError as e:
+            logger.debug("No peaks found")
+            return np.argmax(corrected_profile)
+
+        peak_idx: int = peak_indices[
+            np.argmax(peak_heights)
+        ]  # peak_indices[0]  # peak_indices[peak_select - 1]
+        self._solvent_peak_idx = peak_idx
+        return peak_idx
+
+    def _fit_overlap(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        guess: Optional[List[float]] = None,
+    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]:
+        """Fit overlap based on scattering difference signal to a Gaussian.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            guess (Optional[List[float]]): A list of initial parameter guesses
+                for Gaussian fit in the order (amplitude, x0, sigma, background
+                offset)
+
+        Returns:
+            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+                Q value used for calculating the overlap.
+
+            opt (np.ndarray[np.float64]): Optimized parameters.
+
+            res (np.ndarray[np.float64]): Covariances.
+        """
+        logger.debug("XSS Analysis: fit_overlap")
+        Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]
+        max_pt: int = self._find_solvent_argmax(laser_on)
+        try:
+            idx_peak_q: int = max_pt + 10
+        except IndexError as e:
+            logger.debug(f"{e}: No non-nan values found.")
+            idx_peak_q: int = 15
+
+        raw_curve: np.ndarray = diff[idx_peak_q]
+        if not guess:
+            max_val: int = raw_curve.max()
+            min_val: int = raw_curve.min()
+            # guess = [amplitude, center, stddev, bkgnd]
+            guess = [0, 0, 0, 0]
+            x0: float
+            if max_val > np.abs(min_val):
+                x0 = bins[raw_curve.argmax()]
+                guess[0] = max_val
+            else:
+                x0 = bins[raw_curve.argmin()]
+                guess[0] = min_val
+            guess[1] = x0
+            guess[2] = np.abs(bins[-1] - bins[0]) / 20
+            guess[3] = np.min(raw_curve)
+        try:
+            opt, res = curve_fit(gaussian, bins, raw_curve, p0=guess, maxfev=999999)
+        except ValueError as e:
+            logger.debug(f"{e}:\n No non-nan values...")
+            opt = guess
+            res = None
+
+        return raw_curve, opt, res
+
+    def _fit_convolution_fwhm(
+        self, trace: np.ndarray, bins: np.ndarray[np.float_]
+    ) -> float:
+        """Calculate the FWHM of a convolution signal.
+
+        Args:
+            trace (np.ndarray[np.float64]): 1D convolution trace.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used.
+
+        Returns:
+            fwhm (float): Calculated FWHM.
+        """
+        from scipy.interpolate import UnivariateSpline
+
+        x = np.linspace(0, len(trace) - 1, len(trace))
+        spline = UnivariateSpline(x, (trace - np.max(trace) / 2), s=0)
+        roots = spline.roots()
+        if len(roots) == 2:
+            lb, rb = roots
+            fwhm = rb - lb
+        else:
+            # bins: np.ndarray = self.time_bins[0]
+            max_val: int = trace.max()
+            min_val: int = trace.min()
+            # guess = [amplitude, center, stddev, bkgnd]
+            guess: List[Union[float, int]] = [0, 0, 0, 0]
+            x0: Union[float, int]
+            if max_val > np.abs(min_val):
+                x0 = bins[trace.argmax()]
+                guess[0] = max_val
+            else:
+                x0 = bins[trace.argmin()]
+                guess[0] = min_val
+            guess[1] = x0
+            guess[2] = np.abs(bins[-1] - bins[0]) / 20
+            guess[3] = np.min(trace)
+            opt, res = curve_fit(
+                gaussian, bins, np.nan_to_num(trace), p0=guess, maxfev=999999
+            )
+            fwhm = sigma_to_fwhm(opt[2])
+        return fwhm
+
+    def _convolution_fit(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> Tuple[np.ndarray, np.ndarray, int, float]:
+        """Fits a time scan through convolution with Heaviside kernel.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+        Returns:
+            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+                Q value used for calculating the overlap.
+
+            trace (np.ndarray[np.float64]): 1D convolution trace.
+
+            center (int): The index of the center from the convolution.
+
+            fwhm (float): Width of the convlution signal (fwhm).
+        """
+        from scipy.signal import fftconvolve
+
+        logger.debug("XSS Analysis: convolution_fit")
+        results: List[Tuple] = []
+        max_pt: int = self._find_solvent_argmax(laser_on)
+        raw_curve: np.ndarray = np.nan_to_num(diff[max_pt + 10])
+        npts: int = len(raw_curve)
+        kernel: np.ndarray = np.zeros([npts])
+        kernel[: npts // 2] = 1
+        trace: np.ndarray = fftconvolve(raw_curve, kernel, mode="same")
+        center: int = trace.argmax()
+        fwhm: float = self._fit_convolution_fwhm(trace, bins)
+        return raw_curve, trace, center, fwhm
+
+    def plot_avg_xss(
+        self,
+        laser_on: np.ndarray[np.float64],
+        q_vals: np.ndarray[np.float64],
+        phis: np.ndarray[np.float64],
+    ) -> plt.Figure: ...
+
+    def plot_difference_hv(
+        self,
+        bins: np.ndarray[np.float64],
+        q_vals: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        scan_var_name: str,
+    ) -> pn.GridSpec:
+        """Plot the binned difference scattering.
+
+        Args:
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            q_vals (np.ndarray[np.float64]): 1D set of Q bins.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            scan_var_name (str): Name of the scan variable (for titles, etc.).
+
+        Returns:
+            plot (pn.GridSpec): Plotted binned difference.
+        """
+        grid: pn.GridSpec = pn.GridSpec(name="Difference Profiles")
+        xdim: hv.core.dimension.Dimension = hv.Dimension(
+            ("scan_var", f"Scan Var {scan_var_name}")
+        )
+        ydim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
+        diff_img: hv.Image = hv.Image(
+            (bins, q_vals, diff.T),
+            kdims=[xdim, ydim],
+        ).opts(shared_axes=False)
+        contours = diff_img + hv.operation.contours(diff_img, levels=5)
+        contours.opts(
+            hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
+        ).opts(shared_axes=False)
+        grid[:2, :2] = contours
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", f"Q"))
+        ydim: hv.core.dimension.Dimension = hv.Dimension(("dS", "dS"))
+        diff_curves: hv.Overlay
+        # diff_curves = hv.Curve((q_vals, diff[:, 0]))
+        # for i, _ in enumerate(bins):
+        #    if i == 0:
+        #        continue
+        #    else:
+        #        diff_curves *= hv.Curve(
+        #            (
+        #                q_vals,
+        #                diff[:, i],
+        #            )
+        #        ).opts(xlabel=xdim.label, ylabel=ydim.label)
+
+        # grid[2:4, :] = diff_curves.opts(shared_axes=False)
+        return grid
+
+    def plot_overlap_fit(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+    ) -> plt.Figure:
+        """Plot the overlap fit to a slice of the binned difference.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+        Returns:
+            plot (plt.Figure): Plotted overlap fit.
+        """
+        logger.debug("XSS Analysis: plot_overlap_fit")
+        fig, ax = plt.subplots(1, 1, figsize=(6, 3), dpi=200)
+        if self._scan_var_name is not None and "lxt" in self._scan_var_name:
+            raw_curve: np.ndarray[np.float64]
+            trace: np.ndarray[np.float64]
+            center: int
+            fwhm: float
+            raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
+            msg: str = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {bins[center]}\n"
+                f"FWHM: {fwhm}"
+            )
+            logger.info(msg)
+            ax.plot(bins, raw_curve, label="Raw")
+            ax2 = ax.twinx()
+            ax2.plot(bins, trace, color="orange", label="Convolution")
+            ax.set_title(msg)
+            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
+            ax.set_ylabel(r"$\Delta$S")
+            plt.legend(loc=0, frameon=False)
+        else:
+            raw_curve: np.ndarray[np.float64]
+            opt: np.ndarray[np.float64]
+            raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
+            msg: str = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {opt[1]}\n"
+                f"FWHM: {sigma_to_fwhm(opt[2])}"
+            )
+            logger.info(msg)
+            ax.plot(bins, raw_curve)
+            ax.plot(bins, gaussian(bins, *opt))
+            ax.set_title(msg)
+            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
+            ax.set_ylabel(r"$\Delta$S")
+        fig.tight_layout()
+        return fig
+
+    def plot_all(
+        self,
+        laser_on: np.ndarray[np.float64],
+        bins: np.ndarray[np.float64],
+        diff: np.ndarray[np.float64],
+        scan_var_name: str,
+    ) -> pn.Tabs:
+        """Plot all relevant plots.
+
+        Args:
+            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (np.ndarray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+            scan_var_name (str): Name of the scan variable (for titles, etc.).
+
+        Returns:
+            plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
+        """
+        logger.debug("XSS Analysis: plot_all")
+        # avg_fig = self.plot_avg_xss()
+        overlap_fig = self.plot_overlap_fit(laser_on, bins, diff)
+
+        # avg_grid = pn.GridSpec(name="TR X-ray Scattering")
+        # avg_grid[:2, :2] = avg_fig
+
+        diff_grid = self.plot_difference_hv(laser_on, bins, diff, scan_var_name)
+        overlap_grid = pn.GridSpec(name="Overlap Fit")
+        overlap_grid[:2, :2] = overlap_fig
+
+        tabbed_display = pn.Tabs(diff_grid)
+        tabbed_display.append(overlap_grid)
+        # tabbed_display.append(avg_grid)
+
+        return tabbed_display

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -108,7 +108,10 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
         laser_off: np.ndarray[np.float64]
         ccm_bins, diff, laser_on, laser_off = self._calc_binned_difference_xas()
 
-        if self._mpi_size > 1:
+        # We check None on ccm_bins because the monochromator is not always
+        # scanned -> We return None if there aren't enough bins to be worth
+        # plotting
+        if self._mpi_size > 1 and ccm_bins is not None:
             diff = self._mpi_comm.reduce(diff, op=MPI.SUM)
             laser_on = self._mpi_comm.reduce(laser_on, op=MPI.SUM)
             laser_off = self._mpi_comm.reduce(laser_off, op=MPI.SUM)
@@ -121,7 +124,8 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
             run = 0
         plot_display_name: str
         exp_run: str
-        if self._mpi_rank == 0:
+        if self._mpi_rank == 0 and ccm_bins is not None:
+            # Check None again
             diff /= self._mpi_size
             laser_on /= self._mpi_size
             laser_off /= self._mpi_size

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -9,6 +9,9 @@ Classes:
 
     AnalyzeSmallDataXAS(Task): Analyze absorption data for a single detector in
         a SmallData file.
+
+    AnalyzeSmallDataXES(Task): Analyze emission data for a single detector in
+        a SmallData file.
 """
 
 __all__ = ["AnalyzeSmallDataXSS", "AnalyzeSmallDataXAS", "AnalyzeSmallDataXES"]

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -6,9 +6,12 @@ SmallData files and analyzing it.
 Classes:
     AnalyzeSmallDataXSS(Task): Analyze scattering data for a single detector in
         a SmallData file.
+
+    AnalyzeSmallDataXAS(Task): Analyze absorption data for a single detector in
+        a SmallData file.
 """
 
-__all__ = ["AnalyzeSmallDataXSS"]
+__all__ = ["AnalyzeSmallDataXSS", "AnalyzeSmallDataXAS"]
 __author__ = "Gabriel Dorlhiac"
 
 import sys
@@ -25,10 +28,11 @@ from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 
 from lute.execution.ipc import Message
-from lute.io.models.base import *
+from lute.io.models.base import TaskParameters
 from lute.tasks.task import *
 from lute.tasks.dataclasses import ElogSummaryPlots
 from lute.tasks.math import gaussian, sigma_to_fwhm
+from lute.tasks._smalldata import AnalyzeSmallData
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -39,91 +43,21 @@ else:
     logger.setLevel(logging.INFO)
 
 
-class AnalyzeSmallDataXSS(Task):
+class AnalyzeSmallDataXSS(AnalyzeSmallData):
     """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
-
-    _LARGE_DETNAMES: List[str] = ["epix10k2M", "Rayonix", "Jungfrau4M"]
-    _SMALL_DETNAMES: List[str] = ["epix_1", "epix_2"]
 
     def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
-        hv.extension("bokeh")
-        pn.extension()
-        self._mpi_comm: MPI.Intracomm = MPI.COMM_WORLD
-        self._mpi_rank: int = self._mpi_comm.Get_rank()
-        self._mpi_size: int = self._mpi_comm.Get_size()
-        try:
-            self._smd_h5: h5py.File = h5py.File(self._task_parameters.smd_path, "r")
-        except Exception:
-            if self._mpi_rank == 0:
-                logger.debug(f"Failed to open file: {self._task_parameters.smd_path}!")
-            self._mpi_comm.Barrier()
-            sys.exit(-1)
-
-        self._events_per_rank: np.ndarray[np.int]
-        self._start_indices_per_rank: np.ndarray[np.int]
-        if self._mpi_rank == 0:
-            self._total_num_events: int = len(self._smd_h5["event_time"][()])
-            quotient: int
-            remainder: int
-            quotient, remainder = divmod(self._total_num_events, self._mpi_size)
-            self._events_per_rank = np.array(
-                [
-                    quotient + 1 if rank < remainder else quotient
-                    for rank in range(self._mpi_size)
-                ]
-            )
-            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
-            self._start_indices_per_rank[1:] = np.cumsum(self._events_per_rank[:-1])
-        else:
-            self._events_per_rank = np.zeros(self._mpi_size, dtype=np.int)
-            self._start_indices_per_rank = np.zeros(self._mpi_size, dtype=np.int)
-        self._mpi_comm.Bcast(self._events_per_rank, root=0)
-        self._mpi_comm.Bcast(self._start_indices_per_rank, root=0)
-        self._xss_detname: str
-        if self._task_parameters.xss_detname is None:
-            for key in self._smd_h5.keys():
-                if key in AnalyzeSmallData._LARGE_DETNAMES:
-                    self._xss_detname = key
-                    logger.debug(f"Assuming XSS detector is: {key}.")
-                    break
-            else:
-                logger.error("No XSS detname provided and could not determine detname!")
-                self._mpi_comm.Barrier()
-                sys.exit(-1)
-        else:
-            self._xss_detname = self._task_parameters.xss_detname
-
-        # Basic RANK-LOCAL variables - Each rank holds a subset of data
-        ################################################################
-        self._num_events: int = self._events_per_rank[self._mpi_rank]
-        self._start_idx: int = self._start_indices_per_rank[self._mpi_rank]
-        self._stop_idx: int = self._start_idx + self._num_events
-        logger.debug(
-            f"Rank {self._mpi_rank}: Processing {self._num_events} events from "
-            f"event {self._start_idx}."
-        )
-
-        # Generic filtering variables
-        self._filter_dict: Dict[str, np.ndarray[np.float64]] = {}
-
-        # Azimuthal integration variables
-        self._az_int: np.ndarray[np.float64, np.float64, np.float64]
-        self._q_vals: np.ndarray[np.float64]
-        self._phi_vals: np.ndarray[np.float64]
-        self._integrated_intensity: np.ndarray[np.float64]
-        self._xray_intensity: np.ndarray[np.float64]
-
-        # Scan vars
-        self._scan_var_name: Optional[str] = None
-        self._scan_values: np.ndarray[np.float64]
 
     def _pre_run(self) -> None:
-        self._extract_data()
+        # Currently scattering data is extracted as standard since its used
+        # for all analysis types (XSS, XAS, XES,...)
+        self._extract_standard_data()
 
     def _run(self) -> None:
         diff: np.ndarray[np.float64]
         bins: np.ndarray[np.float64]
+        laser_on: np.ndarray[np.float64]
         bins, diff, laser_on = self._calc_binned_difference_xss()
 
         def sum_diff(
@@ -146,9 +80,13 @@ class AnalyzeSmallDataXSS(Task):
             diff /= self._mpi_size
             laser_on /= self._total_num_events
             name: str = self._scan_var_name if self._scan_var_name else "By_Event"
-            plots: pn.Tabs = self.plot_all(laser_on, bins, diff, name)
+            plots: pn.Tabs = self.plot_all_xss(laser_on, bins, diff, name)
             plot_display_name: str
-            run: int = int(self._task_parameters.lute_config.run)
+            run: int
+            try:
+                run = int(self._task_parameters.lute_config.run)
+            except ValueError:
+                run = 0
             exp_run: str = f"{run:04d}_{name}_XSS"
             if "lens" in name:
                 plot_display_name = f"lens_scans/{exp_run}"
@@ -157,689 +95,53 @@ class AnalyzeSmallDataXSS(Task):
 
             self._result.payload = ElogSummaryPlots(plot_display_name, plots)
 
-    def _post_run(self) -> None: ...
 
-    # Azimuthal integration data
-    # Extracts: azav (2D), q_values (1D), phi values (1D)
-    ############################################################################
-    def _extract_data(self) -> None:
-        """Setup up stored attributes by taking data from the smalldata hdf5 file."""
+class AnalyzeSmallDataXAS(AnalyzeSmallData):
+    """Task to analyze XAS data stored in a SmallData HDF5 file."""
 
-        logger.debug("XSS Analysis: extract_data")
+    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+        super().__init__(params=params, use_mpi=use_mpi)
 
-        self._extract_az_int()
-        try:
-            self._xray_intensity = self._smd_h5[self._task_parameters.ipm_var][
-                self._start_idx : self._stop_idx
-            ]
-        except KeyError as e:
-            logger.error("ipm data not found! Check config!")
-        self._integrated_intensity = np.nansum(self._az_int, axis=(1, 2))
-        self._setup_std_filters()
+    def _pre_run(self) -> None:
+        # Currently scattering data is extracted as standard since its used
+        # for all analysis types (XSS, XAS, XES,...)
+        self._extract_standard_data()
+        self._extract_xas()
 
-        if isinstance(self._task_parameters.scan_var, str):
-            scan_var: str = self._task_parameters.scan_var
-            try:
-                self._scan_values = self._smd_h5[f"scan/{scan_var}"][
-                    self._start_idx : self._stop_idx
-                ]
-                self._scan_var_name = scan_var
-            except KeyError as e:
-                logger.debug(f"Scan variable {scan_var} not found!")
-        elif isinstance(self._task_parameters.scan_var, list):
-            for scan_var in self._task_parameters.scan_var:
-                try:
-                    self._scan_values = self._smd_h5[f"scan/{scan_var}"][
-                        self._start_idx : self._stop_idx
-                    ]
-                    self._scan_var_name = scan_var
-                    break
-                except KeyError as e:
-                    logger.debug(f"Scan variable {scan_var} not found!")
-                    continue
-        if not hasattr(self, "_scan_values"):
-            # Create a set of scan values if none of the above scan
-            # variables are found, either lxt_fast or linear set.
-            try:
-                self._scan_values = self._smd_h5["enc/lasDelay"][
-                    self._start_idx : self._stop_idx
-                ]
-                self._scan_var_name = "lxt_fast"
-                logger.debug("Using scan variable lxt_fast")
-            except KeyError as e:
-                logger.debug("Scan variable lxt_fast not found!")
-                self._scan_values = np.linspace(
-                    self._start_idx, self._stop_idx, self._num_events
-                )
-                logger.debug(
-                    "No scans found, using linearly spaced data for _scan_values."
-                )
+    def _run(self) -> None:
+        diff: np.ndarray[np.float64]
+        ccm_bins: np.ndarray[np.float64]
+        laser_on: np.ndarray[np.float64]
+        laser_off: np.ndarray[np.float64]
+        ccm_bins, diff, laser_on, laser_off = self._calc_binned_difference_xas()
 
-    def _extract_az_int(self) -> None:
-        """Try to extract the azimuthal integration data from HDF5 file.
+        def sum_diff(
+            diff0: np.ndarray[np.float64], diff1: np.ndarray[np.float64]
+        ) -> np.ndarray[np.float64]:
+            return diff0 + diff1
 
-        This internal method will search first to see if a detector has been
-        provided as the scattering detector. If not, it will attempt to guess
-        which detector to use. It will attempt to extract both the internal
-        integration data and PyFAI integrated data (which have different
-        interfaces). If both are present, it will only extract PyFAI data.
-        """
-        detname: str = self._xss_detname
-        try:
-            self._extract_az_int_smd_internal(detname)
-            logger.debug(
-                f"Extracted internal azimuthal integration data for {detname}."
-            )
-        except Exception:
-            try:
-                self._extract_az_int_pyfai(detname)
-                logger.debug(
-                    f"Extracted PyFAI azimuthal integration data for {detname}."
-                )
-            except Exception:
-                logger.error("No azimuthal integration data found.")
-                self._mpi_comm.Barrier()
-                sys.exit(-1)
+        if self._mpi_size > 1:
+            diff = self._mpi_comm.reduce(diff, op=sum_diff)
+            laser_on = self._mpi_comm.reduce(laser_on, op=MPI.SUM)
+            laser_off = self._mpi_comm.reduce(laser_off, op=MPI.SUM)
 
-    def _extract_az_int_smd_internal(self, detname: str) -> None:
-        """Extract stored data from SmallData's azimuthal integration algorithm.
-
-        Args:
-            detname (str): The detector name to extract data for.
-        """
-
-        self._az_int = self._smd_h5[f"{detname}/azav_azav"][
-            self._start_idx : self._stop_idx
-        ]  # 3D
-        self._q_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_q"][()]
-        self._phi_vals = self._smd_h5[f"UserDataCfg/{detname}/azav__azav_phiVec"][()]
-
-    def _extract_az_int_pyfai(self, detname: str) -> None:
-        """Extract stored data from PyFAI's azimuthal integration algorithm.
-
-        Args:
-            detname (str): The detector name to extract data for.
-        """
-
-        self._az_int = self._smd_h5[f"{detname}/pyfai_azav"][
-            self._start_idx : self._stop_idx
-        ]  # 3D
-        self._q_vals = self._smd_h5[f"{detname}/pyfai_q"][()][0]
-        self._phi_vals = self._smd_h5[f"{detname}/pyfai_az"][()][0]
-
-    def _setup_std_filters(self) -> None:
-        """Setup the individual standard event filters.
-
-        Sets up light status (X-ray and laser) filters, and adjustable filters
-        based on, e.g., thresholds.
-        """
-        # For filtering based on event type
-        self._filter_dict["xray on"] = (
-            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 1
-        )
-        self._filter_dict["laser on"] = (
-            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 1
-        )
-
-        self._filter_dict["xray off"] = (
-            self._smd_h5["lightStatus/xray"][self._start_idx : self._stop_idx] == 0
-        )
-        self._filter_dict["laser off"] = (
-            self._smd_h5["lightStatus/laser"][self._start_idx : self._stop_idx] == 0
-        )
-
-        # Create scattering and ipm thresholds for first time
-        self._update_filters()
-
-    def _update_filters(self) -> None:
-        """Update stored event filters that are based on adjustable parameters.
-
-        E.g. update the minimum scattering intensity to use in analyses.
-        """
-        scattering_thresh: float = self._task_parameters.thresholds.min_Iscat
-        ipm_thresh: float = self._task_parameters.thresholds.min_ipm
-        self._filter_dict["total scattering"] = (
-            self._integrated_intensity > scattering_thresh
-        )
-        if hasattr(self, "_xray_intensity"):
-            self._filter_dict["ipm"] = self._xray_intensity > ipm_thresh
-        else:
-            self._filter_dict["ipm"] = np.ones([self._num_events], dtype=bool)
-
-    def _calc_norm_by_qrange(
-        self, q_limits: Tuple[float, float] = (0.9, 3.5)
-    ) -> np.ndarray[np.float64]:
-        """Calculate a normalization factor by averaging over a range of Q values.
-
-        Args:
-            q_limits (Tuple[float, float]): The lower and upper limit of the
-                Q-range to average.
-
-        Returns:
-            norm (np.ndarray[np.float64]): The 2D norm with shape
-                (num_events, num_phi)
-        """
-        norm_range: np.array = self._q_vals > q_limits[0]
-        norm_range &= self._q_vals < q_limits[1]
-        return np.nanmean(self._az_int[..., norm_range], axis=-1)
-
-    def _calc_norm_by_max(self) -> np.ndarray[np.float64]:
-        """Calculate a normalization factor by taking the maximum of each profile.
-
-        Returns:
-        norm (np.ndarray[np.float64]): The 1D norm with shape (num_events)
-        """
-        return np.nanmax(self._az_int, axis=(1, 2))
-
-    def _aggregate_filters(
-        self, filter_vars: str = ("xray on, laser on, total scattering, ipm")
-    ) -> np.ndarray[np.bool_]:
-        """Combine a number of possible data filters.
-
-        Takes a string of filters to be applied in the order specified. The
-        order matters for some filters, e.g. if "percentage" is selected it
-        should be applied after total scattering. See below for a list of
-        filters.
-
-        Possible filters:
-            "xray on": Take shots where X-rays are on,
-            "xray off": Take shots where X-rays are off,
-            "laser on": Take shots where laser is on,
-            "laser off": Take shots where laser is off,
-            "ipm": Take shots with X-ray intensity above a value (ipm value),
-            "total scattering": Take shots with minimum integrated scattering,
-            "percentage": Extract this percentage of data centered on the max
-                scattering intensity. Should be applied after total scatteirng.
-                E.g. Include 50% of shots centered around the Q-value with
-                maximum scattering.
-
-        Args:
-            filter_vars (str): A string of comma-seperated filters to apply,
-                taken from the list above. E.g. "xray on, laser on".
-
-        Returns:
-            total_filter (np.ndarray[np.bool]): A 1D boolean array with a shape
-                of (num_events) which can be used to index and filter a data array.
-        """
-        logger.debug("XSS Analysis: aggregate_filters")
-        filters: List[str] = [f.strip() for f in filter_vars.split(",")]
-        total_filter: np.ndarray = np.ones([self._num_events], dtype=bool)
-
-        for data_filter in filters:
-            logger.debug(f"Filter: {data_filter}")
-            try:
-                total_filter &= self._filter_dict[data_filter]
-            except KeyError as e:
-                logger.debug(
-                    f"Unrecognized filter requested: {data_filter}. "
-                    "Ignoring and continuing processing."
-                )
-                continue
-
-        return total_filter
-
-    def _calc_dark_mean(
-        self, profiles: np.ndarray[np.float64]
-    ) -> np.ndarray[np.float64]:
-        """Calculate the dark (X-ray off) mean of a set of XSS profiles.
-
-        Args:
-            profiles (np.ndarray[np.float64]): Set of profiles to calculate the
-                dark mean from. Shape: (n_events, q_bins)
-        Returns:
-            dark_mean (np.ndarray[np.float64]): The calculated dark mean.
-                Shape: (q_bins)
-        """
-        dark_mean: np.ndarray[np.float64]
-        try:
-            dark_mean = np.nanmean(profiles[self._filter_dict["xray off"]], axis=0)
-            dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
-            dark_mean /= self._mpi_size
-        except KeyError:
-            logger.debug(
-                "No X-ray off event information for filtering. "
-                "Dark mean will be all zeros."
-            )
-            dark_mean = np.zeros([self._num_events])
-        return dark_mean
-
-    def _calc_scan_bins(self) -> np.ndarray[np.float64]:
-        """Calculate a set of scan bins.
-
-        Returns:
-            scan_bins (np.ndarray[np.float64]): 1D set of scan bins.
-        """
-        # Create a full set of scan values
-        self._all_scan_values: np.ndarray[np.float64] = np.zeros(
-            np.sum(self._events_per_rank), dtype=np.float64
-        )
-        self._mpi_comm.Gatherv(
-            self._scan_values,
-            [
-                self._all_scan_values,
-                self._events_per_rank,
-                self._start_indices_per_rank,
-                MPI.DOUBLE,
-            ],
-            root=0,
-        )
-        logger.debug("XSS Analysis: time_bins")
-        scan_bins: np.ndarray[np.float64]
         if self._mpi_rank == 0:
-            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
-                nbins: int = 70  # 200
-                _, edges = np.histogram(np.unique(self._all_scan_values), bins=nbins)
-                scan_bins = edges
-            else:
-                scan_bins = np.unique(self._all_scan_values)
-        else:
-            scan_bins = None
-        scan_bins = self._mpi_comm.bcast(scan_bins, root=0)
-        return scan_bins
-
-    def _calc_binned_difference_xss(
-        self,
-    ) -> Tuple[np.ndarray[np.float], np.ndarray[np.float64], np.ndarray[np.float64]]:
-        """Calculate the binned difference.
-
-        Calculates the 1D difference scattering for each bin of a scan variable.
-        Final difference shape is 2D: (q_bins, scan_bins). Also returns bins and
-        the laser on profiles.
-
-        Returns:
-            bins (np.ndarray[np.float64]): 1D array of scan bins used.
-
-            diff (np.ndarray[np.float64]): 2D binned difference scattering of shape
-                (q_bins, scan_bins)
-
-            laser_on (np.ndarray[np.float64]): 2D laser on scattering profiles
-                of shape (n_events_las_on, q_bins)
-        """
-        logger.debug("XSS Analysis: profiles_1d")
-        profiles: np.ndarray[np.float64, np.float64] = np.nansum(self._az_int, axis=1)
-        dark_mean: np.ndarray[np.float64] = self._calc_dark_mean(profiles)
-        if len(np.unique(dark_mean)) > 1:
-            # Can be len == 1 if all nan
-            profiles -= dark_mean
-        norm: np.ndarray[np.float64] = self._calc_norm_by_qrange()
-        profiles = (profiles.T / np.nanmean(norm, axis=-1).T).T
-        del dark_mean
-        del norm
-
-        filter_las_on: np.ndarray[np.float64] = self._aggregate_filters()
-        filter_las_off: np.ndarray[np.float64] = self._aggregate_filters(
-            filter_vars="xray on, laser off, ipm, total scattering"
-        )
-
-        bins: np.ndarray[np.float64] = self._calc_scan_bins()
-        binned_on: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        binned_off: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        scanvals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
-        scanvals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
-
-        idx: int
-        scan_bin: float
-        for idx, scan_bin in enumerate(bins):
-            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
-                if idx == len(bins) - 1:
-                    continue
-                mask_on: np.ndarray[np.bool_] = (scanvals_las_on >= scan_bin) * (
-                    scanvals_las_on < bins[idx + 1]
-                )
-                mask_off: np.ndarray[np.bool_] = (scanvals_las_off >= scan_bin) * (
-                    scanvals_las_off < bins[idx + 1]
-                )
-                binned_on[:, idx] = np.nanmean(profiles[filter_las_on][mask_on], axis=0)
-                binned_off[:, idx] = np.nanmean(
-                    profiles[filter_las_off][mask_off], axis=0
-                )
-            else:
-                binned_on[:, idx] = np.nanmean(
-                    profiles[filter_las_on][(scanvals_las_on == scan_bin)], axis=0
-                )
-                binned_off[:, idx] = np.nanmean(
-                    profiles[filter_las_off][(scanvals_las_off == scan_bin)], axis=0
-                )
-        diff: np.ndarray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
-            binned_off
-        )
-        return bins, diff, profiles[filter_las_on]
-
-    def _find_solvent_argmax(self, corrected_profile: np.ndarray) -> int:
-        """Find the index of the solvent ring maximum.
-
-        Currently just a hack around SciPy find_peaks.
-
-        Args:
-            corrected_profile (np.ndarray[np.float64]): 1D normalized and dark
-                mean corrected, laser on, scattering profile.
-
-        Returns:
-            peak_idx (int): The index where the solvent maximum is located.
-        """
-        res: Tuple[np.ndarray, Dict[str, np.ndarray]] = find_peaks(corrected_profile, 1)
-        try:
-            peak_indices: np.ndarray = res[0]
-            peak_heights: np.ndarray = res[1]["peak_heights"]
-        except KeyError as e:
-            logger.debug("No peaks found")
-            return np.argmax(corrected_profile)
-
-        peak_idx: int = peak_indices[
-            np.argmax(peak_heights)
-        ]  # peak_indices[0]  # peak_indices[peak_select - 1]
-        self._solvent_peak_idx = peak_idx
-        return peak_idx
-
-    def _fit_overlap(
-        self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-        guess: Optional[List[float]] = None,
-    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]:
-        """Fit overlap based on scattering difference signal to a Gaussian.
-
-        Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
-                scattering profile.
-
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-            guess (Optional[List[float]]): A list of initial parameter guesses
-                for Gaussian fit in the order (amplitude, x0, sigma, background
-                offset)
-
-        Returns:
-            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
-                Q value used for calculating the overlap.
-
-            opt (np.ndarray[np.float64]): Optimized parameters.
-
-            res (np.ndarray[np.float64]): Covariances.
-        """
-        logger.debug("XSS Analysis: fit_overlap")
-        Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]
-        max_pt: int = self._find_solvent_argmax(laser_on)
-        try:
-            idx_peak_q: int = max_pt + 10
-        except IndexError as e:
-            logger.debug(f"{e}: No non-nan values found.")
-            idx_peak_q: int = 15
-
-        raw_curve: np.ndarray = diff[idx_peak_q]
-        if not guess:
-            max_val: int = raw_curve.max()
-            min_val: int = raw_curve.min()
-            # guess = [amplitude, center, stddev, bkgnd]
-            guess = [0, 0, 0, 0]
-            x0: float
-            if max_val > np.abs(min_val):
-                x0 = bins[raw_curve.argmax()]
-                guess[0] = max_val
-            else:
-                x0 = bins[raw_curve.argmin()]
-                guess[0] = min_val
-            guess[1] = x0
-            guess[2] = np.abs(bins[-1] - bins[0]) / 20
-            guess[3] = np.min(raw_curve)
-        try:
-            opt, res = curve_fit(gaussian, bins, raw_curve, p0=guess, maxfev=999999)
-        except ValueError as e:
-            logger.debug(f"{e}:\n No non-nan values...")
-            opt = guess
-            res = None
-
-        return raw_curve, opt, res
-
-    def _fit_convolution_fwhm(
-        self, trace: np.ndarray, bins: np.ndarray[np.float_]
-    ) -> float:
-        """Calculate the FWHM of a convolution signal.
-
-        Args:
-            trace (np.ndarray[np.float64]): 1D convolution trace.
-
-            bins (np.ndarray[np.float64]): 1D set of bins used.
-
-        Returns:
-            fwhm (float): Calculated FWHM.
-        """
-        from scipy.interpolate import UnivariateSpline
-
-        x = np.linspace(0, len(trace) - 1, len(trace))
-        spline = UnivariateSpline(x, (trace - np.max(trace) / 2), s=0)
-        roots = spline.roots()
-        if len(roots) == 2:
-            lb, rb = roots
-            fwhm = rb - lb
-        else:
-            # bins: np.ndarray = self.time_bins[0]
-            max_val: int = trace.max()
-            min_val: int = trace.min()
-            # guess = [amplitude, center, stddev, bkgnd]
-            guess: List[Union[float, int]] = [0, 0, 0, 0]
-            x0: Union[float, int]
-            if max_val > np.abs(min_val):
-                x0 = bins[trace.argmax()]
-                guess[0] = max_val
-            else:
-                x0 = bins[trace.argmin()]
-                guess[0] = min_val
-            guess[1] = x0
-            guess[2] = np.abs(bins[-1] - bins[0]) / 20
-            guess[3] = np.min(trace)
-            opt, res = curve_fit(
-                gaussian, bins, np.nan_to_num(trace), p0=guess, maxfev=999999
+            diff /= self._mpi_size
+            laser_on /= self._total_num_events
+            plots: pn.Tabs = self.plot_all_xas(
+                laser_on, laser_off, ccm_bins, diff, name
             )
-            fwhm = sigma_to_fwhm(opt[2])
-        return fwhm
+            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+            plot_display_name: str
+            run: int = int(self._task_parameters.lute_config.run)
+            exp_run: str = f"{run:04d}_{name}_XAS"
+            if "lens" in name:
+                plot_display_name = f"lens_scans/{exp_run}"
+            elif "lxe_opa" in name:
+                plot_display_name = f"power_scans/{exp_run}"
+            else:
+                plot_display_name = f"time_scans/{exp_run}"
 
-    def _convolution_fit(
-        self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-    ) -> Tuple[np.ndarray, np.ndarray, int, float]:
-        """Fits a time scan through convolution with Heaviside kernel.
+            self._result.payload = ElogSummaryPlots(plot_display_name, plots)
 
-        Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
-                scattering profile.
-
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-        Returns:
-            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
-                Q value used for calculating the overlap.
-
-            trace (np.ndarray[np.float64]): 1D convolution trace.
-
-            center (int): The index of the center from the convolution.
-
-            fwhm (float): Width of the convlution signal (fwhm).
-        """
-        from scipy.signal import fftconvolve
-
-        logger.debug("XSS Analysis: convolution_fit")
-        results: List[Tuple] = []
-        max_pt: int = self._find_solvent_argmax(laser_on)
-        raw_curve: np.ndarray = np.nan_to_num(diff[max_pt + 10])
-        npts: int = len(raw_curve)
-        kernel: np.ndarray = np.zeros([npts])
-        kernel[: npts // 2] = 1
-        trace: np.ndarray = fftconvolve(raw_curve, kernel, mode="same")
-        center: int = trace.argmax()
-        fwhm: float = self._fit_convolution_fwhm(trace, bins)
-        return raw_curve, trace, center, fwhm
-
-    def plot_avg_xss(
-        self,
-        laser_on: np.ndarray[np.float64],
-        q_vals: np.ndarray[np.float64],
-        phis: np.ndarray[np.float64],
-    ) -> plt.Figure: ...
-
-    def plot_difference_hv(
-        self,
-        bins: np.ndarray[np.float64],
-        q_vals: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-        scan_var_name: str,
-    ) -> pn.GridSpec:
-        """Plot the binned difference scattering.
-
-        Args:
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            q_vals (np.ndarray[np.float64]): 1D set of Q bins.
-
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-            scan_var_name (str): Name of the scan variable (for titles, etc.).
-
-        Returns:
-            plot (pn.GridSpec): Plotted binned difference.
-        """
-        grid: pn.GridSpec = pn.GridSpec(name="Difference Profiles")
-        xdim: hv.core.dimension.Dimension = hv.Dimension(
-            ("scan_var", f"Scan Var {scan_var_name}")
-        )
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
-        diff_img: hv.Image = hv.Image(
-            (bins, q_vals, diff.T),
-            kdims=[xdim, ydim],
-        ).opts(shared_axes=False)
-        contours = diff_img + hv.operation.contours(diff_img, levels=5)
-        contours.opts(
-            hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
-        ).opts(shared_axes=False)
-        grid[:2, :2] = contours
-        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", f"Q"))
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("dS", "dS"))
-        diff_curves: hv.Overlay
-        # diff_curves = hv.Curve((q_vals, diff[:, 0]))
-        # for i, _ in enumerate(bins):
-        #    if i == 0:
-        #        continue
-        #    else:
-        #        diff_curves *= hv.Curve(
-        #            (
-        #                q_vals,
-        #                diff[:, i],
-        #            )
-        #        ).opts(xlabel=xdim.label, ylabel=ydim.label)
-
-        # grid[2:4, :] = diff_curves.opts(shared_axes=False)
-        return grid
-
-    def plot_overlap_fit(
-        self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-    ) -> plt.Figure:
-        """Plot the overlap fit to a slice of the binned difference.
-
-        Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
-                scattering profile.
-
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-        Returns:
-            plot (plt.Figure): Plotted overlap fit.
-        """
-        logger.debug("XSS Analysis: plot_overlap_fit")
-        fig, ax = plt.subplots(1, 1, figsize=(6, 3), dpi=200)
-        if self._scan_var_name is not None and "lxt" in self._scan_var_name:
-            raw_curve: np.ndarray[np.float64]
-            trace: np.ndarray[np.float64]
-            center: int
-            fwhm: float
-            raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
-            msg: str = (
-                f"Scan Var: {self._scan_var_name}\n"
-                f"Overlap Position: {bins[center]}\n"
-                f"FWHM: {fwhm}"
-            )
-            logger.info(msg)
-            ax.plot(bins, raw_curve, label="Raw")
-            ax2 = ax.twinx()
-            ax2.plot(bins, trace, color="orange", label="Convolution")
-            ax.set_title(msg)
-            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
-            ax.set_ylabel(r"$\Delta$S")
-            plt.legend(loc=0, frameon=False)
-        else:
-            raw_curve: np.ndarray[np.float64]
-            opt: np.ndarray[np.float64]
-            raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
-            msg: str = (
-                f"Scan Var: {self._scan_var_name}\n"
-                f"Overlap Position: {opt[1]}\n"
-                f"FWHM: {sigma_to_fwhm(opt[2])}"
-            )
-            logger.info(msg)
-            ax.plot(bins, raw_curve)
-            ax.plot(bins, gaussian(bins, *opt))
-            ax.set_title(msg)
-            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
-            ax.set_ylabel(r"$\Delta$S")
-        fig.tight_layout()
-        return fig
-
-    def plot_all(
-        self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-        scan_var_name: str,
-    ) -> pn.Tabs:
-        """Plot all relevant plots.
-
-        Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
-                scattering profile.
-
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-            scan_var_name (str): Name of the scan variable (for titles, etc.).
-
-        Returns:
-            plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
-        """
-        logger.debug("XSS Analysis: plot_all")
-        # avg_fig = self.plot_avg_xss()
-        overlap_fig = self.plot_overlap_fit(laser_on, bins, diff)
-
-        # avg_grid = pn.GridSpec(name="TR X-ray Scattering")
-        # avg_grid[:2, :2] = avg_fig
-
-        diff_grid = self.plot_difference_hv(laser_on, bins, diff, scan_var_name)
-        overlap_grid = pn.GridSpec(name="Overlap Fit")
-        overlap_grid[:2, :2] = overlap_fig
-
-        tabbed_display = pn.Tabs(diff_grid)
-        tabbed_display.append(overlap_grid)
-        # tabbed_display.append(avg_grid)
-
-        return tabbed_display
+    def _post_run(self) -> None: ...

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -1,0 +1,251 @@
+#!/sdf/group/lcls/ds/ana/sw/conda1/inst/envs/ana-4.0.62-py3/bin/python
+
+"""Script to setup LUTE and workflow definitions."""
+
+__author__ = "Gabriel Dorlhiac"
+
+import argparse
+import logging
+import os
+import requests
+import shutil
+import subprocess
+import sys
+from typing import List, Dict, Tuple, Any
+
+from krtc import KerberosTicket
+
+
+logging.basicConfig(level=logging.INFO)
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def git_clone(repo: str, location: str, tag: str) -> None:
+    """Clone a git repository.
+
+    Will not overwrite a directory of there is already a folder at the specified
+    location.
+    Args:
+        repo (str): Name of the repository to clone. Should be specified as:
+            "<user_or_organization>/<repository_name>"
+
+        location (str): Path to the location to clone to.
+    """
+    global logger
+
+    repo_only: str = repo.split("/")[1]
+    if os.path.exists(f"{location}/{repo_only}"):
+        logger.debug(
+            f"Repository {repo} already exists at {location}. Will not overwrite."
+        )
+        return
+    cmd: List[str] = [
+        "git",
+        "clone",
+        f"https://github.com/{repo}.git",
+        f"{location}/{repo_only}",
+    ]
+    out: str
+    out, err = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+    if out:
+        logger.info(out)
+    if err:
+        logger.info(err)
+
+    cwd: str = os.getcwd()
+    os.chdir(f"{location}/{repo_only}")
+    cmd = ["git", "checkout", tag]
+    out, _ = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+    if out:
+        logger.info(out)
+    if err:
+        logger.info(err)
+    os.chdir(cwd)
+
+
+def modify_permissions(lute_path: str):
+    """Recursively set permissions for a LUTE installation."""
+    os.chmod(lute_path, 0o755)
+    for root, dirs, files in os.walk(lute_path):
+        for d in dirs:
+            os.chmod(os.path.join(root, d), 0o755)
+
+        for f in files:
+            os.chmod(os.path.join(root, f), 0o755)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="setup_lute",
+        description="Setup LUTE work space and eLog workflows for an experiment.",
+        epilog="Refer to https://github.com/slac-lcls/lute for more information.",
+    )
+    parser.add_argument(
+        "-d", "--debug", action="store_true", help="Turn on verbose logging."
+    )
+    parser.add_argument(
+        "-e",
+        "--experiment",
+        type=str,
+        help="Experiment to perform setup for.",
+        required=True,
+    )
+    parser.add_argument(
+        "-f",
+        "--fresh_install",
+        help=(
+            "Install a new version of LUTE in the experiment folder. This allows "
+            "for local modifications of code. Otherwise, the central installation "
+            "will be used which cannot be modified."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test", help="Use test Airflow instance.", action="store_true"
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        type=str,
+        help=(
+            "Version of LUTE to use. Corresponds to release tag or `dev`. "
+            "Defaults to `dev`."
+        ),
+        default="dev",
+    )
+    parser.add_argument(
+        "-w",
+        "--workflow",
+        type=str,
+        help=("Which analysis workflow to run. Defaults to smd_summaries."),
+        default="smd_summaries",
+    )
+    args: argparse.Namespace
+    extra_args: List[str]  # May have additional SLURM arguments
+    args, extra_args = parser.parse_known_args()
+
+    hutch: str = args.experiment[:3]
+
+    results_dir: str = f"/sdf/data/lcls/ds/{hutch}/{args.experiment}/results"
+    lute_path: str
+    if args.fresh_install:
+        git_clone("slac-lcls/lute", results_dir, args.version)
+        lute_path = f"{results_dir}/lute"
+        modify_permissions(lute_path)
+    else:
+        lute_path = f"/sdf/group/lcls/ds/tools/lute/{args.version}/lute"
+
+    arp_executable: str = f"{lute_path}/launch_scripts/submit_launch_airflow.sh"
+    launch_executable: str = f"{lute_path}/launch_scripts/launch_airflow.py"
+
+    std_hutch_config: str = f"{lute_path}/config/{hutch}.yaml"
+    config_path: str = f"{results_dir}/{hutch}_lute.yaml"
+    if not os.path.exists(std_hutch_config):
+        shutil.copy(f"{lute_path}/config/test.yaml", config_path)
+    else:
+        shutil.copy(std_hutch_config, config_path)
+    os.chmod(config_path, 0o666)
+
+    param_string: str = f"{launch_executable} -c {config_path} -w {args.workflow}"
+
+    if args.debug:
+        param_string = f"{param_string} --debug"
+    if args.test:
+        param_string = f"{param_string} --test"
+
+    extra_args_str: str = " ".join(extra_args)
+    # Check for partition, account and ntasks. ntasks has defaults by workflow
+    if "partition" not in extra_args_str:
+        logger.warning(
+            "No queue/partition provided. Defaulting to milano. Any key to continue. "
+            "Ctrl-C to exit."
+        )
+        try:
+            _: str = input()
+            extra_args_str = f"{extra_args_str} --partition=milano"
+        except KeyboardInterrupt:
+            logger.info("Exiting.")
+            sys.exit(0)
+    if "account" not in extra_args_str:
+        account: str = f"lcls:{args.experiment}"
+        logger.warning(
+            f"No account provided. Defaulting to {account}. Any key to continue. "
+            "Ctrl-C to exit."
+        )
+        try:
+            _: str = input()
+            extra_args_str = f"{extra_args_str} --account={account}"
+        except KeyboardInterrupt:
+            logger.info("Exiting.")
+            sys.exit(0)
+    if "ntasks" not in extra_args_str:
+        ncores: int
+        if args.workflow == "smd_summaries":
+            ncores = 5
+        else:
+            ncores = 120
+        logger.warning(
+            f"No tasks/cores provided. Defaulting to {ncores}. Any key to continue. "
+            "Ctrl-C to exit."
+        )
+        try:
+            _: str = input()
+            extra_args_str = f"{extra_args_str} --ntasks={ncores}"
+        except KeyboardInterrupt:
+            logger.info("Exiting.")
+            sys.exit(0)
+
+    param_string = f"{param_string} {extra_args_str}"
+
+    main_workflow: Dict[str, str]
+    if args.workflow == "smd_summaries":
+        main_workflow = {
+            "name": "lute_smd_summaries",
+            "executable": arp_executable,
+            "trigger": "RUN_PARAM_IS_VALUE",
+            "run_param_name": "SmallData",
+            "run_param_value": "done",
+            "location": "S3DF",
+            "parameters": param_string,
+        }
+    elif 0:
+        # Replace eventually with workflows which use START_OF_RUN
+        main_workflow = {
+            "name": "lute_smd_summaries",
+            "executable": arp_executable,
+            "trigger": "START_OF_RUN",
+            "location": "S3DF",
+            "parameters": param_string,
+        }
+    else:
+        main_workflow = {
+            "name": "lute_smd_summaries",
+            "executable": arp_executable,
+            "trigger": "END_OF_RUN",
+            "location": "S3DF",
+            "parameters": param_string,
+        }
+
+    workflows: List[Dict[str, str]] = []
+    workflows.append(main_workflow)
+    # Will want to append additional auxiliary workflows eventually
+
+    for workflow in workflows:
+        krbticket: Any = KerberosTicket("HTTP@pswww.slac.stanford.edu")
+        krbheaders: dict = krbticket.getAuthHeaders()
+        url: str = (
+            f"https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk/{args.experiment}/ws"
+            "/create_update_workflow_def"
+        )
+        post_params: Dict[str, Any] = {
+            "url": url,
+            "headers": krbheaders,
+            "json": workflow,
+        }
+        resp: requests.models.Response = requests.post(**post_params)
+        resp.raise_for_status()
+        # Extra logging and such...

--- a/workflows/airflow/smd_summaries.py
+++ b/workflows/airflow/smd_summaries.py
@@ -1,0 +1,50 @@
+"""SFX Processing DAG (W/ Experimental Phasing)
+
+Runs SFX processing, beginning with the PyAlgos peak finding algorithm.
+This workflow is used for data requiring experimental phasing. Do NOT use this
+DAG if you are using molecular replacement.
+
+Note:
+    The task_id MUST match the managed task name when defining DAGs - it is used
+    by the operator to properly launch it.
+
+    dag_id names must be unique, and they are not namespaced via folder
+    hierarchy. I.e. all DAGs on an Airflow instance must have unique ids. The
+    Airflow instance used by LUTE is currently shared by other software - DAG
+    IDs should always be prefixed with `lute_`. LUTE scripts should append this
+    internally, so a DAG "lute_test" can be triggered by asking for "test"
+"""
+
+from datetime import datetime
+import os
+from airflow import DAG
+from lute.operators.jidoperators import JIDSlurmOperator
+
+dag_id: str = f"lute_{os.path.splitext(os.path.basename(__file__))[0]}"
+description: str = (
+    "Produce basic analysis for XSS, XAS, and XES from SmallData hdf5 files."
+)
+
+dag: DAG = DAG(
+    dag_id=dag_id,
+    start_date=datetime(2024, 9, 3),
+    schedule_interval=None,
+    description=description,
+)
+
+xss: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="SmallDataXSSAnalyzer", dag=dag
+)
+
+xas: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="SmallDataXASAnalyzer", dag=dag
+)
+
+xes: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=4, task_id="SmallDataXESAnalyzer", dag=dag
+)
+
+# Run summaries
+xss
+xas
+xes

--- a/workflows/airflow/smd_summaries.py
+++ b/workflows/airflow/smd_summaries.py
@@ -40,9 +40,7 @@ xas: JIDSlurmOperator = JIDSlurmOperator(
     max_cores=2, task_id="SmallDataXASAnalyzer", dag=dag
 )
 
-xes: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=4, task_id="SmallDataXESAnalyzer", dag=dag
-)
+xes: JIDSlurmOperator = JIDSlurmOperator(task_id="SmallDataXESAnalyzer", dag=dag)
 
 # Run summaries
 xss

--- a/workflows/airflow/test_dynamic.py
+++ b/workflows/airflow/test_dynamic.py
@@ -52,7 +52,7 @@ def test_dynamic():
         if "dag_run" in context:
             wf: Dict[str, Any] = context["dag_run"].conf["workflow"]
             Variable.set(key="user_workflow", value=wf, serialize_json=True)
-            time.sleep(3) # Make sure var gets set
+            time.sleep(3)  # Make sure var gets set
             return wf
         return None
 


### PR DESCRIPTION
# Description

This PR provides Tasks for basic analysis of XSS, XAS and XES data based on the output of SmallData. Includes support for basic time-resolved difference calculations and binning as well as scans of various motors.


## Checklist
- [x] Base class for most of the computation
- [x] XSS
- [x] XAS
- [x] XES
- [x] Logger and math utilities
- [x] `Executor` to handle lists of payloads.
- [x] `smd_summaries` workflow
- [x] `setup_lute` setup script

## PR Type:
- [x] New features/Enhancement

## Address issues:
- NA

# Testing
Tested using command-line submission on `xcsl1018322` and `xcsx1017323`. An extra prefix (`test/`) was appended to all paths for writing out files so as not to interfere with other summary plots currently used by the experiments. This path is absent in the committed code. E.g. plots were generated at `test/time_scans/<RUN>_lxt_fast_<TYPE>` but will be generated at `time_scans/<RUN>_lxt_fast_<TYPE>` in production.

# Screenshots
## XSS
Submitted with 1 rank using:
```bash
EXPERIMENT="xcsx1017323" RUN=8 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXSSAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/9efa33ec-de76-4006-8c95-2578f90275e0)

Submitted with 1 rank using:
```bash
EXPERIMENT="xcsx1017323" RUN=9 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXSSAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/2055dae9-3e70-41bd-bd2b-cb26c2a474ac)

Submitted with 1 rank using:
```bash
EXPERIMENT="xcsx1017323" RUN=22 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXSSAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/f6b53a68-a511-4f2c-b511-9c751c37554a)

## XAS
Submitted with 1 rank using:
```bash
EXPERIMENT="xcsl1018322" RUN=327 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXASAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/5c8d061d-fa4a-4248-b9b6-1a62514a3bee)

Submitted with 1 rank using:
```bash
EXPERIMENT="xcsl1018322" RUN=17 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXASAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/664f1555-997f-48c2-9a9c-36baf224de66)

Submitted with 1 rank using:
```bash
EXPERIMENT="xcsl1018322" RUN=18 SLURM_NPROCS=1 python -B run_task.py -t SmallDataXASAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/472d4c84-829e-4548-bd5b-aa3918ae62bc)


## XES
Submitted with 2 rank using:
```bash
EXPERIMENT="xcsl1018322" RUN=22 SLURM_NPROCS=3 python -B run_task.py -t SmallDataXESAnalyzer -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml
```
![image](https://github.com/user-attachments/assets/19fc9e44-5137-49c8-b9a4-ea8815b37bbe)


