### PR TITLE
ENH Add powder plots as an additional PyAlgos peak finding summary

### DIFF
--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -28,6 +28,7 @@ from PSCalib import GeometryAccess
 from lute.execution.ipc import Message
 from lute.io.models.base import *
 from lute.tasks.task import *
+from lute.tasks.dataclasses import ElogSummaryPlots
 
 hv.extension("bokeh")
 pn.extension()
@@ -867,7 +868,12 @@ class FindPeaksPyAlgos(Task):
                 "Number of hits found": str(num_hits_total),
                 "Fractional hit rate": f"{num_hits_total/num_events_total:.2f}",
             }
-            self._result.summary = (text_summary, powder_plots)
+            self._result.summary = (
+                text_summary,
+                ElogSummaryPlots(
+                    f"r{self._task_parameters.lute_config.run}/powders", powder_plots
+                ),
+            )
             with open(Path(self._task_parameters.out_file), "w") as f:
                 print(f"{master_fname}", file=f)
 

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -950,14 +950,36 @@ class FindPeaksPyAlgos(Task):
             max_width=700,
             name=f"{self._task_parameters.det_name} - Hits",
         )
-        grid_hits[0, 0] = assembled_powder_hits
+        dim: hv.Dimension = hv.Dimension(
+            ("image", "Hits"),
+            range=(
+                numpy.nanpercentile(assembled_powder_hits, 1),
+                numpy.nanpercentile(assembled_powder_hits, 99),
+            ),
+        )
+        grid_hits[0, 0] = pn.Row(
+            hv.Image(assembled_powder_hits, vdims=[dim], name=dim.label).options(
+                colorbar=True, cmap="rainbow"
+            )
+        )
 
         grid_misses: pn.GridSpec = pn.GridSpec(
             sizing_mode="stretch_both",
             max_width=700,
             name=f"{self._task_parameters.det_name} - Misses",
         )
-        grid_misses[0, 0] = assembled_powder_misses
+        dim = hv.Dimension(
+            ("image", "Misses"),
+            range=(
+                numpy.nanpercentile(assembled_powder_misses, 1),
+                numpy.nanpercentile(assembled_powder_misses, 99),
+            ),
+        )
+        grid_misses[0, 0] = pn.Row(
+            hv.Image(assembled_powder_misses, vdims=[dim], name=dim.label).options(
+                colorbar=True, cmap="rainbow"
+            )
+        )
 
         tabs: pn.Tabs = pn.Tabs(grid_hits)
         tabs.append(grid_misses)


### PR DESCRIPTION
# Description

This updates the `FindPeaksPyAlgos` summary to include image plots of the powder hits and misses. These are used for display in the eLog.


## Checklist
- [x] Powder plot summary

## PR Type:
- [x] New features/Enhancement

## Address issues:
- NA

# Testing

# Screenshots
