### PR TITLE
MNT Add SLURM Job ID to log file name for SLURM jobs

### DIFF
--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -108,8 +108,8 @@ fi
 export RUN_NUM=$RUN
 FORMAT_RUN=$(printf "%04d" ${RUN:-0})
 LOG_FILE="${TASK}_${EXPERIMENT:-$EXP}_r${FORMAT_RUN}_$(date +'%Y-%m-%d_%H-%M-%S')"
-SLURM_ARGS+=" --output=${LOG_FILE}.out"
-SLURM_ARGS+=" --error=${LOG_FILE}.out"
+SLURM_ARGS+=" --output=${LOG_FILE}_%J.out"
+SLURM_ARGS+=" --error=${LOG_FILE}_%J.out"
 
 # If LUTE_USE_TCP is unset use TCP
 if [[ -z ${LUTE_USE_TCP} || ${LUTE_USE_TCP} != 0 ]]; then


### PR DESCRIPTION
# Description

This PR adds the SLURM job id into the output log file name for each Managed Task submitted with `submit_slurm.sh` . This is to facilitate a backup mechanism used to determine the log file for the eLog database.

Per Murali, when there are issues with the SLURM controller the mechanism used to determine the log file can fail, so a new mechanism searching the work directory for job log files is being added as a backup. This requires a convention that the job id be included in the logfile name.

The convention searches for `ls *$JOB_ID*`, so the indentifier only needs to be present somewhere in the file name.

## Checklist
- [x] Add SLURM job ID to logfile name

## PR Type:
- [x] Style/Maintenance

## Address issues:

# Testing
Tested through manual submission. The job ID now appears at the very end of the log file name.

E.g.
```bash
> ll
total 263336
-rw-rw-r-- 1 dorlhiac xu      3686 Sep 26 12:56 BinaryTester__r0000_2024-09-26_12-55-30_56279842.out
# ...
```
Here the job id is `56279842`

```bash
> sacct -j 56279842 -o SubmitLine%250
                                                                                                                                                                                                                                                SubmitLine
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
sbatch --partition=milano --account=lcls:data --output=BinaryTester__r0000_2024-09-26_12-55-30_%J.out --error=BinaryTester__r0000_2024-09-26_12-55-30_%J.out --wrap python -B /sdf/scratch/users/d/dorlhiac/lute/run_task.py -c /sdf/scratch/users/d/dorl+
```

# Screenshots
