### PR TITLE
ENH Show electron density with UglyMol for dimple summary

### DIFF
--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -611,9 +611,9 @@ class BaseExecutor(ABC):
             return
 
         # First try to set from result_from_params (faster)
-        if self._analysis_desc.task_parameters.Config.result_from_params is not None:
+        if hasattr(self._analysis_desc.task_parameters, "_result_from_params"):
             result_from_params: str = (
-                self._analysis_desc.task_parameters.Config.result_from_params
+                self._analysis_desc.task_parameters._result_from_params
             )
             logger.info(f"TaskResult specified as {result_from_params}.")
             self._analysis_desc.task_result.payload = result_from_params
@@ -621,6 +621,8 @@ class BaseExecutor(ABC):
             # Iterate parameters to find the one that is the result
             schema: Dict[str, Any] = self._analysis_desc.task_parameters.schema()
             for param, value in self._analysis_desc.task_parameters.dict().items():
+                if param == "_result_from_params":
+                    continue
                 param_attrs: Dict[str, Any]
                 if isinstance(value, TemplateParameters):
                     # Extract TemplateParameters if needed

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -617,6 +617,7 @@ class BaseExecutor(ABC):
             )
             logger.info(f"TaskResult specified as {result_from_params}.")
             self._analysis_desc.task_result.payload = result_from_params
+            del self._analysis_desc.task_parameters._result_from_params
         else:
             # Iterate parameters to find the one that is the result
             schema: Dict[str, Any] = self._analysis_desc.task_parameters.schema()

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -436,8 +436,17 @@ class IndexCrystFELParameters(ThirdPartyParameters):
             expmt: str = values["lute_config"].experiment
             run: int = int(values["lute_config"].run)
             work_dir: str = values["lute_config"].work_dir
-            fname: str = f"{expmt}_r{run:04d}.stream"
-            return f"{work_dir}/{fname}"
+            tag: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "tag"
+            )
+            if tag is None:
+                tag: Optional[str] = read_latest_db_entry(
+                    f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "tag"
+                )
+            fname: str = f"{expmt}_r{run:04d}"
+            if tag is not None:
+                fname = f"{fname}_{tag}"
+            return f"{work_dir}/{fname}.stream"
         return out_file
 
 

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -493,7 +493,7 @@ class ConcatenateStreamFilesParameters(TaskParameters):
                 f"{values['lute_config'].work_dir}", "IndexCrystFEL", "out_file"
             )
             if stream_file:
-                stream_tag: str = Path(stream_file).name.split("_")[0]
+                stream_tag: str = Path(stream_file).name.split("_")[-1].split(".")[0]
                 return stream_tag
         return tag
 

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -602,7 +602,11 @@ class ManipulateHKLParameters(ThirdPartyParameters):
     )
     # Resolution cutoffs
     cutoff_angstroms: Optional[Union[str, int, float]] = Field(
-        description="Either n, or n1,n2,n3. For n, reflections < n are removed. For n1,n2,n3 anisotropic trunction performed at separate resolution limits for a*, b*, c*.",
+        description=(
+            "Either n, or n1,n2,n3. For n, reflections < n are removed. "
+            "For n1,n2,n3 anisotropic trunction performed at separate resolution "
+            "limits for a*, b*, c*."
+        ),
         flag_type="--",
         rename_param="cutoff-angstroms",
     )

--- a/lute/io/models/sfx_solve.py
+++ b/lute/io/models/sfx_solve.py
@@ -127,7 +127,9 @@ class DimpleSolveParameters(ThirdPartyParameters):
         rename_param="no-blob-search",
     )
     anode: bool = Field(
-        False, description="Use SHELX/AnoDe to find peaks in the anomalous map."
+        False,
+        description="Use SHELX/AnoDe to find peaks in the anomalous map.",
+        flag_type="--",
     )
     # Run customization
     no_hetatm: bool = Field(

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -10,6 +10,7 @@ from lute.tasks.tasklets import (
     clone_smalldata,
     compare_hkl_fom_summary,
     indexamajig_summary_indexing_rate,
+    setup_dimple_uglymol,
 )
 
 # Tests
@@ -108,6 +109,13 @@ HKLManipulator: Executor = Executor("ManipulateHKL")  # For hkl->mtz, but can do
 DimpleSolver: Executor = Executor("DimpleSolve")
 """Solves a crystallographic structure using molecular replacement."""
 DimpleSolver.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")
+DimpleSolver.add_tasklet(
+    setup_dimple_uglymol,
+    ["{{ out_dir }}/final.mtz", "{{ lute_config.experiment }}", "{{ in_file }}"],
+    when="after",
+    set_result=False,
+    set_summary=True,
+)
 
 PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
 """Performs Bragg peak finding using the PyAlgos algorithm."""

--- a/lute/tasks/sfx_index.py
+++ b/lute/tasks/sfx_index.py
@@ -33,7 +33,7 @@ class ConcatenateStreamFiles(Task):
 
         stream_file_path: Path = Path(self._task_parameters.in_file)
         stream_file_list: List[Path] = list(
-            stream_file_path.rglob(f"{self._task_parameters.tag}_*.stream")
+            stream_file_path.rglob(f"*{self._task_parameters.tag}*.stream")
         )
 
         processed_file_list = [str(stream_file) for stream_file in stream_file_list]

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -80,9 +80,14 @@ class Task(ABC):
             payload="",
         )
         self._task_parameters: TaskParameters = params
-        if hasattr(self._task_parameters.Config, "result_from_params"):
-            self._task_parameters._result_from_params = (
-                self._task_parameters.Config.result_from_params
+        if (
+            hasattr(self._task_parameters.Config, "result_from_params")
+            and self._task_parameters.Config.result_from_params is not None
+        ):
+            object.__setattr__(
+                self._task_parameters,
+                "_result_from_params",
+                self._task_parameters.Config.result_from_params,
             )
         timeout: int = self._task_parameters.lute_config.task_timeout
         signal.setitimer(signal.ITIMER_REAL, timeout)

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -80,6 +80,10 @@ class Task(ABC):
             payload="",
         )
         self._task_parameters: TaskParameters = params
+        if hasattr(self._task_parameters.Config, "result_from_params"):
+            self._task_parameters._result_from_params = (
+                self._task_parameters.Config.result_from_params
+            )
         timeout: int = self._task_parameters.lute_config.task_timeout
         signal.setitimer(signal.ITIMER_REAL, timeout)
 
@@ -319,7 +323,7 @@ class ThirdPartyTask(Task):
             # Clunky test with __dict__[param] because compound model-types are
             # converted to `dict`. E.g. type(value) = dict not AnalysisHeader
             if (
-                param == "executable"
+                param in ("executable", "_result_from_params")
                 or value is None  # Cannot have empty values in argument list for execvp
                 or value == ""  # But do want to include, e.g. 0
                 or isinstance(self._task_parameters.__dict__[param], TemplateConfig)

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -27,6 +27,10 @@ Functions:
         Tuple[Dict[str, str], Optional[ElogSummaryPlots]]: Extract the figure of
         merit and produce a plot of figure of merit/resolution ring.
 
+    setup_dimple_uglymol(final_mtz: str, experiment: str, density_display_name: str
+        ) -> None: Set's up the javascript and HTML files needed to display electron
+        density in the eLog using UglyMol and the output from dimple.
+
 Usage:
     As tasklets are just functions they can be imported and used within Task
     code normally if needed.
@@ -52,11 +56,13 @@ __all__ = [
     "git_clone",
     "indexamajig_summary_indexing_rate",
     "compare_hkl_fom_summary",
+    "setup_dimple_uglymol",
 ]
 __author__ = "Gabriel Dorlhiac"
 
 import logging
 import os
+import shutil
 import subprocess
 from typing import List, Dict, Tuple, Optional
 
@@ -82,7 +88,6 @@ def concat_files(location: str, in_files_glob: str, out_file: str) -> None:
 
         out_file (str): Name of the concatenated output.
     """
-    import shutil
     from pathlib import Path
     from typing import BinaryIO
 
@@ -171,6 +176,25 @@ def grep(match_str: str, in_file: str) -> List[str]:
     return lines
 
 
+def wget(url: str, out_dir: Optional[str] = None) -> None:
+    """Pull down some resource.
+
+    Args:
+        url (str): URL of the resource.
+
+        out_dir (Optional[str]): Path of a directory to write the resource to.
+            If None, will write to the current working directory, which is
+            likely user scratch if running from the eLog.
+    """
+    cmd: List[str] = ["wget", url]
+    if out_dir is not None:
+        cmd.extend(["-P", out_dir])
+
+    out, _ = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    ).communicate()
+
+
 def indexamajig_summary_indexing_rate(stream_file: str) -> Dict[str, str]:
     """Return indexing rate from indexamajig output.
 
@@ -237,3 +261,59 @@ def compare_hkl_fom_summary(
     grid[:2, :2] = pts
     tabs = pn.Tabs(grid)
     return run_params, ElogSummaryPlots(figure_display_name, tabs)
+
+
+def setup_dimple_uglymol(
+    final_mtz: str, experiment: str, density_display_name: str
+) -> None:
+    """Setup uglymol so electron density can be explored in eLog.
+
+    Args:
+        final_mtz (str): Path to the output MTZ file after running dimple.
+
+        experiment (str): Experiment name.
+
+        density_display_name (str): Name of the tabbed navigation to find the
+            electron density in the eLog.
+    """
+    # We will allow passing a file name to try and guess the display name to use
+    display_name: str
+    if "." in density_display_name:
+        display_name = density_display_name.split(".")[0]
+        if len(display_name.split("_")) > 1:
+            # The standard workflow uses <exp/run...>_<tag> to name files
+            # Extract tag if present
+            display_name = display_name.split("_")[1]
+        else:
+            display_name = "density"
+
+    output_path: str = (
+        f"/sdf/data/lcls/ds/{experiment[:3]}/experiment/stats/summary/{density_display_name}"
+    )
+    wasm_path: str = f"{output_path}/wasm"
+
+    if not os.path.exists(output_path):
+        os.makedirs(wasm_path)
+
+    final_pdb: str = f"{final_mtz.split('.')[0]}.pdb"
+
+    uglymol_js_url: str = (
+        "https://raw.githubusercontent.com/uglymol/uglymol/master/uglymol.js"
+    )
+    mtz_js_url: str = (
+        "https://raw.githubusercontent.com/uglymol/uglymol.github.io/master/wasm/mtz.js"
+    )
+    mtz_wasm_url: str = (
+        "https://github.com/uglymol/uglymol.github.io/raw/master/wasm/mtz.wasm"
+    )
+
+    wget(uglymol_js_url, output_path)
+    wget(mtz_js_url, wasm_path)
+    wget(mtz_wasm_url, wasm_path)
+    shutil.copyfile(final_mtz, f"{output_path}/final.mtz")
+    shutil.copyfile(final_pdb, f"{output_path}/final.pdb")
+
+    with open(f"{output_path}/report.html", "w") as f:
+        from lute.tasks.util.html import DIMPLE_HTML
+
+        f.write(DIMPLE_HTML)

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -280,23 +280,27 @@ def setup_dimple_uglymol(
     display_name: str
     if "." in density_display_name:
         display_name = density_display_name.split(".")[0]
+        if "/" in display_name:
+            # If it's a path we only want to keep last part of /path/to/filename
+            display_name = display_name.split("/")[-1]
         if len(display_name.split("_")) > 1:
             # The standard workflow uses <exp/run...>_<tag> to name files
             # Extract tag if present
             display_name = display_name.split("_")[1]
         else:
             display_name = "density"
+    else:
+        display_name = density_display_name
 
     output_path: str = (
-        f"/sdf/data/lcls/ds/{experiment[:3]}/experiment/stats/summary/{density_display_name}"
+        f"/sdf/data/lcls/ds/{experiment[:3]}/{experiment}/stats/summary/{display_name}"
     )
     wasm_path: str = f"{output_path}/wasm"
-
+    logger.debug(f"Electron density path: {output_path}")
     if not os.path.exists(output_path):
         os.makedirs(wasm_path)
 
     final_pdb: str = f"{final_mtz.split('.')[0]}.pdb"
-
     uglymol_js_url: str = (
         "https://raw.githubusercontent.com/uglymol/uglymol/master/uglymol.js"
     )

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -282,11 +282,9 @@ def setup_dimple_uglymol(
         display_name = density_display_name.split(".")[0]
         if "/" in display_name:
             # If it's a path we only want to keep last part of /path/to/filename
+            # The standard workflow will name the stream and downstream files
+            # <tag>.stream, <tag>.hkl, ...
             display_name = display_name.split("/")[-1]
-        if len(display_name.split("_")) > 1:
-            # The standard workflow uses <exp/run...>_<tag> to name files
-            # Extract tag if present
-            display_name = display_name.split("_")[1]
         else:
             display_name = "density"
     else:

--- a/lute/tasks/util/html.py
+++ b/lute/tasks/util/html.py
@@ -1,0 +1,110 @@
+"""Utilities for Tasks working with HTML.
+
+This includes HTML templates and associated functions.
+"""
+
+__all__ = []
+__author__ = "Gabriel Dorlhiac"
+
+DIMPLE_HTML: str = """
+<html lang="en">
+    <head>
+        <title>dimple_thaum - UglyMol</title>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, user-scalable=no" />
+        <meta name="theme-color" content="#333333" />
+        <style>
+            body {
+                font-family: sans-serif;
+            }
+            canvas {
+                display: block;
+            }
+            #viewer {
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 100%;
+                height: 100%;
+            }
+            #hud {
+                font-size: 15px;
+                color: #ddd;
+                background-color: rgba(0, 0, 0, 0.6);
+                text-align: center;
+                position: absolute;
+                top: 10px;
+                left: 50%;
+                transform: translateX(-50%);
+                padding: 2px 8px;
+                border-radius: 5px;
+                z-index: 9;
+                white-space: pre-line;
+            }
+            #hud u {
+                padding: 0 8px;
+                text-decoration: none;
+                border: solid;
+                border-width: 1px 0;
+            }
+            #hud s {
+                padding: 0 8px;
+                text-decoration: none;
+                opacity: 0.5;
+            }
+            #help {
+                display: none;
+                font-size: 16px;
+                color: #eee;
+                background-color: rgba(0, 0, 0, 0.7);
+                position: absolute;
+                left: 20px;
+                top: 50%;
+                transform: translateY(-50%);
+                cursor: default;
+                padding: 5px;
+                border-radius: 5px;
+                z-index: 9;
+                white-space: pre-line;
+            }
+            #inset {
+                width: 200px;
+                height: 200px;
+                background-color: #888;
+                position: absolute;
+                right: 0;
+                bottom: 0;
+                z-index: 2;
+                display: none;
+            }
+            a {
+                color: #59c;
+            }
+        </style>
+        <script src="uglymol.js"></script>
+        <script src="wasm/mtz.js"></script>
+    </head>
+    <body style="background-color: black;">
+        <div id="viewer">
+            <canvas width="1561" height="1" style="width: 1561px; height: 1px;"></canvas>
+        </div>
+        <header id="hud" onmousedown="event.stopPropagation();" ondblclick="event.stopPropagation();">This is UglyMol not Coot. <a href="#" onclick="V.toggle_help(); return false;">H shows help.</a></header>
+        <footer id="help" style="display: none;">
+            <b>mouse:</b>
+            Left = rotate Middle or Ctrl+Left = pan Right = zoom Ctrl+Right = clipping Ctrl+Shift+Right = roll Wheel = σ level Shift+Wheel = diff map σ
+            <b>keyboard:</b>
+            H = toggle help S = general style L = ligand style T = water style C = coloring B = bg color E = toggle fog Q = label font +/- = sigma level ]/[ = map radius D/F = clip width &lt;/&gt; = move clip M/N = zoom U = unitcell box Y =
+            hydrogens V = inactive models R = center view W = wireframe style I = spin K = rock Home/End = bond width \ = bond caps P = nearest Cα Shift+P = permalink (Shift+)space = next res. Shift+F = full screen &nbsp;
+            <a href="https://uglymol.github.io">uglymol</a> 0.7.0
+        </footer>
+        <div id="inset"></div>
+        <script>
+            V = new UM.Viewer({ viewer: "viewer", hud: "hud", help: "help" });
+            V.load_pdb("final.pdb");
+            GemmiMtz().then(function (Module) {
+                UM.load_maps_from_mtz(Module, V, "final.mtz", ["FWT", "PHWT", "DELFWT", "PHDELWT"]);
+            });
+        </script>
+    </body>
+</html>
+"""


### PR DESCRIPTION
# Description

This PR provides an uglymol electron density explorer as a summary after running `DimpleSolver`.

The default behaviour is that if the `tasklet` is passed a filename, it will try and extract a "tag" to use for the display name. This will only be present in the filename if the initial peak finding was run with a tag. If no tag was used the density will just be displayed under a "density" tab in the eLog summaries.

## Checklist
- [x] Electron density summary
- [x] Bug fix: Fix the `result_from_params` mechanism
- [x] Bug fix: Propagate the tag to output stream files when indexing with CrystFEL (so downstream tasks get it)

## PR Type:
- [x] New features/Enhancement
- [x] Bug Fix

## Address issues:
- NA

# Testing
Tested with `mfxx49820` run 16. Manual submission works:
```bash
[dorlhiac@sdfiana002 /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute]$> python -B run_task.py -t DimpleSolver -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/mfx.yaml
```

Also submit the full workflow from the eLog for the same result.

# Screenshots
Density production works:
![image](https://github.com/user-attachments/assets/3a83a5eb-546e-4354-94ce-5fada734af1f)

When using a tag (`lyso`):
![image](https://github.com/user-attachments/assets/7869fd8c-f85e-4b68-b7ea-828af9a3c480)

