### PR TITLE
BUG Fix the default workflow definition for smd summary plots.

### DIFF
--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -218,7 +218,7 @@ if __name__ == "__main__":
     param_string = f"{param_string} {extra_args_str}"
 
     main_workflow: Dict[str, str]
-    if args.workflow == "smd_summaries":
+    if args.workflow in ("smd_summaries", "smd_xss", "smd_xes", "smd_xss"):
         main_workflow = {
             "name": "lute_smd_summaries",
             "executable": arp_executable,


### PR DESCRIPTION
# Description

This PR fixes the default workflow definition for smd summaries created by the `setup_lute` script.

## Checklist
- [x] Fix workflow definition.

## PR Type:
- [x] Bug fix

## Address issues:

# Testing

# Screenshots

