### PR TITLE
BUG Database permissions for multi-user environment

### DIFF
--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -295,7 +295,7 @@ def record_analysis_db(cfg: DescribedAnalysis) -> None:
         except sqlite3.OperationalError as err:
             logger.error(f"Database storage error: {err}")
     try:
-        os.chmod(db_path, 0o666)
+        os.chmod(db_path, 0o664)
     except:
         logger.error("Cannot setup permissions on database!")
 

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -174,6 +174,7 @@ if __name__ == "__main__":
     lute_output_dir: str = f"{results_dir}/lute_output"
     if not os.path.exists(lute_output_dir):
         os.makedirs(lute_output_dir, mode=0o777)
+        os.chmod(lute_output_dir, 0o777)
     config_path: str = f"{lute_output_dir}/{hutch}_lute.yaml"
     if not os.path.exists(std_hutch_config):
         shutil.copy(f"{lute_path}/config/test.yaml", config_path)

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -33,6 +33,23 @@ def _run_subprocess_log(cmd: List[str]) -> None:
     if err:
         logger.info(err)
 
+def touch(full_path: str) -> None:
+    """Touch a file.
+
+    Args:
+        full_path (str): The full path to the file to touch.
+    """
+    cmd: List[str] = ["touch", full_path]
+    _run_subprocess_log(cmd)
+
+def database_setup(full_path: str) -> None:
+    """Touch a file.
+
+    Args:
+        full_path (str): The full path to the file to touch.
+    """
+    touch(full_path)
+    os.chmod(full_path, 0o666)
 
 def git_clone(repo: str, location: str, tag: str) -> None:
     """Clone a git repository.
@@ -164,6 +181,7 @@ if __name__ == "__main__":
     sed_pattern: str = f"s|work_dir:\(.*\)|work_dir: \\\"{results_dir}\\\"|g"
     inplace_sed(config_path, sed_pattern)
 
+    database_setup(f"{results_dir}/lute.db") # Setup permissions on database
     param_string: str = f"{launch_executable} -c {config_path} -w {args.workflow}"
 
     if args.debug:

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -171,17 +171,20 @@ if __name__ == "__main__":
     launch_executable: str = f"{lute_path}/launch_scripts/launch_airflow.py"
 
     std_hutch_config: str = f"{lute_path}/config/{hutch}.yaml"
-    config_path: str = f"{results_dir}/{hutch}_lute.yaml"
+    lute_output_dir: str = f"{results_dir}/lute_output"
+    if not os.path.exists(lute_output_dir):
+        os.makedirs(lute_output_dir, mode=0o777)
+    config_path: str = f"{lute_output_dir}/{hutch}_lute.yaml"
     if not os.path.exists(std_hutch_config):
         shutil.copy(f"{lute_path}/config/test.yaml", config_path)
     else:
         shutil.copy(std_hutch_config, config_path)
     os.chmod(config_path, 0o666)
     # Substitute the work_dir in LUTE's config to the experiment results folder.
-    sed_pattern: str = f"s|work_dir:\(.*\)|work_dir: \\\"{results_dir}\\\"|g"
+    sed_pattern: str = f"s|work_dir:\(.*\)|work_dir: \\\"{lute_output_dir}\\\"|g"
     inplace_sed(config_path, sed_pattern)
 
-    database_setup(f"{results_dir}/lute.db") # Setup permissions on database
+    database_setup(f"{lute_output_dir}/lute.db") # Setup permissions on database
     param_string: str = f"{launch_executable} -c {config_path} -w {args.workflow}"
 
     if args.debug:

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -49,7 +49,7 @@ def database_setup(full_path: str) -> None:
         full_path (str): The full path to the file to touch.
     """
     touch(full_path)
-    os.chmod(full_path, 0o666)
+    os.chmod(full_path, 0o664)
 
 def git_clone(repo: str, location: str, tag: str) -> None:
     """Clone a git repository.


### PR DESCRIPTION
# Description

This PR tries to ensure that the database is read/write for all users when running with multiple users (e.g. on S3DF).

## Checklist
- [x] Setup permissions in `setup_lute`
- [x] Try to ensure permissions with `Executor`.
- [x] Fail gracefully on permissions bugs.

## PR Type:
- [x] Bug fix

## Address issues:

# Testing

# Screenshots

