### PR TITLE
ENH Provide smalldata with pyalgos workflow. clone_smalldata tasklet.

### DIFF
--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -1,0 +1,231 @@
+%YAML 1.3
+---
+title: "LUTE Task Configuration" # Include experiment description if desired
+experiment: "{{ $EXPERIMENT }}"
+#run: "{{ $RUN }}"
+date: "2023/10/25"
+lute_version: 0.1      # Do not be change unless need to force older version
+task_timeout: 6000
+work_dir: ""
+...
+---
+###########
+# SFX
+###########
+
+# You must provide det_name and pv_camera_length
+# pv_camera_length is the detector distance
+# It can be a PV, or alternative a float for a fixed offset
+# Example PVs are commented below, ask beamline staff for relevant PV
+# Change outdir to an appropriate directory for CXI files.
+FindPeaksPyAlgos:
+    outdir: "/path/to/cxi_out"
+    det_name: "epix10k2M"
+    event_receiver: "evr0"
+    tag: "lyso"
+    event_logic: false
+    psana_mask: false
+    mask_file: null
+    min_peaks: 10
+    max_peaks: 2048
+    npix_min: 2
+    npix_max: 30
+    amax_thr: 40
+    atot_thr: 180
+    son_min: 10.0
+    peak_rank: 3
+    r0: 3.0
+    dr: 2.0
+    nsigm: 10.0
+    pv_camera_length: "MFX:ROB:CONT:POS:Z"  # MFX epix10k2M
+    #pv_camera_length: "MFX:DET:MMS:04.RBV" # MFX Rayonix
+    #n_events: 20000
+
+# You must provide a geometry file. Cell file is optional but improves results
+# mosflm is fast, you can provide additional methods for improved results at cost of speed
+IndexCrystFEL:
+  #in_file: ""            # Location of a `.lst` file listing CXI files
+  #out_file: ""           # Where to write the output stream file
+  geometry: "/geom.geom"  # Location of a geometry file
+  indexing: "mosflm"      # Indeexing methods - e.g. mosflm,xgandalf
+  int_radius: "3,4,5"     # Integration radii
+  tolerance: "5,5,5,1.5"  # Tolerances
+  multi: True
+  profile: True
+  no_revalidate: True
+  cell_file: "/path/to/cell.cell"
+  peaks: "cxi"
+
+# You must set symmetry
+MergePartialator:
+  #in_file: ""
+  #out_file: ""
+  #model: "unity"
+  #niter: 1
+  symmetry: "4/mmm_uac"
+
+CompareHKL:
+  #in_files: ""
+  #fom: "Rsplit"
+  #nshells: 10
+  #shell_file: ""
+  #cell_file: ""
+  symmetry: "4/mmm_uac"
+
+# Select a different output format if desired. Dimple requires mtz
+#ManipulateHKL:
+  #output_format: "mtz"
+  #out_file: "..."
+
+# You must provide a PDB file to use Dimple.
+DimpleSolve:
+  pdb: "/path/to/pdb/XYZ.pdb"
+
+###########
+# Smalldata
+###########
+
+# Producer will be auto-determined. Set only if you have a separate install
+# Set `directory` if you want to write to a different folder
+SubmitSMD:
+  # Command line arguments
+  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  #run: 99
+  #experiment: ""
+  #stn: 0
+  #directory: ""
+  #gather_interval: 25
+  #norecorder: False
+  #url: "https://pswww.slac.stanford.edu"
+  #epicsAll: False
+  #full: False
+  #fullSum: False
+  default: true
+  #image: False
+  #tiff: False
+  #centerpix: False
+  #postRuntable: False
+  #wait: False
+  #xtcav: False
+  #noarch: False
+  # Producer variables. These are substituted into the producer to run specific
+  # data reduction algorithms. Uncomment and modify as needed.
+  # If you prefer to modify the producer file directly, leave commented.
+  # Beginning with `getROIs`, you will need to modify the first entry to be a
+  # detector. This detector MUST MATCH one of the detectors in `detnames`.
+  # In the future this will be automated. If you have multiple detectors you can
+  # add them with their own set of parameters.
+  #detnames: []
+  #epicsPV: []
+  #ttCalib: []
+  #getROIs:
+  #  jungfrau1M:   # Change to detector name
+  #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
+  #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
+  #    thresADU: None
+  #getAzIntParams:
+  #  Rayonix:
+  #    eBeam: 18
+  #    center: [87526.79161840, 92773.3296889500]
+  #    dis_to_sam: 80.0
+  #    tx: 0
+  #    ty: 0
+  #getAzIntPyFAIParams:
+  #  Rayonix:
+  #    pix_size: 176e-6
+  #    ai_kwargs:
+  #      dist: 1
+  #      poni1: 960 * 1.76e-4
+  #      poni2: 960 * 1.76e-4
+  #    npts: 512
+  #    int_units: "2th_deg"
+  #    return2d: False
+  #getPhotonsParams:
+  #  jungfrau1M:
+  #    ADU_per_photon: 9.5
+  #    thresADU: 0.8
+  #getDropletParams:
+  #  epix_1:
+  #    threshold: 5
+  #    thresholdLow: 5
+  #    thresADU: 60
+  #    useRms: True
+  #    nData: 1e5
+  #getDroplet2Photons:
+  #  epix_alc1:
+  #    droplet:
+  #      threshold: 10
+  #      thresholdLow: 3
+  #      thresADU: 10
+  #      useRms: True
+  #    d2p:
+  #      aduspphot: 162
+  #      mask: np.load('path_to_mask.npy')
+  #      cputime: True
+  #    nData: 3e4
+  #getSvdParams:
+  #  acq_0:
+  #    basis_file: None
+  #    n_pulse: 1
+  #    delay: None
+  #    return_reconstructed: True
+  #getAutocorrParams:
+  #  epix_2:
+  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+  #    thresAdu: [72.0, 1.0e6]
+  #    save_range: [70, 50]
+  #    save_lineout: True
+
+AnalyzeSmallDataXSS:
+  #smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm PV to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lens_v"
+    - "lens_h"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+
+AnalyzeSmallDataXAS:
+  #smd_path: ""
+  # Detector selection - scattering det used for normalization.
+  xas_detname: "epix_2"     # Name of detector with XAS signal
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lxe_opa"
+    - "lxt_fast"
+  ccm: "epics/ccm_E"
+  ccm_set: "epicsUser/ccm_E_setpoint"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+  #element: null       # For EXAFS -- currently unused
+
+AnalyzeSmallDataXES:
+  #smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection - scattering det used for normalization.
+  xes_detname: "epix_2"     # Name of detector with XAS signal
+  xss_detname: "epix10k2M"  # Name of detector with scattering signal
+  ipm_var: "ipm5/sum"       # ipm to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lxt_fast"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 1000           # Minimum x-ray intensity at selected ipm
+  # Optional settings.
+  #invert_xes_axes: false   # Switch projection axis for spectrum. Default projects along 1
+  #rot_angle: null          # If not null, rotate images by N degrees before projection
+  #batch_size: 0            # If not 0, load images in batches of N. Helps OOM.
+...

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -105,7 +105,7 @@ if [[ -v RUN_PARAM ]]; then
     RUN_NUM=$RUN_PARAM
     RUN=$RUN_NUM
 fi
-export RUN_NUM
+export RUN_NUM=$RUN
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
 SLURM_ARGS+=" --output=${LOG_FILE}.out"

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -5,16 +5,16 @@ Classes:
         to produce a smalldata HDF5 file.
 
     AnalyzeSmallDataXSSParameters(TaskParameters): Parameter model for the
-        AnalyzeSmallDataXSS. Used to determine spatial/temporal overlap based on
-        XSS difference signal and provide basic XSS feedback.
+        AnalyzeSmallDataXSS Task. Used to determine spatial/temporal overlap
+        based on XSS difference signal and provide basic XSS feedback.
 
     AnalyzeSmallDataXASParameters(TaskParameters): Parameter model for the
-        AnalyzeSmallDataXES. Used to determine spatial/temporal overlap based on
-        XAS difference signal and provide basic XAS feedback.
+        AnalyzeSmallDataXAS Task. Used to determine spatial/temporal overlap
+        based on XAS difference signal and provide basic XAS feedback.
 
     AnalyzeSmallDataXESParameters(TaskParameters): Parameter model for the
-        AnalyzeSmallDataXES. Used to determine spatial/temporal overlap based on
-        XES difference signal and provide basic XES feedback.
+        AnalyzeSmallDataXES Task. Used to determine spatial/temporal overlap
+        based on XES difference signal and provide basic XES feedback.
 """
 
 __all__ = [

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -4,9 +4,17 @@ Classes:
     SubmitSMDParameters(ThirdPartyParameters): Parameters to run smalldata_tools
         to produce a smalldata HDF5 file.
 
-    FindOverlapXSSParameters(TaskParameters): Parameter model for the
-        FindOverlapXSS Task. Used to determine spatial/temporal overlap based on
-        XSS difference signal.
+    AnalyzeSmallDataXSSParameters(TaskParameters): Parameter model for the
+        AnalyzeSmallDataXSS. Used to determine spatial/temporal overlap based on
+        XSS difference signal and provide basic XSS feedback.
+
+    AnalyzeSmallDataXASParameters(TaskParameters): Parameter model for the
+        AnalyzeSmallDataXES. Used to determine spatial/temporal overlap based on
+        XAS difference signal and provide basic XAS feedback.
+
+    AnalyzeSmallDataXESParameters(TaskParameters): Parameter model for the
+        AnalyzeSmallDataXES. Used to determine spatial/temporal overlap based on
+        XES difference signal and provide basic XES feedback.
 """
 
 __all__ = [

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -7,6 +7,7 @@ here.
 from lute.execution.executor import *
 from lute.io.config import *
 from lute.tasks.tasklets import (
+    clone_smalldata,
     compare_hkl_fom_summary,
     indexamajig_summary_indexing_rate,
 )
@@ -38,6 +39,14 @@ MultiNodeCommunicationTester: MPIExecutor = MPIExecutor("TestMultiNodeCommunicat
 ###################
 SmallDataProducer: Executor = Executor("SubmitSMD")
 """Runs the production of a smalldata HDF5 file."""
+SmallDataProducer.add_tasklet(
+    clone_smalldata,
+    ["{{ producer }}"],
+    when="before",
+    set_result=False,
+    set_summary=False,
+)
+
 
 SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
 """Process scattering results from a Small Data HDF5 file."""

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -97,7 +97,7 @@ def concat_files(location: str, in_files_glob: str, out_file: str) -> None:
                 shutil.copyfileobj(rf, wf)
 
 
-def modify_permissions(path: str, permissions: int):
+def modify_permissions(path: str, permissions: int) -> None:
     """Recursively set permissions for a path."""
     os.chmod(path, permissions)
     for root, dirs, files in os.walk(path):

--- a/workflows/airflow/pyalgos_sfx.py
+++ b/workflows/airflow/pyalgos_sfx.py
@@ -60,8 +60,12 @@ hkl_manipulator: JIDSlurmOperator = JIDSlurmOperator(
 # CCP4
 dimple_runner: JIDSlurmOperator = JIDSlurmOperator(task_id="DimpleSolver", dag=dag)
 
+# Smalldata
+smd_producer: JIDSlurmOperator = JIDSlurmOperator(task_id="SmallDataProducer", dag=dag)
+
 
 peak_finder >> indexer >> concatenator >> merger >> hkl_manipulator >> dimple_runner
 merger >> hkl_comparer
 
 # Run summaries
+smd_producer

--- a/workflows/airflow/pyalgos_sfx.py
+++ b/workflows/airflow/pyalgos_sfx.py
@@ -1,8 +1,11 @@
-"""SFX Processing DAG (W/ Experimental Phasing)
+"""SFX Processing DAG (W/ Molecular Replacement)
 
 Runs SFX processing, beginning with the PyAlgos peak finding algorithm.
-This workflow is used for data requiring experimental phasing. Do NOT use this
-DAG if you are using molecular replacement.
+This workflow is used for data which will use molecular replacement.
+
+Smalldata_tools is also run to provide auxiliary run information. If no
+additional reduction algorithms are specified, it will just provide default
+detector information.
 
 Note:
     The task_id MUST match the managed task name when defining DAGs - it is used


### PR DESCRIPTION
# Description

This PR provides smalldata as part of the `pyalgos_sfx` workflow. When run with default configuration it provides basic information which can be reliably built on for additional summaries, even if no more advanced reduction algorithms are used.

This PR also introduces a tasklet to clone the smalldata repository if it is not present.

## Checklist
- [x] Add smalldata to the `pyalgos_sfx` workflow
- [x] Tasklet for cloning the `smalldata_tools` repo if it isn't present.
- [x] `mfx.yaml` for a template config for MFX.

## PR Type:
- [x] New features/Enhancement

## Address issues:
- NA

# Testing
## Command-line submission
Submitted in `mfxx49820` run 16:
```bash
[dorlhiac@sdfiana001 /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute]$> ./launch_scripts/submit_slurm.sh --debug -t SmallDataProducer -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/mfx.yaml --account=lcls:mfxx49820 --partition=milano -r 16 -e mfxx49820 --ntasks=10
Using TCP
Running in debug mode - verbose logging.
Submitting task SmallDataProducer
Running SmallDataProducer with SLURM arguments: --account=lcls:mfxx49820 --partition=milano --ntasks=10 --output=SmallDataProducer__r0016_2024-09-09_11-39-45.out --error=SmallDataProducer__r0016_2024-09-09_11-39-45.out
Using socket
python -B /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute/run_task.py -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/mfx.yaml -t SmallDataProducer
Submitted batch job 55153334
```
Using the following additional YAML configuration:
```yaml
SubmitSMD:
  default: true
```

Tried changing `nevents` in the YAML a few times. See results such as:
```

INFO:lute.execution.executor:Current Event / rank : 1001

INFO:lute.execution.executor:########## JOB TIME: 0.296598 minutes ###########
 (Closing remaining open files:/sdf/data/lcls/ds/mfx/mfxx49820/hdf5/smalldata/mfxx49820_Run0016.h5...done
)
DEBUG:lute.execution.executor:Task did not change from RUNNING status. Assume COMPLETED.
ERROR:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
```

`smalldata_tools` gets created under `/sdf/data/lcls/ds/mfx/mfxx49820/results/smalldata_tools`. This is because the default producer file is defined from the experiment and will be `/sdf/data/lcls/ds/mfx/mfxx49820/results/smalldata_tools/producers/smd_producer.py`

## Workflow submission
Works - see `mfxx49820` run 16

Smalldata file is produced (small, since we are running in `--default` mode per our YAML specification):
```bash
[dorlhiac@sdfiana001 /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute_output]$> ll /sdf/data/lcls/ds/mfx/mfxx49820/hdf5/smalldata/
total 39920
-rw-rw----+ 1 dorlhiac ps-data 40874648 Sep  9 11:54 mfxx49820_Run0016.h5
```

# Screenshots
**NOTE:** Smalldata uses the counter update URL independently of our infrastructure and **does not preserve** any messages that are currently there. This is not a problem as long as the smalldata task **always runs first**. If it doesn't, or it starts to finish after peak finding in this specific workflow we will need to remove the appropriate environment variable from the task environment so it cannot mess up other task reporting.
![image](https://github.com/user-attachments/assets/f537dc36-42e4-4615-8060-1762ee0621f7)

