### PR TITLE
ENH Template parameter help

### DIFF
--- a/utilities/src/help/task_parameters.py
+++ b/utilities/src/help/task_parameters.py
@@ -146,7 +146,6 @@ if __name__ == "__main__":
 
         # For types need to check for key `type` or a list of dicts `anyOf=[{'type': ...}, {'type': ...}]`
         parameter_schema: ModelSchema = parameter_model.schema()
-
         if args.full_schema:
             pprint.pprint(parameter_schema)
             sys.exit(0)
@@ -170,8 +169,23 @@ if __name__ == "__main__":
                 out_msg = f"{out_msg}{_format_parameter_row(param[0], param[1])}"
             out_msg = f"{out_msg}\n\n"
 
-        out_msg = f"{out_msg}All Parameters:\n-------------\n"
+        out_msg = f"{out_msg}All Parameters:\n---------------\n"
         for param in parameter_schema["properties"]:
             out_msg = f"{out_msg}{_format_parameter_row(param, parameter_schema['properties'][param])}"
 
+        if "definitions" in parameter_schema and parameter_schema["definitions"]:
+            definitions: List[str] = [
+                defn
+                for defn in parameter_schema["definitions"]
+                if defn not in ("AnalysisHeader", "TemplateConfig")
+            ]
+            if len(definitions) > 0:
+                out_msg = f"{out_msg}Template Parameters:\n--------------------\n"
+                for defn in definitions:
+                    for param in parameter_schema["definitions"][defn]["properties"]:
+                        row: str = _format_parameter_row(
+                            param,
+                            parameter_schema["definitions"][defn]["properties"][param],
+                        )
+                        out_msg = f"{out_msg}{row}"
         print(out_msg)

--- a/utilities/src/help/task_parameters.py
+++ b/utilities/src/help/task_parameters.py
@@ -82,6 +82,8 @@ def _format_parameter_row(param: str, param_description: PropertyDict) -> str:
     default: str
     if "default" in param_description:
         default = param_description["default"]
+        if default == "":
+            default = "<Empty String> - May be populated by validator"
         msg = f"{msg} - Default: {default}"
 
     description: str

--- a/utilities/src/help/task_parameters.py
+++ b/utilities/src/help/task_parameters.py
@@ -71,6 +71,9 @@ def _format_parameter_row(param: str, param_description: PropertyDict) -> str:
         typeinfo = param_description["type"]
     elif "anyOf" in param_description:  # anyOf is present instead
         typeinfo = " | ".join(_["type"] for _ in param_description["anyOf"])
+    elif "allOf" in param_description and "$ref" in param_description["allOf"][0]:
+        typeinfo = param_description["allOf"][0]["$ref"].split("/")[-1]
+        typeinfo = f"{typeinfo}"
     else:
         typeinfo = "No type information"
     typeinfo = f"({typeinfo})"
@@ -182,6 +185,7 @@ if __name__ == "__main__":
             if len(definitions) > 0:
                 out_msg = f"{out_msg}Template Parameters:\n--------------------\n"
                 for defn in definitions:
+                    out_msg = f"{out_msg}{defn}:\n"
                     for param in parameter_schema["definitions"][defn]["properties"]:
                         row: str = _format_parameter_row(
                             param,


### PR DESCRIPTION
# Description

This PR adds type-checked template parameters to the output of the `lute_help` utility for `Task`s that use them.

## Checklist
- [x] Include type-checked template parameters in the `lute_help` output for a `Task`.

## PR Type:
- [x] New feature/Enhancement
- [x] Utility

## Address issues:
- NA

# Testing

```bash
> ./utilities/lute_help -t IndexCCTBXXFEL
INFO:__main__:Fetching parameter information for IndexCCTBXXFEL.
IndexCCTBXXFEL
--------------
Parameters for indexing with cctbx.xfel.


Required Parameters:
--------------------
lute_config (No type information)
	Unknown description.



All Parameters:
---------------
lute_config (No type information)
	Unknown description.

executable (string) - Default: /sdf/group/lcls/ds/tools/cctbx/conda_base/bin/mpirun
	MPI executable.

cctbx_executable (string) - Default: /sdf/group/lcls/ds/tools/cctbx/build/bin/dials.stills_process
	CCTBX indexing program (DIALS).

in_file (string) - Default:
	The location of a data specification for LCLS. This file will be written for you based on the data_spec parameter. If not running at LCLS, this can be an input file, or a glob.

data_spec (object)
	Provide a CCTBX specification for data access.

phil_file (string) - Default:
	Location of the input settings ('phil') file.

phil_parameters (No type information)
	Optional template parameters to fill in a CCTBX phil file.

lute_template_cfg (No type information) - Default: {'template_name': 'cctbx_index.phil', 'output_path': ''}
	Template information for the cctbx_index file.

Template Parameters:
--------------------
input_reference_geometry (string)
	Provide an models.expt file with exactly one detector model. Data processing will use that geometry instead of the geometry found in the image headers.
```

# Screenshots

