### PR TITLE
BUG Fix clone repo tasklets

### DIFF
--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -128,7 +128,7 @@ def git_clone(repo: str, location: str, permissions: int) -> None:
         permissions (str): Permissions to set on the repository.
     """
     repo_only: str = repo.split("/")[1]
-    if os.path.exists(f"location/{repo_only}"):
+    if os.path.exists(f"{location}/{repo_only}"):
         logger.debug(
             f"Repository {repo} already exists at {location}. Will not overwrite."
         )
@@ -150,7 +150,7 @@ def clone_smalldata(producer_location: str) -> None:
     from pathlib import Path
 
     repo: str = "slac-lcls/smalldata_tools"
-    location: str = str(Path(producer_location).parent.parent)
+    location: str = str(Path(producer_location).parent.parent.parent)
     git_clone(repo, location, 0o777)
 
 

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -133,7 +133,12 @@ def git_clone(repo: str, location: str, permissions: int) -> None:
             f"Repository {repo} already exists at {location}. Will not overwrite."
         )
         return
-    cmd: List[str] = ["git", "clone", f"https://github.com/{repo}.git", location]
+    cmd: List[str] = [
+        "git",
+        "clone",
+        f"https://github.com/{repo}.git",
+        f"{location}/{repo_only}",
+    ]
     out: str
     out, _ = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True


### PR DESCRIPTION
# Description

This PR fixes the check to not overwrite repositories that already exist when the `git_clone` tasklet is used. Fixes the `clone_smalldata` tasklet to correctly set the location from the producer path.

## Checklist
- [x] Fix `git_clone`
- [x] Fix `clone_smalldata`

## PR Type:
- [x] Bug fix

## Address issues:

# Testing

# Screenshots

