### PR TITLE
MNT/UTL Linting and Type Checking

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,6 +13,6 @@ jobs:
       - name: "Install python dependencies"
         run: "pip install numpy pydantic==1.10 zmq jinja2 panel requests mpi4py"
       - name: "Run mypy install-types"
-        run: "yes | mypy ./lute --install-types || true"
+        run: "yes | mypy ./lute ./utilities/src ./launch_scripts ./workflows/airflow --install-types || true"
       - name: "Run mypy"
-        run: "mypy ./lute"
+        run: "mypy ./lute ./utilities/src ./launch_scripts"

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
       - run: "pip install mypy==1.13"
       - name: "Install python dependencies"
-        run: "pip install numpy pydantic==1.10 zmq jinja2 panel requests mpi4py"
+        run: "pip install numpy pydantic==1.10 zmq jinja2 panel requests mpi4py textual"
       - name: "Run mypy install-types"
         run: "yes | mypy ./lute ./utilities/src ./launch_scripts ./workflows/airflow --install-types || true"
       - name: "Run mypy"

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,18 @@
+name: mypy-check
+on: [push, pull_request]
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: mpi4py/setup-mpi@v1
+      - run: "pip install mypy==1.13"
+      - name: "Install python dependencies"
+        run: "pip install numpy pydantic==1.10 zmq jinja2 panel requests mpi4py"
+      - name: "Run mypy install-types"
+        run: "yes | mypy ./lute --install-types || true"
+      - name: "Run mypy"
+        run: "mypy ./lute"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,11 @@
+name: Ruff-lint
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1
+        with:
+          src: "./lute"
+          args: "check"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,5 +7,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v1
         with:
-          src: "./lute"
+          src: "./lute ./launch_scripts ./utilities ./run_task.py ./subprocess_task.py ./workflows"
           args: "check"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Inspired by `pcdshub` repositories, in turn following [NumPy conventions](https:
 ### Class and Object Naming Conventions
 
 ### Style, Formatting, Linting
-This repository uses [Black](https://black.readthedocs.io/en/stable/) for formatting of Python code. Pre-commit hooks will be setup shortly to facilitate compliance with the formatting rules.
+This repository uses [Black](https://black.readthedocs.io/en/stable/) for formatting of Python code. [Ruff](https://docs.astral.sh/ruff/) is used for linting with flake8 rules, and [mypy](https://mypy-lang.org/) for type checking.
+
+Github actions implement checks for compliance. Formatting changes are auto-committed.
 
 ### Debugging Code
 Temporary debugging code should **not** be commited to the repository. E.g., extraneous `print` statements, etc, which are added when fixing a bug. Nonetheless, a selection of permanent debugging options may be included in the code provided they can be disabled when not running in debug mode. For standard operation, this package should be run using the `-O` flag which disables `assert` statements and sets the constant `__debug__ = False`. Without that flag, the package is considered to be running in "debug mode". As such, to include debug related code, please use a construction similar to the following:

--- a/docs/usage/running_lute.md
+++ b/docs/usage/running_lute.md
@@ -143,10 +143,10 @@ slurm_params: ''
 next:
 - task_name: CrystFELIndexer
   slurm_params: ''
-  next: []
+  next:
   - task_name: PartialatorMerger
     slurm_params: ''
-    next: []
+    next:
     - task_name: HKLComparer
       slurm_params: ''
       next:

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import argparse
 import time
-from typing import Dict, Union, List, Optional, Any
+from typing import Dict, Union, List, Optional, Any, cast, TypedDict
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -33,6 +33,26 @@ if __debug__:
     logger.setLevel(logging.DEBUG)
 else:
     logger.setLevel(logging.INFO)
+
+
+class DagRunConf(TypedDict):
+    experiment: str
+    run_id: str
+    JID_UPDATE_COUNTERS: Optional[str]
+    ARP_ROOT_JOB_ID: str
+    ARP_LOCATION: str
+    Authorization: str
+    user: str
+    lute_location: str
+    kerb_file: Optional[str]
+    lute_params: Dict[str, Union[str, bool]]
+    slurm_params: List[str]
+    workflow: Dict[str, Any]
+
+
+class DagRunData(TypedDict):
+    dag_run_id: str
+    conf: DagRunConf
 
 
 def _retrieve_pw(instance: str = "prod", is_admin: bool = False) -> str:
@@ -68,8 +88,8 @@ def _request_arp_token(exp: str, lifetime: int = 300) -> str:
             token is used for the entirety of a workflow, it must have a lifetime
             equal or longer than the duration of the workflow's execution time.
     """
-    from kerberos import GSSError
-    from krtc import KerberosTicket
+    from kerberos import GSSError  # type: ignore
+    from krtc import KerberosTicket  # type: ignore
 
     try:
         krbheaders: Dict[str, str] = KerberosTicket(
@@ -139,7 +159,11 @@ if __name__ == "__main__":
         True  # Always copy kerberos ticket so non-active experiments can work.
     )
     cache_file: Optional[str] = os.getenv("KRB5CCNAME")
-    if os.getenv("Authorization") is None:
+    if (
+        os.getenv("Authorization") is None
+        or os.getenv("EXPERIMENT") is None
+        or os.getenv("RUN_NUM") is None
+    ):
         if cache_file is None:
             logger.info("No Kerberos cache. Try running `kinit` and resubmitting.")
             sys.exit(-1)
@@ -203,7 +227,7 @@ if __name__ == "__main__":
     )
     resp.raise_for_status()
 
-    params: Dict[str, Union[str, int, List[str]]] = {
+    params: Dict[str, Union[str, bool]] = {
         "config_file": args.config,
         "debug": args.debug,
     }
@@ -257,15 +281,20 @@ if __name__ == "__main__":
         logger.debug("Re-parsed DAG for setup with new workflow.")
 
     # Experiment, run #, and ARP env variables come from ARP submission only
-    dag_run_data: Dict[str, Union[str, Dict[str, Union[str, int, List[str]]]]] = {
+    # We override above or exit if we cannot, so we cast here
+    assert isinstance(os.getenv("EXPERIMENT"), str)
+    assert isinstance(os.getenv("RUN_NUM"), str)
+    assert isinstance(os.getenv("ARP_JOB_ID"), str)
+    assert isinstance(os.getenv("Authorization"), str)
+    dag_run_data: DagRunData = {
         "dag_run_id": str(uuid.uuid4()),
         "conf": {
-            "experiment": os.environ.get("EXPERIMENT"),
-            "run_id": f"{os.environ.get('RUN_NUM')}_{datetime.datetime.utcnow().isoformat()}",
-            "JID_UPDATE_COUNTERS": os.environ.get("JID_UPDATE_COUNTERS"),
-            "ARP_ROOT_JOB_ID": os.environ.get("ARP_JOB_ID"),
-            "ARP_LOCATION": os.environ.get("ARP_LOCATION", "S3DF"),
-            "Authorization": os.environ.get("Authorization"),
+            "experiment": cast(str, os.getenv("EXPERIMENT")),
+            "run_id": f"{cast(str, os.getenv('RUN_NUM'))}_{datetime.datetime.utcnow().isoformat()}",
+            "JID_UPDATE_COUNTERS": os.getenv("JID_UPDATE_COUNTERS"),
+            "ARP_ROOT_JOB_ID": cast(str, os.getenv("ARP_JOB_ID")),
+            "ARP_LOCATION": os.getenv("ARP_LOCATION", "S3DF"),
+            "Authorization": cast(str, os.getenv("Authorization")),
             "user": getpass.getuser(),
             "lute_location": os.path.abspath(f"{os.path.dirname(__file__)}/.."),
             "kerb_file": cache_file,
@@ -329,7 +358,7 @@ if __name__ == "__main__":
         task_url: str = f"{url}/taskInstances"
         resp = requests.get(task_url, auth=auth)
         resp.raise_for_status()
-        instance_information: Dict[str, Any] = resp.json()["task_instances"]
+        instance_information: List[Dict[str, Any]] = resp.json()["task_instances"]
         for inst in instance_information:
             task_id: str = inst["task_id"]
             task_state: Optional[str] = inst["state"]
@@ -364,9 +393,10 @@ if __name__ == "__main__":
                     logger.info(f"End of logs for {task_id}")
                     completed_tasks[task_id] = task_state
 
-                elif task_state in ("upstream_failed"):
+                # Ignore type check since cannot be None here
+                elif task_state in ("upstream_failed"):  # type: ignore
                     # upstream_failed never launches so has no log
-                    completed_tasks[task_id] = task_state
+                    completed_tasks[task_id] = task_state  # type: ignore
 
         if dag_state in ("queued", "running"):
             continue
@@ -382,9 +412,9 @@ if __name__ == "__main__":
         if cache_file is not None:
             try:
                 os.remove(cache_file[5:])
+                os.rmdir(f"{os.path.expanduser('~')}/.tmp_cache")
             except FileNotFoundError:
                 logger.error("No cache file found to remove.")
-            os.rmdir(f"{os.path.expanduser('~')}/.tmp_cache")
 
     if dag_state == "failed":
         sys.exit(1)

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -362,7 +362,11 @@ if __name__ == "__main__":
         for inst in instance_information:
             task_id: str = inst["task_id"]
             task_state: Optional[str] = inst["state"]
-            if task_id not in completed_tasks and task_state not in (None, "scheduled"):
+            if task_id not in completed_tasks and task_state not in (
+                None,
+                "scheduled",
+                "queued",
+            ):
                 if task_id not in logged_running:
                     # Should be "running" by first time it reaches here.
                     # Or e.g. "upstream_failed"... Setup to skip "scheduled"

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -974,7 +974,10 @@ class Executor(BaseExecutor):
 
     def _process_result_payload(self, payload: Any) -> None:
         if self._analysis_desc.task_parameters is None:
-            logger.error("Please run Task before using this method!")
+            logger.error(
+                "Please run Task before using this method! (_process_result_payload). "
+                "If you did run a Task, it may have failed immediately!"
+            )
             return
         new_payload: Optional[str]
         if isinstance(payload, ElogSummaryPlots):
@@ -1013,7 +1016,10 @@ class Executor(BaseExecutor):
             path (str): Path the plots were written out to.
         """
         if self._analysis_desc.task_parameters is None:
-            logger.error("Please run Task before using this method!")
+            logger.error(
+                "Please run Task before using this method! (_process_elog_plot). "
+                "If you did run a Task, it may have failed immediately!"
+            )
             return None
         # ElogSummaryPlots has figures and a display name
         # display name also serves as a path.

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -29,7 +29,7 @@ import subprocess
 import time
 import os
 import signal
-from typing import Dict, Callable, List, Optional, Any, Tuple
+from typing import Dict, Callable, List, Optional, Any, Tuple, Literal, Union
 from typing_extensions import Self, TypedDict
 from abc import ABC, abstractmethod
 import warnings
@@ -137,11 +137,13 @@ class BaseExecutor(ABC):
 
         def task_result(
             self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> bool: ...
+        ) -> bool:
+            return False
 
         def task_log(
             self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> bool: ...
+        ) -> bool:
+            return False
 
     def __init__(
         self,
@@ -189,7 +191,7 @@ class BaseExecutor(ABC):
         self,
         tasklet: Callable,
         args: List[Any],
-        when: str = "after",
+        when: Union[Literal["before"], Literal["after"]] = "after",
         set_result: bool = False,
         set_summary: bool = False,
     ) -> None:
@@ -264,10 +266,14 @@ class BaseExecutor(ABC):
             new_args.append(new_arg)
         return new_args
 
-    def _run_tasklets(self, *, when: str) -> None:
+    def _run_tasklets(
+        self, *, when: Union[Literal["before"], Literal["after"]]
+    ) -> None:
         """Run all tasklets of the specified kind."""
         if when not in self._tasklets.keys():
             logger.error(f"Ignore request to run tasklets of unknown kind: {when}")
+            return
+        if self._tasklets[when] is None:
             return
         for tasklet_spec in self._tasklets[when]:
             tasklet: Callable[[Any], Any]
@@ -285,13 +291,14 @@ class BaseExecutor(ABC):
                 output = None
             # We set result payloads or summaries now, but the processing is done
             # by process_results method called sometime after the last tasklet
+            tmp: Any
             if set_result and output is not None:
                 if isinstance(self._analysis_desc.task_result.payload, list):
                     # We have multiple payloads to process, append to list
                     self._analysis_desc.task_result.payload.append(output)
                 elif self._analysis_desc.task_result.payload != "":
                     # We have one payload already, convert to list and append
-                    tmp: Any = self._analysis_desc.task_result.payload
+                    tmp = self._analysis_desc.task_result.payload
                     self._analysis_desc.task_result.payload = []
                     self._analysis_desc.task_result.payload.append(tmp)
                     self._analysis_desc.task_result.payload.append(output)
@@ -304,7 +311,7 @@ class BaseExecutor(ABC):
                     self._analysis_desc.task_result.summary.append(output)
                 elif self._analysis_desc.task_result.summary != "":
                     # We have one summary already, convert to list and append
-                    tmp: Any = self._analysis_desc.task_result.summary
+                    tmp = self._analysis_desc.task_result.summary
                     self._analysis_desc.task_result.summary = []
                     self._analysis_desc.task_result.summary.append(tmp)
                     self._analysis_desc.task_result.summary.append(output)
@@ -315,7 +322,7 @@ class BaseExecutor(ABC):
     def add_hook(
         self,
         event: str,
-        hook: Callable[[Self, Message, Optional[subprocess.Popen]], None],
+        hook: Callable[[Self, Message, Optional[subprocess.Popen]], Optional[bool]],
     ) -> None:
         """Add a new hook.
 
@@ -457,8 +464,10 @@ class BaseExecutor(ABC):
             stderr=subprocess.PIPE,
             env=self._analysis_desc.task_env,
         )
-        os.set_blocking(proc.stdout.fileno(), False)
-        os.set_blocking(proc.stderr.fileno(), False)
+        if proc.stdout is not None:
+            os.set_blocking(proc.stdout.fileno(), False)
+        if proc.stderr is not None:
+            os.set_blocking(proc.stderr.fileno(), False)
         return proc
 
     @abstractmethod
@@ -526,12 +535,16 @@ class BaseExecutor(ABC):
             self._task_loop(proc)
             time.sleep(self._analysis_desc.poll_interval)
 
-        os.set_blocking(proc.stdout.fileno(), True)
-        os.set_blocking(proc.stderr.fileno(), True)
+        if proc.stdout is not None:
+            os.set_blocking(proc.stdout.fileno(), True)
+        if proc.stderr is not None:
+            os.set_blocking(proc.stderr.fileno(), True)
 
         self._finalize_task(proc)
-        proc.stdout.close()
-        proc.stderr.close()
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None:
+            proc.stderr.close()
         proc.wait()
         if ret := proc.returncode:
             logger.warning(f"Task failed with return code: {ret}")
@@ -695,8 +708,9 @@ class BaseExecutor(ABC):
                     break  # We should only have 1 result-like parameter!
 
         # If we get this far and haven't changed the payload we should complain
+        task_name: str
         if self._analysis_desc.task_result.payload == "":
-            task_name: str = self._analysis_desc.task_result.task_name
+            task_name = self._analysis_desc.task_result.task_name
             logger.debug(
                 (
                     f"{task_name} specified result be set from {task_name}Parameters,"
@@ -711,7 +725,7 @@ class BaseExecutor(ABC):
         self._analysis_desc.task_result.impl_schemas = impl_schemas
         # If we set_result but didn't get schema information we should complain
         if self._analysis_desc.task_result.impl_schemas is None:
-            task_name: str = self._analysis_desc.task_result.task_name
+            task_name = self._analysis_desc.task_result.task_name
             logger.debug(
                 (
                     f"{task_name} specified result be set from {task_name}Parameters,"
@@ -780,7 +794,10 @@ class Executor(BaseExecutor):
 
         self.add_hook("no_pickle_mode", no_pickle_mode)
 
-        def task_started(self: Executor, msg: Message, proc: subprocess.Popen) -> None:
+        def task_started(
+            self: Executor, msg: Message, proc: Optional[subprocess.Popen]
+        ) -> None:
+            assert proc is not None
             if isinstance(msg.contents, TaskParameters):
                 self._analysis_desc.task_parameters = msg.contents
                 # Run "before" tasklets
@@ -892,9 +909,9 @@ class Executor(BaseExecutor):
             while True:
                 msg: Message = communicator.read(proc)
                 if msg.signal is not None and msg.signal.upper() in LUTE_SIGNALS:
-                    hook: Callable[[Executor, Message], None] = getattr(
-                        self.Hooks, msg.signal.lower()
-                    )
+                    hook: Callable[
+                        [Executor, Message, Optional[subprocess.Popen]], None
+                    ] = getattr(self.Hooks, msg.signal.lower())
                     should_continue = hook(self, msg, proc)
                     if should_continue:
                         continue
@@ -968,7 +985,7 @@ class Executor(BaseExecutor):
         """
         if self._analysis_desc.task_parameters is None:
             logger.error("Please run Task before using this method!")
-            return
+            return None
         # ElogSummaryPlots has figures and a display name
         # display name also serves as a path.
         expmt: str = self._analysis_desc.task_parameters.lute_config.experiment

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -29,8 +29,20 @@ import subprocess
 import time
 import os
 import signal
-from typing import Dict, Callable, List, Optional, Any, Tuple, Literal, Union, cast
-from typing_extensions import Self, TypedDict, TypeAlias
+from typing import (
+    Dict,
+    Callable,
+    List,
+    Optional,
+    Any,
+    Tuple,
+    Literal,
+    Union,
+    cast,
+    Protocol,
+    Type,
+)
+from typing_extensions import TypedDict, TypeAlias
 from abc import ABC, abstractmethod
 import warnings
 import copy
@@ -82,6 +94,36 @@ class TaskletDict(TypedDict):
 Executor_T: TypeAlias = "BaseExecutor"
 
 
+class Hook(Protocol):
+    def __call__(
+        self,
+        executor: Executor_T,
+        msg: Message,
+        proc: Optional[subprocess.Popen] = None,
+    ) -> Optional[bool]: ...
+
+
+class ExecutorHooks:
+    """A container class for the Executor's event hooks.
+
+    There is a corresponding function (hook) for each event/signal. Each
+    function takes three parameters - a reference to the Executor, a reference
+    to the Message (msg) which includes the corresponding signal and the Task
+    subprocess.
+    """
+
+    __slots__ = LUTE_SIGNALS
+
+    no_pickle_mode: Hook
+    task_started: Hook
+    task_failed: Hook
+    task_stopped: Hook
+    task_done: Hook
+    task_cancelled: Hook
+    task_result: Hook
+    task_log: Hook
+
+
 class BaseExecutor(ABC):
     """ABC to manage Task execution and communication with user services.
 
@@ -105,72 +147,7 @@ class BaseExecutor(ABC):
         execute_task(): Run the task as a subprocess.
     """
 
-    class Hooks:
-        """A container class for the Executor's event hooks.
-
-        There is a corresponding function (hook) for each event/signal. Each
-        function takes two parameters - a reference to the Executor (self) and
-        a reference to the Message (msg) which includes the corresponding
-        signal.
-        """
-
-        @staticmethod
-        def no_pickle_mode(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_started(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_failed(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_stopped(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_done(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_cancelled(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> None: ...
-
-        @staticmethod
-        def task_result(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> bool:
-            return False
-
-        @staticmethod
-        def task_log(
-            executor: Executor_T,
-            msg: Message,
-            proc: Optional[subprocess.Popen] = None,
-        ) -> bool:
-            return False
+    Hooks: Type[ExecutorHooks] = ExecutorHooks
 
     def __init__(
         self,
@@ -351,7 +328,8 @@ class BaseExecutor(ABC):
     def add_hook(
         self,
         event: str,
-        hook: Callable[[Self, Message, Optional[subprocess.Popen]], Optional[bool]],
+        # hook: Callable[[Self, Message, Optional[subprocess.Popen]], Optional[bool]],
+        hook: Hook,
     ) -> None:
         """Add a new hook.
 
@@ -827,101 +805,123 @@ class Executor(BaseExecutor):
         """Populate the set of default event hooks."""
 
         def no_pickle_mode(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> None:
-            for idx, communicator in enumerate(self._communicators):
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
+            for idx, communicator in enumerate(executor._communicators):
                 if isinstance(communicator, PipeCommunicator):
-                    self._communicators[idx] = PipeCommunicator(
+                    executor._communicators[idx] = PipeCommunicator(
                         Party.EXECUTOR, use_pickle=False
                     )
+            return None
 
         self.add_hook("no_pickle_mode", no_pickle_mode)
 
         def task_started(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen]
-        ) -> None:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             assert proc is not None
             if isinstance(msg.contents, TaskParameters):
-                self._analysis_desc.task_parameters = msg.contents
+                executor._analysis_desc.task_parameters = msg.contents
                 # Run "before" tasklets
-                if self._tasklets["before"] is not None:
-                    self._run_tasklets(when="before")
+                if executor._tasklets["before"] is not None:
+                    executor._run_tasklets(when="before")
                 # Need to continue since Task._signal_start raises SIGSTOP
-                self._continue(proc)
-                if hasattr(self._analysis_desc.task_parameters.Config, "set_result"):
+                executor._continue(proc)
+                if hasattr(
+                    executor._analysis_desc.task_parameters.Config, "set_result"
+                ):
                     # Tasks may mark a parameter as the result
                     # If so, setup the result now.
-                    self._set_result_from_parameters()
+                    executor._set_result_from_parameters()
             logger.info(
-                f"Executor: {self._analysis_desc.task_result.task_name} started"
+                f"Executor: {executor._analysis_desc.task_result.task_name} started"
             )
-            self._analysis_desc.task_result.task_status = TaskStatus.RUNNING
+            executor._analysis_desc.task_result.task_status = TaskStatus.RUNNING
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "RUNNING",
+                f"{executor._analysis_desc.task_result.task_name} status": "RUNNING",
             }
             post_elog_run_status(elog_data)
+            return None
 
         self.add_hook("task_started", task_started)
 
         def task_failed(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> None:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "FAILED",
+                f"{executor._analysis_desc.task_result.task_name} status": "FAILED",
             }
             post_elog_run_status(elog_data)
+            return None
 
         self.add_hook("task_failed", task_failed)
 
         def task_stopped(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> None:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "STOPPED",
+                f"{executor._analysis_desc.task_result.task_name} status": "STOPPED",
             }
             post_elog_run_status(elog_data)
+            return None
 
         self.add_hook("task_stopped", task_stopped)
 
         def task_done(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> None:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "COMPLETED",
+                f"{executor._analysis_desc.task_result.task_name} status": "COMPLETED",
             }
             post_elog_run_status(elog_data)
+            return None
 
         self.add_hook("task_done", task_done)
 
         def task_cancelled(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> None:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "CANCELLED",
+                f"{executor._analysis_desc.task_result.task_name} status": "CANCELLED",
             }
             post_elog_run_status(elog_data)
+            return None
 
         self.add_hook("task_cancelled", task_cancelled)
 
         def task_result(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> bool:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             if isinstance(msg.contents, TaskResult):
-                self._analysis_desc.task_result = msg.contents
+                executor._analysis_desc.task_result = msg.contents
                 # flake8: noqa: E731
                 is_printable_type: Callable[[Any], bool] = lambda x: isinstance(
                     x, dict
                 ) or isinstance(x, str)
-                if is_printable_type(self._analysis_desc.task_result.summary):
-                    logger.info(self._analysis_desc.task_result.summary)
-                elif isinstance(self._analysis_desc.task_result.summary, list):
-                    for item in self._analysis_desc.task_result.summary:
+                if is_printable_type(executor._analysis_desc.task_result.summary):
+                    logger.info(executor._analysis_desc.task_result.summary)
+                elif isinstance(executor._analysis_desc.task_result.summary, list):
+                    for item in executor._analysis_desc.task_result.summary:
                         if is_printable_type(item):
                             logger.info(item)
 
-                logger.info(self._analysis_desc.task_result.task_status)
+                logger.info(executor._analysis_desc.task_result.task_status)
             elog_data: Dict[str, str] = {
-                f"{self._analysis_desc.task_result.task_name} status": "COMPLETED",
+                f"{executor._analysis_desc.task_result.task_name} status": "COMPLETED",
             }
             post_elog_run_status(elog_data)
 
@@ -930,8 +930,10 @@ class Executor(BaseExecutor):
         self.add_hook("task_result", task_result)
 
         def task_log(
-            self: Executor, msg: Message, proc: Optional[subprocess.Popen] = None
-        ) -> bool:
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
+        ) -> Optional[bool]:
             if isinstance(msg.contents, str):
                 # This should be log formatted already
                 print(msg.contents)
@@ -1059,7 +1061,10 @@ class Executor(BaseExecutor):
                 individually.
         """
         if self._analysis_desc.task_parameters is None:
-            logger.error("Please run Task before using this method!")
+            logger.error(
+                "Please run Task before using this method! (_process_result_summary). "
+                "If you did run a Task, it may have failed immediately!"
+            )
             return
         if isinstance(summary, dict):
             # Assume dict is key: value pairs of eLog run parameters to post
@@ -1094,7 +1099,10 @@ class Executor(BaseExecutor):
                 summary field of the database.
         """
         if self._analysis_desc.task_parameters is None:
-            logger.error("Please run Task before using this method!")
+            logger.error(
+                "Please run Task before using this method! (_process_summary_run_params). "
+                "If you did run a Task, it may have failed immediately!"
+            )
             return ""
         exp: str = self._analysis_desc.task_parameters.lute_config.experiment
         run: int = int(self._analysis_desc.task_parameters.lute_config.run)

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -36,8 +36,6 @@ import warnings
 import copy
 import re
 
-import psutil
-
 from lute.execution.logging import get_logger
 from lute.execution.ipc import (
     Party,
@@ -642,19 +640,19 @@ class BaseExecutor(ABC):
     def _continue(self, proc: subprocess.Popen) -> None:
         """Resume a stopped Task subprocess."""
         os.kill(proc.pid, signal.SIGCONT)
-        status: str = psutil.Process(proc.pid).status()
-        max_tries: int = 10
-        while status != "running":
-            max_tries -= 1
-            os.kill(proc.pid, signal.SIGCONT)
-            status = psutil.Process(proc.pid).status()
-            if max_tries == 0:
-                logger.error(
-                    "Cannot resume process from stopped/sleeping state! Exiting!"
-                )
-                os.kill(proc.pid, signal.SIGKILL)
-                self._analysis_desc.task_result.task_status = TaskStatus.FAILED
-                return None
+        # status: str = psutil.Process(proc.pid).status()
+        # max_tries: int = 10
+        # while status != "running":
+        #    max_tries -= 1
+        #    os.kill(proc.pid, signal.SIGCONT)
+        #    status = psutil.Process(proc.pid).status()
+        #    if max_tries == 0:
+        #        logger.error(
+        #            "Cannot resume process from stopped/sleeping state! Exiting!"
+        #        )
+        #        os.kill(proc.pid, signal.SIGKILL)
+        #        self._analysis_desc.task_result.task_status = TaskStatus.FAILED
+        #        return None
         self._analysis_desc.task_result.task_status = TaskStatus.RUNNING
 
     def _set_result_from_parameters(self) -> None:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -24,13 +24,12 @@ __all__ = ["BaseExecutor", "Executor", "MPIExecutor"]
 __author__ = "Gabriel Dorlhiac"
 
 import sys
-import _io
 import logging
 import subprocess
 import time
 import os
 import signal
-from typing import Dict, Callable, List, Optional, Any, Tuple, Union
+from typing import Dict, Callable, List, Optional, Any, Tuple
 from typing_extensions import Self, TypedDict
 from abc import ABC, abstractmethod
 import warnings
@@ -46,7 +45,6 @@ from lute.execution.ipc import (
     LUTE_SIGNALS,
     Communicator,
 )
-from lute.tasks.task import Task
 from lute.tasks.dataclasses import (
     DescribedAnalysis,
     TaskResult,
@@ -56,9 +54,8 @@ from lute.tasks.dataclasses import (
 from lute.io.models.base import (
     TaskParameters,
     TemplateParameters,
-    AnalysisHeader,
-    TemplateConfig,
-    TemplateParameters,
+    AnalysisHeader,  # noqa: F401
+    TemplateConfig,  # noqa: F401
     ThirdPartyParameters,
 )  # NOTE: All imports required for unpickling!
 from lute.io.db import record_analysis_db
@@ -543,7 +540,7 @@ class BaseExecutor(ABC):
         elif self._analysis_desc.task_result.task_status == TaskStatus.RUNNING:
             # Ret code is 0, no exception was thrown, task forgot to set status
             self._analysis_desc.task_result.task_status = TaskStatus.COMPLETED
-            logger.debug(f"Task did not change from RUNNING status. Assume COMPLETED.")
+            logger.debug("Task did not change from RUNNING status. Assume COMPLETED.")
             self.Hooks.task_done(self, msg=Message())
         if self._tasklets["after"] is not None:
             # Tasklets before results processing since they may create result
@@ -851,6 +848,7 @@ class Executor(BaseExecutor):
         ) -> bool:
             if isinstance(msg.contents, TaskResult):
                 self._analysis_desc.task_result = msg.contents
+                # flake8: noqa: E731
                 is_printable_type: Callable[[Any], bool] = lambda x: isinstance(
                     x, dict
                 ) or isinstance(x, str)
@@ -947,8 +945,9 @@ class Executor(BaseExecutor):
             if new_payload != "":
                 self._analysis_desc.task_result.payload = new_payload
         elif isinstance(payload, str):
+            ...
             # May be a path to a file...
-            schemas: Optional[str] = self._analysis_desc.task_result.impl_schemas
+            # schemas: Optional[str] = self._analysis_desc.task_result.impl_schemas
             # Should also check `impl_schemas` to determine what to do with path
 
     def _process_elog_plot(self, plots: ElogSummaryPlots) -> Optional[str]:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -954,10 +954,8 @@ class Executor(BaseExecutor):
             while True:
                 msg: Message = communicator.read(proc)
                 if msg.signal is not None and msg.signal.upper() in LUTE_SIGNALS:
-                    hook: Callable[
-                        [Executor, Message, Optional[subprocess.Popen]], None
-                    ] = getattr(self.Hooks, msg.signal.lower())
-                    should_continue = hook(self, msg, proc)  # type: ignore
+                    hook: Hook = getattr(self.Hooks, msg.signal.lower())
+                    should_continue = hook(self, msg, proc)
                     if should_continue:
                         continue
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -36,6 +36,8 @@ import warnings
 import copy
 import re
 
+import psutil
+
 from lute.execution.logging import get_logger
 from lute.execution.ipc import (
     Party,
@@ -629,6 +631,7 @@ class BaseExecutor(ABC):
         is_running: bool = task_status != TaskStatus.COMPLETED
         is_running &= task_status != TaskStatus.CANCELLED
         is_running &= task_status != TaskStatus.TIMEDOUT
+        is_running &= task_status != TaskStatus.FAILED
         return proc.poll() is None and is_running
 
     def _stop(self, proc: subprocess.Popen) -> None:
@@ -639,6 +642,19 @@ class BaseExecutor(ABC):
     def _continue(self, proc: subprocess.Popen) -> None:
         """Resume a stopped Task subprocess."""
         os.kill(proc.pid, signal.SIGCONT)
+        status: str = psutil.Process(proc.pid).status()
+        max_tries: int = 10
+        while status != "running":
+            max_tries -= 1
+            os.kill(proc.pid, signal.SIGCONT)
+            status = psutil.Process(proc.pid).status()
+            if max_tries == 0:
+                logger.error(
+                    "Cannot resume process from stopped/sleeping state! Exiting!"
+                )
+                os.kill(proc.pid, signal.SIGKILL)
+                self._analysis_desc.task_result.task_status = TaskStatus.FAILED
+                return None
         self._analysis_desc.task_result.task_status = TaskStatus.RUNNING
 
     def _set_result_from_parameters(self) -> None:

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -29,8 +29,8 @@ import subprocess
 import time
 import os
 import signal
-from typing import Dict, Callable, List, Optional, Any, Tuple, Literal, Union
-from typing_extensions import Self, TypedDict
+from typing import Dict, Callable, List, Optional, Any, Tuple, Literal, Union, cast
+from typing_extensions import Self, TypedDict, TypeAlias
 from abc import ABC, abstractmethod
 import warnings
 import copy
@@ -79,6 +79,9 @@ class TaskletDict(TypedDict):
     after: Optional[List[Tuple[Callable[[Any], Any], List[Any], bool, bool]]]
 
 
+Executor_T: TypeAlias = "BaseExecutor"
+
+
 class BaseExecutor(ABC):
     """ABC to manage Task execution and communication with user services.
 
@@ -111,37 +114,61 @@ class BaseExecutor(ABC):
         signal.
         """
 
+        @staticmethod
         def no_pickle_mode(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_started(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_failed(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_stopped(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_done(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_cancelled(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> None: ...
 
+        @staticmethod
         def task_result(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> bool:
             return False
 
+        @staticmethod
         def task_log(
-            self: Self, msg: Message, proc: Optional[subprocess.Popen] = None
+            executor: Executor_T,
+            msg: Message,
+            proc: Optional[subprocess.Popen] = None,
         ) -> bool:
             return False
 
@@ -230,7 +257,8 @@ class BaseExecutor(ABC):
         if self._tasklets[when] is None:
             self._tasklets[when] = [tasklet_tuple]
         else:
-            self._tasklets[when].append(tasklet_tuple)
+            assert isinstance(self._tasklets[when], list)
+            cast(list, self._tasklets[when]).append(tasklet_tuple)
 
     def _sub_tasklet_parameters(self, args: List[Any]) -> List[Any]:
         """Substitute tasklet arguments using TaskParameters members."""
@@ -274,8 +302,9 @@ class BaseExecutor(ABC):
             logger.error(f"Ignore request to run tasklets of unknown kind: {when}")
             return
         if self._tasklets[when] is None:
+            logger.debug(f"No tasklets to run {when}.")
             return
-        for tasklet_spec in self._tasklets[when]:
+        for tasklet_spec in cast(list, self._tasklets[when]):
             tasklet: Callable[[Any], Any]
             args: List[Any]
             set_result: bool
@@ -912,7 +941,7 @@ class Executor(BaseExecutor):
                     hook: Callable[
                         [Executor, Message, Optional[subprocess.Popen]], None
                     ] = getattr(self.Hooks, msg.signal.lower())
-                    should_continue = hook(self, msg, proc)
+                    should_continue = hook(self, msg, proc)  # type: ignore
                     if should_continue:
                         continue
 

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -47,7 +47,7 @@ import queue
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Set, List, Literal, Union, Tuple
+from typing import Any, Optional, Set, List, Union, Tuple, cast
 from typing_extensions import Self
 
 USE_ZMQ: bool = True
@@ -126,11 +126,11 @@ class Communicator(ABC):
         """Method for sending data through the communication mechanism."""
         ...
 
-    def __str__(self):
+    def __str__(self) -> str:
         name: str = str(type(self)).split("'")[1].split(".")[-1]
         return f"{name}: {self.desc}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
     def __enter__(self) -> Self:
@@ -194,8 +194,12 @@ class PipeCommunicator(Communicator):
         """
         signal: Optional[str]
         contents: Optional[str]
-        raw_signal: bytes = proc.stderr.read()
-        raw_contents: bytes = proc.stdout.read()
+        raw_signal: Optional[bytes] = (
+            proc.stderr.read() if proc.stderr is not None else None
+        )
+        raw_contents: Optional[bytes] = (
+            proc.stdout.read() if proc.stdout is not None else None
+        )
         if raw_signal is not None:
             signal = raw_signal.decode()
         else:
@@ -418,12 +422,13 @@ class SocketCommunicator(Communicator):
         to use them.
         """
         self._data_socket: Union[socket.socket, zmq.sugar.socket.Socket]
+        self.desc: str
         if USE_ZMQ:
-            self.desc: str = "Communicates using ZMQ through TCP or Unix sockets."
-            self._context: zmq.context.Context = zmq.Context()
+            self.desc = "Communicates using ZMQ through TCP or Unix sockets."
+            self._context: zmq.Context = zmq.Context()
             self._data_socket = self._create_socket_zmq()
         else:
-            self.desc: str = "Communicates through a TCP or Unix socket."
+            self.desc = "Communicates through a TCP or Unix socket."
             self._data_socket = self._create_socket_raw()
             self._data_socket.settimeout(SocketCommunicator.ACCEPT_TIMEOUT)
 
@@ -491,10 +496,11 @@ class SocketCommunicator(Communicator):
 
         Raw socket implementation for the reader thread.
         """
+        assert isinstance(self._data_socket, socket.socket)
         connection: socket.socket
-        addr: Union[str, Tuple[str, int]]
+        _: Union[str, Tuple[str, int]]
         try:
-            connection, addr = self._data_socket.accept()
+            connection, _ = self._data_socket.accept()
             full_data: bytes = b""
             while True:
                 data: bytes = connection.recv(8192)
@@ -606,6 +612,7 @@ class SocketCommunicator(Communicator):
         if USE_ZMQ:
             self._data_socket.send(packed_msg)
         else:
+            assert isinstance(self._data_socket, socket.socket)
             self._data_socket.sendall(packed_msg)
 
     def write(self, msg: Message) -> None:
@@ -665,7 +672,7 @@ class SocketCommunicator(Communicator):
         Returns:
             data_socket (socket.socket): Unix socket object.
         """
-        socket_type: Literal[zmq.PULL, zmq.PUSH]
+        socket_type: int  # zmq.SocketType - either zmq.PULL or zmq.PUSH
         if self._party == Party.EXECUTOR:
             socket_type = zmq.PULL
         else:
@@ -956,7 +963,7 @@ class SocketCommunicator(Communicator):
             return
         else:
             if self._party == Party.EXECUTOR:
-                os.unlink(os.getenv("LUTE_SOCKET"))  # Should be defined
+                os.unlink(cast(str, os.getenv("LUTE_SOCKET")))  # Should be defined
                 return
             elif self._use_ssh_tunnel:
                 if self._ssh_proc is not None:

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -48,7 +48,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional, Set, List, Literal, Union, Tuple
-import _io
 from typing_extensions import Self
 
 USE_ZMQ: bool = True
@@ -205,14 +204,14 @@ class PipeCommunicator(Communicator):
             if self._use_pickle:
                 try:
                     contents = pickle.loads(raw_contents)
-                except (pickle.UnpicklingError, ValueError, EOFError) as err:
+                except (pickle.UnpicklingError, ValueError, EOFError):
                     logger.debug("PipeCommunicator (Executor) - Set _use_pickle=False")
                     self._use_pickle = False
                     contents = self._safe_unpickle_decode(raw_contents)
             else:
                 try:
                     contents = raw_contents.decode()
-                except UnicodeDecodeError as err:
+                except UnicodeDecodeError:
                     logger.debug("PipeCommunicator (Executor) - Set _use_pickle=True")
                     self._use_pickle = True
                     contents = self._safe_unpickle_decode(raw_contents)
@@ -278,7 +277,7 @@ class PipeCommunicator(Communicator):
                     logger.debug(
                         f"PipeCommunicator has truncated message. Unable to retrieve {missing_bytes} bytes."
                     )
-        except (pickle.UnpicklingError, ValueError, EOFError) as err:
+        except (pickle.UnpicklingError, ValueError, EOFError):
             # Pickle may also throw a ValueError, e.g. this bytes: b"Found! \n"
             # Pickle may also throw an EOFError, eg. this bytes: b"F0\n"
             try:
@@ -709,7 +708,7 @@ class SocketCommunicator(Communicator):
                 sock.close()
                 del sock
                 return port
-            except:
+            except Exception:
                 continue
         return None
 
@@ -810,7 +809,7 @@ class SocketCommunicator(Communicator):
         socket_path: str
         try:
             socket_path = os.environ["LUTE_SOCKET"]
-        except KeyError as err:
+        except KeyError:
             import uuid
             import tempfile
 

--- a/lute/execution/logging.py
+++ b/lute/execution/logging.py
@@ -10,7 +10,7 @@ Functions:
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 from lute.execution.ipc import SocketCommunicator, Message
 
@@ -20,7 +20,7 @@ __author__ = "Gabriel Dorlhiac"
 STD_PYTHON_LOG_FORMAT: str = "%(levelname)s:%(name)s:%(message)s"
 """Default Python logging formatter specification."""
 
-LUTE_TASK_LOG_FORMAT: str = f"TASK_LOG -- %(levelname)s:%(name)s: %(message)s"
+LUTE_TASK_LOG_FORMAT: str = "TASK_LOG -- %(levelname)s:%(name)s: %(message)s"
 """Format specification for the formatter used by the standard LUTE logger."""
 
 

--- a/lute/execution/logging.py
+++ b/lute/execution/logging.py
@@ -10,7 +10,7 @@ Functions:
 """
 
 import logging
-from typing import Optional, Dict
+from typing import Optional, Dict, Literal
 
 from lute.execution.ipc import SocketCommunicator, Message
 
@@ -50,7 +50,7 @@ class ColorFormatter(logging.Formatter):
         self,
         fmt: Optional[str] = None,
         datefmt: Optional[str] = None,
-        style: str = "%",
+        style: Literal["%", "{", "$"] = "%",
         validate: bool = True,
         *,
         is_task: bool = True,
@@ -69,7 +69,7 @@ class ColorFormatter(logging.Formatter):
             logging.CRITICAL: f"{self.CRITICAL_COLOR_FMT}{log_format}{self.RESET_COLOR_FMT}",
         }
 
-    def format(self, record):
+    def format(self, record) -> str:
         log_fmt: str = self.level_formats[record.levelno]
         formatter: logging.Formatter = logging.Formatter(log_fmt)
         return formatter.format(record)
@@ -102,7 +102,7 @@ def get_logger(name: str, is_task: bool = True) -> logging.Logger:
     logger.propagate = False
     handler: logging.Handler
     if is_task:
-        handler: SocketCommunicatorHandler = SocketCommunicatorHandler()
+        handler = SocketCommunicatorHandler()
     else:
         handler = logging.StreamHandler()
     formatter: ColorFormatter = ColorFormatter(is_task=is_task)

--- a/lute/io/_sqlite.py
+++ b/lute/io/_sqlite.py
@@ -3,7 +3,9 @@
 Functions should be used only by the higher-level database module.
 """
 
-__all__ = []
+from typing import List
+
+__all__: List[str] = []
 __author__ = "Gabriel Dorlhiac"
 
 import sqlite3
@@ -150,6 +152,7 @@ def _make_task_table(
     Returns:
         success (bool): Whether the table was created correctly or not.
     """
+    sql: str
     # Check existence explicitly because may need to modify...
     if _does_table_exist(con, task_name):
         # Compare current columns vs new columns - the same Task can have
@@ -157,7 +160,7 @@ def _make_task_table(
         current_cols: Dict[str, str] = _get_table_cols(con, task_name)
         if diff := _compare_cols(current_cols, columns):
             for col in diff.items():
-                sql: str = f'ALTER TABLE {task_name} ADD COLUMN "{col[0]}" {col[1]}'
+                sql = f'ALTER TABLE {task_name} ADD COLUMN "{col[0]}" {col[1]}'
                 logger.debug(f"_make_task_table[ALTER]: {sql}")
                 with con:
                     con.execute(sql)
@@ -172,7 +175,7 @@ def _make_task_table(
         f"gen_cfg_id INTEGER, exec_cfg_id INTEGER, {col_str}, "
         "valid_flag INTEGER)"
     )
-    sql: str = f"CREATE TABLE IF NOT EXISTS {db_str}"
+    sql = f"CREATE TABLE IF NOT EXISTS {db_str}"
     logger.debug(f"_make_task_table[CREATE]: {sql}")
     with con:
         con.execute(sql)

--- a/lute/io/_sqlite.py
+++ b/lute/io/_sqlite.py
@@ -8,7 +8,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import sqlite3
 import logging
-from typing import List, Dict, Dict, Any, Tuple, Optional
+from typing import List, Dict, Any, Tuple, Optional
 
 if __debug__:
     logging.basicConfig(level=logging.DEBUG)
@@ -225,7 +225,7 @@ def _add_task_entry(
     with con:
         # ins_str: str = "".join(f':"{x}", ' for x in entry.keys())[:-2]
         logger.debug(f"_add_task_entry: {keys}\n\t\t{values}")
-        res = con.execute(
+        _ = con.execute(
             f"INSERT INTO {task_name} ({','.join(keys)}) VALUES ({placeholder_str})",
             values,
         )

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -21,7 +21,7 @@ import warnings
 from typing import List, Dict, Iterator, Any
 
 import pprint
-import yaml
+import yaml  # type: ignore
 
 from lute.io.models import *
 from lute.execution.debug_utils import LUTE_DEBUG_EXIT

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -11,29 +11,19 @@ Exceptions:
         Pydantic)
 """
 
+# flake8: noqa: F403,F405
+
 __all__ = ["parse_config"]
 __author__ = "Gabriel Dorlhiac"
 
 import re
 import warnings
-from typing import List, Dict, Iterator, Dict, Any
+from typing import List, Dict, Iterator, Any
 
 import pprint
 import yaml
-from pydantic import (
-    BaseModel,
-    BaseSettings,
-    HttpUrl,
-    PositiveInt,
-    NonNegativeInt,
-    Field,
-    conint,
-    root_validator,
-    validator,
-)
-from pydantic.dataclasses import dataclass
 
-from .models import *
+from lute.io.models import *
 from lute.execution.debug_utils import LUTE_DEBUG_EXIT
 
 
@@ -195,7 +185,7 @@ def parse_config(task_name: str = "test", config_path: str = "") -> TaskParamete
     try:
         task_config: Dict[str, Any] = dict(config[task_name])
         lute_config.update(task_config)
-    except KeyError as err:
+    except KeyError:
         warnings.warn(
             (
                 f"{task_name} has no parameter definitions in YAML file."

--- a/lute/io/config.py
+++ b/lute/io/config.py
@@ -21,7 +21,7 @@ import warnings
 from typing import List, Dict, Iterator, Any
 
 import pprint
-import yaml  # type: ignore
+import yaml
 
 from lute.io.models import *
 from lute.execution.debug_utils import LUTE_DEBUG_EXIT

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -21,7 +21,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import logging
 import os
-from typing import List, Dict, Dict, Any, Tuple, Optional, Union
+from typing import List, Dict, Any, Tuple, Optional, Union
 
 from lute.execution.logging import get_logger
 from lute.io.models.base import TaskParameters, TemplateParameters
@@ -165,7 +165,7 @@ def _check_type(value: Any) -> str:
 
 
 def _list_to_flatlists(
-    l: List[Any], curr_key: str = ""
+    l_entry: Union[List[Any], Tuple], curr_key: str = ""
 ) -> Tuple[List[Tuple[str, Any]], List[Tuple[str, str]]]:
     """Flatten lists for database storage.
 
@@ -174,7 +174,7 @@ def _list_to_flatlists(
     function is called recursively to handle nesting.
 
     Args:
-        l (List[Any]): Dictionary to flatten.
+        l_entry (List[Any]): Dictionary to flatten.
 
         curr_key (str): Current flattened key. Base key for indexing.
 
@@ -188,7 +188,7 @@ def _list_to_flatlists(
     type_list: List[Tuple[str, str]] = []
     idx: int
     indexed_value: Any
-    for idx, indexed_value in enumerate(l):
+    for idx, indexed_value in enumerate(l_entry):
         indexed_curr_key: str = f"{curr_key}[{idx}]"
         if isinstance(indexed_value, tuple) or isinstance(indexed_value, list):
             x, y = _list_to_flatlists(indexed_value, indexed_curr_key)
@@ -331,7 +331,7 @@ def record_analysis_db(cfg: DescribedAnalysis) -> None:
             logger.error(f"Database storage error: {err}")
     try:
         os.chmod(db_path, 0o664)
-    except:
+    except Exception:
         logger.error("Cannot setup permissions on database!")
 
 

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -240,6 +240,8 @@ def _dict_to_flatdicts(
         corrected_value: Any = value
         if isinstance(corrected_value, TemplateParameters):
             corrected_value = value.params
+        x: Union[Dict[str, Any], List[Tuple[str, Any]]]
+        y: Union[Dict[str, str], List[Tuple[str, str]]]
         if isinstance(corrected_value, dict):
             x, y = _dict_to_flatdicts(corrected_value, curr_key=flat_key)
             param_list.extend(x.items())
@@ -272,6 +274,7 @@ def record_analysis_db(cfg: DescribedAnalysis) -> None:
         _add_task_entry,
     )
 
+    assert isinstance(cfg.task_parameters, TaskParameters)
     try:
         work_dir: str = cfg.task_parameters.lute_config.work_dir
     except AttributeError:

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -393,7 +393,7 @@ def post_elog_run_status(
         {"key": f"{key}", "value": f"{value}"} for key, value in current_status.items()
     ]
     params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
-    resp: requests.models.Response = requests.post(update_url, **params)
+    _: requests.models.Response = requests.post(update_url, **params)
 
 
 def post_elog_message(

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -53,7 +53,7 @@ from requests.auth import HTTPBasicAuth
 import mimetypes
 import os
 import logging
-from typing import Any, Dict, Optional, List, Union, Tuple, Mapping
+from typing import Any, Dict, Optional, List, Union, Tuple, Mapping, cast
 from io import BufferedReader
 
 from lute.io.exceptions import ElogFileFormatError
@@ -221,7 +221,7 @@ def get_elog_kerberos_auth() -> Dict[str, str]:
     Returns:
         auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
     """
-    from krtc import KerberosTicket
+    from krtc import KerberosTicket  # type: ignore
 
     return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
 
@@ -340,15 +340,19 @@ def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]
     """
     import getpass
 
+    if os.getenv("ARP_ROOT_JOB_ID") is None or os.getenv("RUN_NUM") is None:
+        raise RuntimeError(
+            "Cannot call _get_current_run_status with no ROOT_JOB or RUN_NUM"
+        )
     user: str = getpass.getuser()
     replace_counters_parts: List[str] = update_url.split("/")
     exp: str = replace_counters_parts[-2]
     get_url: str = "/".join(replace_counters_parts[:-3])
     get_url = f"{get_url}/{exp}/get_counters"
     job_doc: Dict[str, str] = {
-        "_id": os.environ.get("ARP_ROOT_JOB_ID"),
+        "_id": cast(str, os.environ.get("ARP_ROOT_JOB_ID")),
         "experiment": exp,
-        "run_num": os.environ.get("RUN_NUM"),
+        "run_num": cast(str, os.environ.get("RUN_NUM")),
         "user": user,
     }
     resp: requests.models.Response = requests.post(
@@ -392,8 +396,7 @@ def post_elog_run_status(
     post_list: List[Dict[str, str]] = [
         {"key": f"{key}", "value": f"{value}"} for key, value in current_status.items()
     ]
-    params: Dict[str, List[Dict[str, str]]] = {"json": post_list}
-    _: requests.models.Response = requests.post(update_url, **params)
+    _: requests.models.Response = requests.post(update_url, json=post_list)
 
 
 def post_elog_message(
@@ -450,6 +453,7 @@ def post_elog_message(
     if resp_msg != "SUCCESS":
         return resp_msg
     # NEED to handle/propagate errors...
+    return None
 
 
 def post_elog_run_table(
@@ -482,6 +486,7 @@ def post_elog_run_table(
     if resp_msg != "SUCCESS":
         return resp_msg
     # NEED to handle/propagate errors....
+    return None
 
 
 def get_elog_runs_by_tag(
@@ -509,7 +514,7 @@ def get_elog_runs_by_tag(
 
 def get_elog_params_by_run(
     exp: str, params: List[str], runs: Optional[List[int]] = None
-) -> Dict[str, str]:
+) -> Optional[Dict[str, str]]:
     """Retrieve requested parameters by run or for all runs.
 
     Args:
@@ -519,4 +524,4 @@ def get_elog_params_by_run(
             parameter recorded in the eLog (PVs, parameters posted by other
             Tasks, etc.)
     """
-    ...
+    return None

--- a/lute/io/elog.py
+++ b/lute/io/elog.py
@@ -53,7 +53,7 @@ from requests.auth import HTTPBasicAuth
 import mimetypes
 import os
 import logging
-from typing import Any, Dict, Optional, List, Union, Tuple
+from typing import Any, Dict, Optional, List, Union, Tuple, Mapping
 from io import BufferedReader
 
 from lute.io.exceptions import ElogFileFormatError
@@ -363,7 +363,7 @@ def _get_current_run_status(update_url: str) -> Dict[str, Union[str, int, float]
 
 
 def post_elog_run_status(
-    data: Dict[str, Union[str, int, float]], update_url: Optional[str] = None
+    data: Mapping[str, Union[str, int, float]], update_url: Optional[str] = None
 ) -> None:
     """Post a summary to the status/report section of a specific run.
 

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -1,5 +1,7 @@
 """Pydantic models for Task parameters and configuration."""
 
+# flake8: noqa: F403
+
 from .base import *
 from .sfx_find_peaks import *
 from .sfx_index import *

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -39,7 +39,6 @@ from pydantic import (
     PrivateAttr,
 )
 from pydantic.dataclasses import dataclass
-from pydantic.schema import model_schema, default_ref_template
 
 
 class AnalysisHeader(BaseModel):
@@ -289,9 +288,6 @@ class ThirdPartyParameters(TaskParameters):
     @root_validator(pre=False)
     def extra_fields_to_thirdparty(cls, values: Dict[str, Any]):
         cls._unknown_template_params = {}
-        my_schema: Dict[str, Any] = model_schema(
-            cls, by_alias=True, ref_template=default_ref_template
-        )
         param_schema_template: Dict[str, Any] = {
             "title": "",
             "description": "Unknown template parameters.",

--- a/lute/io/models/base.py
+++ b/lute/io/models/base.py
@@ -300,7 +300,7 @@ class ThirdPartyParameters(TaskParameters):
         new_values: Dict[str, Any] = {}
         for key in values:
             if key not in cls.__fields__:
-                new_values[key] = TemplateParameters(values[key])
+                new_values[key] = TemplateParameters(params=values[key])
                 param_schema: Dict[str, Any] = param_schema_template.copy()
                 param_schema["title"] = key
                 param_schema["properties"]["params"] = values[key]

--- a/lute/io/models/mpi_tests.py
+++ b/lute/io/models/mpi_tests.py
@@ -1,38 +1,21 @@
-"""Models for all test Tasks.
+"""Models for MPI test Tasks.
 
 Classes:
     TestMultiNodeCommunicationParameters(TaskParameters): Model for test Task
         which verifies that the SocketCommunicator can write back to the
         Executor on a different node.
-    TestParameters(TaskParameters): Model for most basic test case. Single
-        core first-party Task. Uses only communication via pipes.
-
-    TestBinaryParameters(ThirdPartyParameters): Parameters for a simple multi-
-        threaded binary executable.
-
-    TestSocketParameters(TaskParameters): Model for first-party test requiring
-        communication via socket.
-
-    TestWriteOutputParameters(TaskParameters): Model for test Task which writes
-        an output file. Location of file is recorded in database.
-
-    TestReadOutputParameters(TaskParameters): Model for test Task which locates
-        an output file based on an entry in the database, if no path is provided.
 """
 
 __all__ = ["TestMultiNodeCommunicationParameters"]
 __author__ = "Gabriel Dorlhiac"
 
-from typing import Dict, Any, Optional, Literal
+from typing import Optional, Literal
 
 from pydantic import (
-    BaseModel,
     Field,
-    validator,
 )
 
-from .base import TaskParameters, ThirdPartyParameters
-from ..db import read_latest_db_entry
+from lute.io.models.base import TaskParameters
 
 
 class TestMultiNodeCommunicationParameters(TaskParameters):

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -162,7 +162,7 @@ class IndexCrystFELParameters(ThirdPartyParameters):
         flag_type="--",
         rename_param="temp-dir",
     )
-    wait_for_file: conint(gt=-2) = Field(
+    wait_for_file: conint(gt=-2) = Field(  # type: ignore
         0,
         description="Wait at most `x` seconds for a file to be created. A value of -1 means wait forever.",
         flag_type="--",
@@ -440,7 +440,7 @@ class IndexCrystFELParameters(ThirdPartyParameters):
                 f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "tag"
             )
             if tag is None:
-                tag: Optional[str] = read_latest_db_entry(
+                tag = read_latest_db_entry(
                     f"{values['lute_config'].work_dir}", "FindPeaksPsocake", "tag"
                 )
             fname: str = f"{expmt}_r{run:04d}"
@@ -517,7 +517,7 @@ class IndexCCTBXXFELParameters(ThirdPartyParameters):
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
-        class Config(BaseModel.Config):
+        class Config(BaseModel.Config):  # type: ignore
             extra: str = "allow"
 
         # Generic input settings: input_

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -23,7 +23,6 @@ import os
 from typing import Union, Optional, Dict, Any
 
 from pydantic import Field, validator, BaseModel
-from pydantic.schema import model_schema, default_ref_template  # Update `schema` method
 
 from lute.io.db import read_latest_db_entry
 from lute.io.models.base import ThirdPartyParameters, TemplateConfig

--- a/lute/io/models/sfx_merge.py
+++ b/lute/io/models/sfx_merge.py
@@ -225,7 +225,7 @@ class MergeCCTBXXFELParameters(ThirdPartyParameters):
     class PhilParameters(BaseModel):
         """Template parameters for CCTBX phil file."""
 
-        class Config(BaseModel.Config):
+        class Config(BaseModel.Config):  # type: ignore
             extra: str = "allow"
 
         # Generic input settings: input_

--- a/lute/io/models/sfx_solve.py
+++ b/lute/io/models/sfx_solve.py
@@ -9,7 +9,7 @@ __all__ = ["DimpleSolveParameters", "RunSHELXCParameters"]
 __author__ = "Gabriel Dorlhiac"
 
 import os
-from typing import Union, List, Optional, Dict, Any
+from typing import Union, Optional, Dict, Any
 
 from pydantic import Field, validator, PositiveFloat, PositiveInt, root_validator
 

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -39,7 +39,6 @@ from pydantic import (
 )
 
 from lute.io.models.base import TaskParameters, ThirdPartyParameters, TemplateConfig
-from lute.io.db import read_latest_db_entry
 from lute.io.models.validators import validate_smd_path, template_parameter_validator
 
 

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -507,9 +507,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     smd_path: str = Field(
         "", description="Path to the Small Data HDF5 file to analyze."
     )
-    xas_detname: Optional[str] = Field(
-        None, description="Name of the detector with absorption data."
-    )
+    xas_detname: str = Field(description="Name of the detector with absorption data.")
     xss_detname: Optional[str] = Field(
         None,
         description="Name of the detector with scattering data, for normalization.",
@@ -529,7 +527,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
         None, description="Name of the PV for the setpoint of the CCM."
     )
     thresholds: Thresholds = Field(Thresholds())
-    element: Optional[bool] = Field(
+    element: Optional[str] = Field(
         None,
         description="Element under investigation. Currently unused. For future EXAFS.",
     )
@@ -556,9 +554,7 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
     smd_path: str = Field(
         "", description="Path to the Small Data HDF5 file to analyze."
     )
-    xes_detname: Optional[str] = Field(
-        None, description="Name of the detector with absorption data."
-    )
+    xes_detname: str = Field(description="Name of the detector with absorption data.")
     xss_detname: Optional[str] = Field(
         None,
         description="Name of the detector with scattering data, for normalization.",

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -164,7 +164,8 @@ class SubmitSMDParameters(ThirdPartyParameters):
                 )
 
             droplet: DropletParams = Field(
-                DropletParams(), description="Droplet finding parameters."
+                DropletParams(threshold=5, thresholdLow=5, thresADU=60, useRms=True),
+                description="Droplet finding parameters.",
             )
 
             aduspphot: int = Field(162, description="")
@@ -482,7 +483,7 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    thresholds: Thresholds = Field(Thresholds())
+    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
     # analysis_flags: AnalysisFlags
 
 
@@ -526,7 +527,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     ccm_set: Optional[str] = Field(
         None, description="Name of the PV for the setpoint of the CCM."
     )
-    thresholds: Thresholds = Field(Thresholds())
+    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
     element: Optional[str] = Field(
         None,
         description="Element under investigation. Currently unused. For future EXAFS.",
@@ -569,7 +570,7 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    thresholds: Thresholds = Field(Thresholds())
+    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
     invert_xes_axes: bool = Field(
         False,
         description=(

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -4,8 +4,7 @@ Executor-managed Tasks with specific environment specifications are defined
 here.
 """
 
-from lute.execution.executor import *
-from lute.io.config import *
+from lute.execution.executor import Executor, MPIExecutor
 from lute.tasks.tasklets import (
     clone_smalldata,
     compare_hkl_fom_summary,

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -10,7 +10,7 @@ Exceptions:
 
 from typing import Type
 
-from .task import Task
+from lute.tasks.task import Task
 
 
 class TaskNotFoundError(Exception):

--- a/lute/tasks/_geometry.py
+++ b/lute/tasks/_geometry.py
@@ -3,42 +3,43 @@ from __future__ import annotations
 # flake8: noqa: F821 -- __future__ annota.
 
 import os
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, cast
 
-import lmfit
+import lmfit  # type: ignore
 import numpy as np
-from scipy.ndimage import map_coordinates
+import numpy.typing as npt
+from scipy.ndimage import map_coordinates  # type: ignore
 
 
 def generate_concentric_sample_pts(
-    peak_radii: np.ndarray[np.int64],
+    peak_radii: Union[npt.NDArray[np.int64], List[int]],
     center: List[float],
     num_pts: int = 200,
-) -> np.ndarray[np.float64]:
+) -> npt.NDArray[np.float64]:
     """Generate sample points along concentric circles.
 
     Args:
-        peak_radii (np.ndarray[np.int64]): Radii indices.
+        peak_radii (npt.NDArray[np.int64]): Radii indices.
 
         center (List[float]): Center_x, Center_y for the concentric circles.
 
         num_pts (int): Number of sample points.
 
     Returns:
-        coords (np.ndarray[np.float64]): X/Y coordinates of sample points.
+        coords (npt.NDArray[np.float64]): X/Y coordinates of sample points.
     """
     # X,Y labelling seems backwards
     cx: float = center[0]
     cy: float = center[1]
     # Reshape linear radii (peak indices) for broadcasting
-    radii: np.ndarray[np.int64] = np.array([peak_radii]).reshape(-1, 1)
-    theta: np.ndarray[np.float64] = np.linspace(0.0, 2 * np.pi, 200)
+    radii: npt.NDArray[np.int64] = np.array([peak_radii]).reshape(-1, 1)
+    theta: npt.NDArray[np.float64] = np.linspace(0.0, 2 * np.pi, 200)
 
-    coords_x: np.ndarray[np.float64] = radii * np.cos(theta) + cx
-    coords_y: np.ndarray[np.float64] = radii * np.sin(theta) + cy
+    coords_x: npt.NDArray[np.float64] = radii * np.cos(theta) + cx
+    coords_y: npt.NDArray[np.float64] = radii * np.sin(theta) + cy
 
     # Reshape for optimization routines
-    coords: np.ndarray[np.float64] = np.zeros((2, num_pts * len(peak_radii)))
+    coords: npt.NDArray[np.float64] = np.zeros((2, num_pts * len(peak_radii)))
     coords[1] = coords_x.reshape(-1)
     coords[0] = coords_y.reshape(-1)
 
@@ -46,31 +47,31 @@ def generate_concentric_sample_pts(
 
 
 def geometry_optimize_residual(
-    params: lmfit.Parameters, powder: np.ndarray[np.float64]
-) -> np.ndarray[np.float64]:
+    params: lmfit.Parameters, powder: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
     """Target function for OptimizeAgBhGeometryExhaustive geometry fitting.
 
     Args:
         params (lmfit.Parameters): Parameters. [center_x, center_y, peaks...]
             Center values are floats. Peaks are integers.
 
-        powder (np.ndarray[np.float64]): Powder image.
+        powder (npt.NDArray[np.float64]): Powder image.
 
     Returns:
-        pixel_values (np.ndarray[np.float64]): Residuals for fitting.
+        pixel_values (npt.NDArray[np.float64]): Residuals for fitting.
     """
     # Unpack the parameters
-    params_l: List[float] = [val.value for _, val in params.items()]
+    params_l: List[Union[float, int]] = [val.value for _, val in params.items()]
     center_guess: List[float] = params_l[:2]
     # Indices are in radii units since they are for a radial profile
-    indices: List[float] = params_l[2:]
-    coords: np.ndarray[np.float64] = generate_concentric_sample_pts(
+    indices: List[int] = cast(List[int], params_l[2:])
+    coords: npt.NDArray[np.float64] = generate_concentric_sample_pts(
         indices, center_guess
     )
 
     # Use residual for fitting - difference between intensity in ring
     # and powder max
-    pixel_values: np.ndarray[np.float64] = map_coordinates(powder, coords)
+    pixel_values: npt.NDArray[np.float64] = map_coordinates(powder, coords)
     pixel_values -= np.max(powder)
     return pixel_values
 
@@ -78,8 +79,8 @@ def geometry_optimize_residual(
 def generate_geom_file(
     exp: str,
     run: int,
-    ds: Union[psana.DataSource, psana.MPIDataSource],
-    det: psana.Detector,
+    ds: Union[psana.DataSource, psana.MPIDataSource],  # type: ignore
+    det: psana.Detector,  # type: ignore
     input_file: str,
     output_file: str,
     det_dist: Optional[float] = None,
@@ -110,7 +111,7 @@ def generate_geom_file(
 
         pv_camera_length (Optional[str]): PV associated with the camera length
     """
-    from psgeom import camera, sensors
+    from psgeom import camera, sensors  # type: ignore
 
     if input_file.split(".")[-1] == "data":
         geom = camera.CompoundAreaCamera.from_psana_file(input_file)
@@ -243,8 +244,8 @@ def deploy_geometry(
     out_dir: str,
     exp: str,
     run: int,
-    ds: Union[psana.DataSource, psana.MPIDataSource],
-    det: psana.Detector,
+    ds: Union[psana.DataSource, psana.MPIDataSource],  # type: ignore
+    det: psana.Detector,  # type: ignore
     pixel_size_mm: float,
     center: Tuple[float, float],
     distance: float,
@@ -273,7 +274,7 @@ def deploy_geometry(
 
         pv_camera_length (str | None): PV associated with camera length.
     """
-    import PSCalib
+    import PSCalib  # type: ignore
 
     # retrieve original geometry
     geom: PSCalib.GeometryAcces.GeometryAccess = det.geometry(run)

--- a/lute/tasks/_geometry.py
+++ b/lute/tasks/_geometry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# flake8: noqa: F821 -- __future__ annota.
+
 import os
 from typing import List, Optional, Tuple, Union
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -13,7 +13,7 @@ __author__ = "Gabriel Dorlhiac"
 
 import sys
 import logging
-from typing import List, Optional, Dict, Tuple, Union, cast
+from typing import List, Optional, Dict, Tuple, Union, cast, ClassVar
 
 import h5py  # type: ignore
 import holoviews as hv  # type: ignore
@@ -42,8 +42,8 @@ logger: logging.Logger = get_logger(__name__)
 class AnalyzeSmallData(Task):
     """Base class for analyzing a SmallData HDF5 file with MPI support."""
 
-    _LARGE_DETNAMES: List[str] = ["epix10k2M", "Rayonix", "Jungfrau4M"]
-    _SMALL_DETNAMES: List[str] = ["epix_1", "epix_2"]
+    _LARGE_DETNAMES: ClassVar[List[str]] = ["epix10k2M", "Rayonix", "Jungfrau4M"]
+    _SMALL_DETNAMES: ClassVar[List[str]] = ["epix_1", "epix_2"]
 
     def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
         super().__init__(params=params, use_mpi=use_mpi)

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -1703,7 +1703,7 @@ class AnalyzeSmallData(Task):
             ("Energy (Pixel)", "Energy (Pixel)")
         )
 
-        bin_centers: npt.NDArray[np.float_] = (scan_bins[:1] + scan_bins[1:]) / 2
+        bin_centers: npt.NDArray[np.float64] = (scan_bins[:1] + scan_bins[1:]) / 2
         diff_img: hv.Image = hv.Image(
             (
                 bin_centers,

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -15,15 +15,15 @@ import sys
 import logging
 from typing import List, Optional, Dict, Tuple, Union, cast
 
-import h5py
-import holoviews as hv
+import h5py  # type: ignore
+import holoviews as hv  # type: ignore
 import numpy as np
 import numpy.typing as npt
 import panel as pn
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore
 from mpi4py import MPI
-from scipy.signal import find_peaks
-from scipy.optimize import curve_fit
+from scipy.signal import find_peaks  # type: ignore
+from scipy.optimize import curve_fit  # type: ignore
 
 from lute.execution.logging import get_logger
 from lute.io.models.base import TaskParameters
@@ -416,7 +416,7 @@ class AnalyzeSmallData(Task):
             peak_heights: npt.NDArray = res[1]["peak_heights"]
         except KeyError:
             logger.debug("No peaks found")
-            return np.argmax(corrected_profile)
+            return cast(int, np.argmax(corrected_profile))
 
         peak_idx: int = peak_indices[
             np.argmax(peak_heights)
@@ -504,7 +504,7 @@ class AnalyzeSmallData(Task):
         Returns:
             fwhm (float): Calculated FWHM.
         """
-        from scipy.interpolate import UnivariateSpline
+        from scipy.interpolate import UnivariateSpline  # type: ignore
 
         x = np.linspace(0, len(trace) - 1, len(trace))
         spline = UnivariateSpline(x, (trace - np.max(trace) / 2), s=0)
@@ -560,7 +560,7 @@ class AnalyzeSmallData(Task):
 
             fwhm (float): Width of the convlution signal (fwhm).
         """
-        from scipy.signal import fftconvolve
+        from scipy.signal import fftconvolve  # type: ignore
 
         max_pt: int = self._find_solvent_argmax(laser_on)
         raw_curve: npt.NDArray = np.nan_to_num(diff[max_pt + 10])
@@ -733,7 +733,7 @@ class AnalyzeSmallData(Task):
                         (self._num_events, xes_roi.shape[spatial_axis + 1])
                     )
                 if self._task_parameters.rot_angle is not None:
-                    from scipy.ndimage import rotate
+                    from scipy.ndimage import rotate  # type: ignore
 
                     xes_roi = rotate(
                         xes_roi, angle=self._task_parameters.rot_angle, axes=(2, 1)

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -24,11 +24,9 @@ from mpi4py import MPI
 from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
 
-from lute.execution.ipc import Message
 from lute.execution.logging import get_logger
 from lute.io.models.base import TaskParameters
-from lute.tasks.task import *
-from lute.tasks.dataclasses import ElogSummaryPlots
+from lute.tasks.task import Task
 from lute.tasks.math import gaussian, sigma_to_fwhm
 
 
@@ -122,7 +120,7 @@ class AnalyzeSmallData(Task):
             self._xray_intensity = self._smd_h5[self._task_parameters.ipm_var][
                 self._start_idx : self._stop_idx
             ]
-        except KeyError as e:
+        except KeyError:
             logger.error("ipm data not found! Check config!")
         self._integrated_intensity = np.nansum(self._az_int, axis=(1, 2))
         self._setup_std_filters()
@@ -134,7 +132,7 @@ class AnalyzeSmallData(Task):
                     self._start_idx : self._stop_idx
                 ]
                 self._scan_var_name = scan_var
-            except KeyError as e:
+            except KeyError:
                 logger.error(f"Scan variable {scan_var} not found!")
         elif isinstance(self._task_parameters.scan_var, list):
             for scan_var in self._task_parameters.scan_var:
@@ -144,7 +142,7 @@ class AnalyzeSmallData(Task):
                     ]
                     self._scan_var_name = scan_var
                     break
-                except KeyError as e:
+                except KeyError:
                     logger.debug(f"Scan variable {scan_var} not found!")
                     continue
         if not hasattr(self, "_scan_values"):
@@ -156,7 +154,7 @@ class AnalyzeSmallData(Task):
                 ]
                 self._scan_var_name = "lxt_fast"
                 logger.debug("Using scan variable lxt_fast")
-            except KeyError as e:
+            except KeyError:
                 logger.debug("Scan variable lxt_fast not found!")
                 self._scan_values = np.linspace(
                     self._start_idx, self._stop_idx, self._num_events
@@ -332,7 +330,7 @@ class AnalyzeSmallData(Task):
         for data_filter in filters:
             try:
                 total_filter &= self._filter_dict[data_filter]
-            except KeyError as e:
+            except KeyError:
                 logger.debug(
                     f"Unrecognized filter requested: {data_filter}. "
                     "Ignoring and continuing processing."
@@ -384,7 +382,7 @@ class AnalyzeSmallData(Task):
         try:
             peak_indices: np.ndarray = res[0]
             peak_heights: np.ndarray = res[1]["peak_heights"]
-        except KeyError as e:
+        except KeyError:
             logger.debug("No peaks found")
             return np.argmax(corrected_profile)
 
@@ -529,7 +527,6 @@ class AnalyzeSmallData(Task):
         """
         from scipy.signal import fftconvolve
 
-        results: List[Tuple] = []
         max_pt: int = self._find_solvent_argmax(laser_on)
         raw_curve: np.ndarray = np.nan_to_num(diff[max_pt + 10])
         npts: int = len(raw_curve)
@@ -1146,7 +1143,7 @@ class AnalyzeSmallData(Task):
             hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
         ).opts(shared_axes=False)
         grid[:2, :2] = contours
-        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", f"Q"))
+        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
         ydim: hv.core.dimension.Dimension = hv.Dimension(("dS", "dS"))
         diff_curves: hv.Overlay
         diff_curves = hv.Curve((q_vals, diff[:, 0]))

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -13,11 +13,12 @@ __author__ = "Gabriel Dorlhiac"
 
 import sys
 import logging
-from typing import List, Optional, Dict, Tuple, Union
+from typing import List, Optional, Dict, Tuple, Union, cast
 
 import h5py
 import holoviews as hv
 import numpy as np
+import numpy.typing as npt
 import panel as pn
 import matplotlib.pyplot as plt
 from mpi4py import MPI
@@ -26,6 +27,11 @@ from scipy.optimize import curve_fit
 
 from lute.execution.logging import get_logger
 from lute.io.models.base import TaskParameters
+from lute.io.models.smd import (
+    AnalyzeSmallDataXASParameters,
+    AnalyzeSmallDataXESParameters,
+    AnalyzeSmallDataXSSParameters,
+)
 from lute.tasks.task import Task
 from lute.tasks.math import gaussian, sigma_to_fwhm
 
@@ -41,6 +47,14 @@ class AnalyzeSmallData(Task):
 
     def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
+        self._task_parameters = cast(
+            Union[
+                AnalyzeSmallDataXASParameters,
+                AnalyzeSmallDataXESParameters,
+                AnalyzeSmallDataXSSParameters,
+            ],
+            self._task_parameters,
+        )
         hv.extension("bokeh")
         pn.extension()
         self._mpi_comm: MPI.Intracomm = MPI.COMM_WORLD
@@ -54,8 +68,8 @@ class AnalyzeSmallData(Task):
             self._mpi_comm.Barrier()
             sys.exit(-1)
 
-        self._events_per_rank: np.ndarray[np.int64]
-        self._start_indices_per_rank: np.ndarray[np.int64]
+        self._events_per_rank: npt.NDArray[np.int64]
+        self._start_indices_per_rank: npt.NDArray[np.int64]
         if self._mpi_rank == 0:
             self._total_num_events: int = len(self._smd_h5["event_time"][()])
             quotient: int
@@ -98,13 +112,15 @@ class AnalyzeSmallData(Task):
         )
 
         # Generic filtering variables
-        self._filter_dict: Dict[str, np.ndarray[np.float64]] = {}
-        self._xray_intensity: np.ndarray[np.float64]
-        self._integrated_intensity: np.ndarray[np.float64]
+        self._filter_dict: Dict[
+            str, Union[npt.NDArray[np.float64], npt.NDArray[np.bool_]]
+        ] = {}
+        self._xray_intensity: npt.NDArray[np.float64]
+        self._integrated_intensity: npt.NDArray[np.float64]
 
         # Scan vars
         self._scan_var_name: Optional[str] = None
-        self._scan_values: np.ndarray[np.float64]
+        self._scan_values: npt.NDArray[np.float64]
 
     def _pre_run(self) -> None: ...
 
@@ -115,6 +131,14 @@ class AnalyzeSmallData(Task):
     def _extract_standard_data(self) -> None:
         """Setup up stored attributes by taking data from the smalldata hdf5 file."""
 
+        self._task_parameters = cast(
+            Union[
+                AnalyzeSmallDataXASParameters,
+                AnalyzeSmallDataXESParameters,
+                AnalyzeSmallDataXSSParameters,
+            ],
+            self._task_parameters,
+        )
         self._extract_az_int()
         try:
             self._xray_intensity = self._smd_h5[self._task_parameters.ipm_var][
@@ -245,6 +269,14 @@ class AnalyzeSmallData(Task):
 
         E.g. update the minimum scattering intensity to use in analyses.
         """
+        self._task_parameters = cast(
+            Union[
+                AnalyzeSmallDataXASParameters,
+                AnalyzeSmallDataXESParameters,
+                AnalyzeSmallDataXSSParameters,
+            ],
+            self._task_parameters,
+        )
         scattering_thresh: float = self._task_parameters.thresholds.min_Iscat
         ipm_thresh: float = self._task_parameters.thresholds.min_ipm
         self._filter_dict["total scattering"] = (
@@ -257,7 +289,7 @@ class AnalyzeSmallData(Task):
 
     def _calc_norm_by_qrange(
         self, q_limits: Tuple[float, float] = (0.9, 3.5)
-    ) -> np.ndarray[np.float64]:
+    ) -> npt.NDArray[np.float64]:
         """Calculate a normalization factor by averaging over a range of Q values.
 
         Args:
@@ -265,22 +297,22 @@ class AnalyzeSmallData(Task):
                 Q-range to average.
 
         Returns:
-            norm (np.ndarray[np.float64]): The 2D norm with shape
+            norm (npt.NDArray[np.float64]): The 2D norm with shape
                 (num_events, num_phi)
         """
-        norm_range: np.array = self._q_vals > q_limits[0]
+        norm_range: npt.NDArray[np.bool_] = self._q_vals > q_limits[0]
         norm_range &= self._q_vals < q_limits[1]
         return np.nanmean(self._az_int[..., norm_range], axis=-1)
 
-    def _calc_norm_by_max(self) -> np.ndarray[np.float64]:
+    def _calc_norm_by_max(self) -> npt.NDArray[np.float64]:
         """Calculate a normalization factor by taking the maximum of each profile.
 
         Returns:
-        norm (np.ndarray[np.float64]): The 1D norm with shape (num_events)
+        norm (npt.NDArray[np.float64]): The 1D norm with shape (num_events)
         """
         return np.nanmax(self._az_int, axis=(1, 2))
 
-    def _calc_1d_water_norm(self) -> np.ndarray[np.float64]:
+    def _calc_1d_water_norm(self) -> npt.NDArray[np.float64]:
         """Calculate normalization factors by integrating the water ring.
 
         https://www.osti.gov/servlets/purl/1760438 says to use 1.5-3.5 A-1
@@ -296,7 +328,7 @@ class AnalyzeSmallData(Task):
 
     def _aggregate_filters(
         self, filter_vars: str = ("xray on, laser on, total scattering, ipm")
-    ) -> np.ndarray[np.bool_]:
+    ) -> npt.NDArray[np.bool_]:
         """Combine a number of possible data filters.
 
         Takes a string of filters to be applied in the order specified. The
@@ -321,11 +353,11 @@ class AnalyzeSmallData(Task):
                 taken from the list above. E.g. "xray on, laser on".
 
         Returns:
-            total_filter (np.ndarray[np.bool]): A 1D boolean array with a shape
+            total_filter (npt.NDArray[np.bool]): A 1D boolean array with a shape
                 of (num_events) which can be used to index and filter a data array.
         """
         filters: List[str] = [f.strip() for f in filter_vars.split(",")]
-        total_filter: np.ndarray = np.ones([self._num_events], dtype=bool)
+        total_filter: npt.NDArray = np.ones([self._num_events], dtype=bool)
 
         for data_filter in filters:
             try:
@@ -340,18 +372,18 @@ class AnalyzeSmallData(Task):
         return total_filter
 
     def _calc_xss_dark_mean(
-        self, profiles: np.ndarray[np.float64]
-    ) -> np.ndarray[np.float64]:
+        self, profiles: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
         """Calculate the dark (X-ray off) mean of a set of XSS profiles.
 
         Args:
-            profiles (np.ndarray[np.float64]): Set of profiles to calculate the
+            profiles (npt.NDArray[np.float64]): Set of profiles to calculate the
                 dark mean from. Shape: (n_events, q_bins)
         Returns:
-            dark_mean (np.ndarray[np.float64]): The calculated dark mean.
+            dark_mean (npt.NDArray[np.float64]): The calculated dark mean.
                 Shape: (q_bins)
         """
-        dark_mean: np.ndarray[np.float64]
+        dark_mean: npt.NDArray[np.float64]
         try:
             dark_mean = np.nanmean(profiles[self._filter_dict["xray off"]], axis=0)
             dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
@@ -364,24 +396,24 @@ class AnalyzeSmallData(Task):
             dark_mean = np.zeros([self._num_events])
         return dark_mean
 
-    def _find_solvent_argmax(self, corrected_profile: np.ndarray) -> int:
+    def _find_solvent_argmax(self, corrected_profile: npt.NDArray) -> int:
         """Find the index of the solvent ring maximum.
 
         Currently just a hack around SciPy find_peaks.
 
         Args:
-            corrected_profile (np.ndarray[np.float64]): 1D normalized and dark
+            corrected_profile (npt.NDArray[np.float64]): 1D normalized and dark
                 mean corrected, laser on, scattering profile.
 
         Returns:
             peak_idx (int): The index where the solvent maximum is located.
         """
-        res: Tuple[np.ndarray[np.int64], Dict[str, np.ndarray[np.float64]]] = (
+        res: Tuple[npt.NDArray[np.int64], Dict[str, npt.NDArray[np.float64]]] = (
             find_peaks(corrected_profile, 1)
         )
         try:
-            peak_indices: np.ndarray = res[0]
-            peak_heights: np.ndarray = res[1]["peak_heights"]
+            peak_indices: npt.NDArray = res[0]
+            peak_heights: npt.NDArray = res[1]["peak_heights"]
         except KeyError:
             logger.debug("No peaks found")
             return np.argmax(corrected_profile)
@@ -394,21 +426,23 @@ class AnalyzeSmallData(Task):
 
     def _fit_overlap(
         self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
         guess: Optional[List[float]] = None,
-    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]:
+    ) -> Tuple[
+        npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]
+    ]:
         """Fit overlap based on scattering difference signal to a Gaussian.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 scattering profile.
 
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
                 (q_bins, scan_bins).
 
             guess (Optional[List[float]]): A list of initial parameter guesses
@@ -416,22 +450,23 @@ class AnalyzeSmallData(Task):
                 offset)
 
         Returns:
-            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+            raw_curve (npt.NDArray[np.float64]): 1D difference slice at a specific
                 Q value used for calculating the overlap.
 
-            opt (np.ndarray[np.float64]): Optimized parameters.
+            opt (npt.NDArray[np.float64]): Optimized parameters.
 
-            res (np.ndarray[np.float64]): Covariances.
+            res (npt.NDArray[np.float64]): Covariances.
         """
-        Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]
+        Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]
         max_pt: int = self._find_solvent_argmax(laser_on)
+        idx_peak_q: int
         try:
-            idx_peak_q: int = max_pt + 10
+            idx_peak_q = max_pt + 10
         except IndexError as e:
             logger.debug(f"{e}: No non-nan values found.")
-            idx_peak_q: int = 15
+            idx_peak_q = 15
 
-        raw_curve: np.ndarray = diff[idx_peak_q]
+        raw_curve: npt.NDArray = diff[idx_peak_q]
         if not guess:
             max_val: int = raw_curve.max()
             min_val: int = raw_curve.min()
@@ -457,14 +492,14 @@ class AnalyzeSmallData(Task):
         return raw_curve, opt, res
 
     def _fit_convolution_fwhm(
-        self, trace: np.ndarray, bins: np.ndarray[np.float64]
+        self, trace: npt.NDArray, bins: npt.NDArray[np.float64]
     ) -> float:
         """Calculate the FWHM of a convolution signal.
 
         Args:
-            trace (np.ndarray[np.float64]): 1D convolution trace.
+            trace (npt.NDArray[np.float64]): 1D convolution trace.
 
-            bins (np.ndarray[np.float64]): 1D set of bins used.
+            bins (npt.NDArray[np.float64]): 1D set of bins used.
 
         Returns:
             fwhm (float): Calculated FWHM.
@@ -499,27 +534,27 @@ class AnalyzeSmallData(Task):
 
     def _convolution_fit(
         self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
-    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], int, float]:
+        laser_on: npt.NDArray[np.float64],
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
+    ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], int, float]:
         """Fits a time scan through convolution with Heaviside kernel.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 scattering profile.
 
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
                 (q_bins, scan_bins).
 
         Returns:
-            raw_curve (np.ndarray[np.float64]): 1D difference slice at a specific
+            raw_curve (npt.NDArray[np.float64]): 1D difference slice at a specific
                 Q value used for calculating the overlap.
 
-            trace (np.ndarray[np.float64]): 1D convolution trace.
+            trace (npt.NDArray[np.float64]): 1D convolution trace.
 
             center (int): The index of the center from the convolution.
 
@@ -528,12 +563,12 @@ class AnalyzeSmallData(Task):
         from scipy.signal import fftconvolve
 
         max_pt: int = self._find_solvent_argmax(laser_on)
-        raw_curve: np.ndarray = np.nan_to_num(diff[max_pt + 10])
+        raw_curve: npt.NDArray = np.nan_to_num(diff[max_pt + 10])
         npts: int = len(raw_curve)
-        kernel: np.ndarray = np.zeros([npts])
+        kernel: npt.NDArray = np.zeros([npts])
         kernel[: npts // 2] = 1
-        trace: np.ndarray = fftconvolve(raw_curve, kernel, mode="same")
-        center: int = trace.argmax()
+        trace: npt.NDArray = fftconvolve(raw_curve, kernel, mode="same")
+        center: int = cast(int, trace.argmax())
         fwhm: float = self._fit_convolution_fwhm(trace, bins)
         return raw_curve, trace, center, fwhm
 
@@ -549,6 +584,7 @@ class AnalyzeSmallData(Task):
         Args:
             detname (str): The detector name to extract data for.
         """
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXASParameters)
         self._xas_raw = self._smd_h5[f"{detname}/ROI_0_sum"][
             self._start_idx : self._stop_idx
         ]
@@ -567,10 +603,10 @@ class AnalyzeSmallData(Task):
     def _calc_binned_difference_xas(
         self,
     ) -> Tuple[
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
     ]:
         """Calculate the binned difference absorption.
 
@@ -581,19 +617,19 @@ class AnalyzeSmallData(Task):
         Returns None for all values if the final number of CCM bins is small (<=2).
 
         Returns:
-            bins (Optional[np.ndarray[np.float64]]): 1D array of ccm bins used.
+            bins (Optional[npt.NDArray[np.float64]]): 1D array of ccm bins used.
 
-            diff (Optional[np.ndarray[np.float64]]): 1D binned difference absorption
+            diff (Optional[npt.NDArray[np.float64]]): 1D binned difference absorption
                 of shape (ccm_bins)
 
-            laser_on (Optional[np.ndarray[np.float64]]): 1D laser on absorption
+            laser_on (Optional[npt.NDArray[np.float64]]): 1D laser on absorption
                 profiles of shape (ccm_bins)
 
-            laser_off (Optional[np.ndarray[np.float64]]): 1D laser off absorption
+            laser_off (Optional[npt.NDArray[np.float64]]): 1D laser off absorption
                 profiles of shape (ccm_bins)
         """
         nbins: int
-        b_edges: np.ndarray[np.float64]
+        b_edges: npt.NDArray[np.float64]
         if self._ccm_E_set_pt is not None:
             # nbins = len(self.ccm_E_set_pt)
             nbins, b_edges = self._calc_ccm_bins_by_set_pt()
@@ -603,20 +639,20 @@ class AnalyzeSmallData(Task):
         if nbins <= 2:
             return None, None, None, None
 
-        filter_las_on: np.ndarray = self._aggregate_filters()
-        filter_las_off: np.ndarray = self._aggregate_filters(
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        norm: np.ndarray[np.float64] = self._calc_1d_water_norm()
+        norm: npt.NDArray[np.float64] = self._calc_1d_water_norm()
         if (norm < 0).any():
             norm = self._xray_intensity
-        xas_norm: np.ndarray[np.float64] = self._xas_raw / norm
+        xas_norm: npt.NDArray[np.float64] = self._xas_raw / norm
 
-        xas_laser_on: np.ndarray = np.zeros(nbins)
-        xas_laser_off: np.ndarray = np.zeros(nbins)
+        xas_laser_on: npt.NDArray = np.zeros(nbins)
+        xas_laser_off: npt.NDArray = np.zeros(nbins)
         # bins are [lower, upper) except for last which is [lower, upper]
         # _, b_edges = np.histogram(self.ccm_E_unique, bins=nbins)
-        bins: np.ndarray = np.zeros([nbins])
+        bins: npt.NDArray = np.zeros([nbins])
         i: int = 0
         while i < nbins:  # - win_size + 1
             win = b_edges[i : i + 2]
@@ -627,7 +663,7 @@ class AnalyzeSmallData(Task):
             lower: int = b_edges[i]
             upper: int = b_edges[i + 1]
             # Prepare CCM_E bin
-            energy_filt: np.ndarray
+            energy_filt: npt.NDArray
             if i == nbins - 1:
                 # upper edge inclusive bin
                 energy_filt = self._ccm_E <= upper
@@ -664,6 +700,7 @@ class AnalyzeSmallData(Task):
         Args:
             detname (str): The detector name to extract data for.
         """
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXESParameters)
         # Lets assume they set up the ROI nicley?
         # By xcsl1004821
         # proj0 should be spatial distribution
@@ -677,7 +714,9 @@ class AnalyzeSmallData(Task):
             spatial_axis = 1
             spectral_axis = 0
 
-        self._xes: np.ndarray[np.float64]
+        self._xes: npt.NDArray[np.float64]
+        spatial_dist: npt.NDArray[np.float64]
+        guess_idx: int
         if self._task_parameters.batch_size:
             # Read data in batches for OOM issues
             size: int = self._task_parameters.batch_size
@@ -699,10 +738,8 @@ class AnalyzeSmallData(Task):
                     xes_roi = rotate(
                         xes_roi, angle=self._task_parameters.rot_angle, axes=(2, 1)
                     )
-                spatial_dist: np.ndarray[np.float64] = np.nansum(
-                    xes_roi, axis=(0, spatial_axis + 1)
-                )
-                guess_idx: int = np.argmax(spatial_dist)
+                spatial_dist = np.nansum(xes_roi, axis=(0, spatial_axis + 1))
+                guess_idx = cast(int, np.argmax(spatial_dist))
                 if not self._task_parameters.invert_xes_axes:
                     self._xes[start:end] = np.nansum(
                         xes_roi[..., guess_idx - 5 : guess_idx + 5],
@@ -724,10 +761,8 @@ class AnalyzeSmallData(Task):
                     xes_roi, angle=self._task_parameters.rot_angle, axes=(2, 1)
                 )
 
-            spatial_dist: np.ndarray[np.float64] = np.nansum(
-                xes_roi, axis=(0, spatial_axis + 1)
-            )
-            guess_idx: int = np.argmax(spatial_dist)
+            spatial_dist = np.nansum(xes_roi, axis=(0, spatial_axis + 1))
+            guess_idx = cast(int, np.argmax(spatial_dist))
             if not self._task_parameters.invert_xes_axes:
                 self._xes = np.nansum(
                     xes_roi[..., guess_idx - 5 : guess_idx + 5], axis=spectral_axis + 1
@@ -740,9 +775,9 @@ class AnalyzeSmallData(Task):
     def _calc_avg_difference_xes(
         self,
     ) -> Tuple[
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
     ]:
         """Calculate the average difference XES.
 
@@ -752,38 +787,38 @@ class AnalyzeSmallData(Task):
         image rotation if that is requested (see _extract_xes).
 
         Returns:
-            diff (np.ndarray[np.float64]): 1D binned difference emission of shape
+            diff (npt.NDArray[np.float64]): 1D binned difference emission of shape
                 (pixels)
 
-            laser_on (np.ndarray[np.float64]): 1D laser on emission profiles
+            laser_on (npt.NDArray[np.float64]): 1D laser on emission profiles
                 of shape (pixels)
 
-            laser_off (np.ndarray[np.float64]): 1D laser off emission profiles
+            laser_off (npt.NDArray[np.float64]): 1D laser off emission profiles
                 of shape (pixels)
         """
 
-        filter_las_on: np.ndarray[np.float64] = self._aggregate_filters()
-        filter_las_off: np.ndarray[np.float64] = self._aggregate_filters(
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
 
-        xes_on: np.ndarray[np.float64] = np.nanmean(self._xes[filter_las_on], axis=0)
-        xes_off: np.ndarray[np.float64] = np.nanmean(self._xes[filter_las_off], axis=0)
+        xes_on: npt.NDArray[np.float64] = np.nanmean(self._xes[filter_las_on], axis=0)
+        xes_off: npt.NDArray[np.float64] = np.nanmean(self._xes[filter_las_off], axis=0)
 
-        diff: np.ndarray[np.float64] = xes_on - xes_off
+        diff: npt.NDArray[np.float64] = xes_on - xes_off
 
         return diff, xes_on, xes_off
 
     # Binning
     ############################################################################
-    def _calc_ccm_bins_by_set_pt(self) -> np.ndarray[np.float64]:
+    def _calc_ccm_bins_by_set_pt(self) -> Tuple[int, npt.NDArray[np.float64]]:
         """Caculate bin edges based on the provided CCM_E set points.
 
         Returns:
-            bins (np.ndarray[np.float64]): 1D array of ccm bins used.
+            bins (npt.NDArray[np.float64]): 1D array of ccm bins used.
         """
         if self._ccm_E_set_pt is not None:
-            all_set_pts: np.ndarray[np.float64] = np.zeros(
+            all_set_pts: npt.NDArray[np.float64] = np.zeros(
                 np.sum(self._events_per_rank), dtype=np.float64
             )
             self._mpi_comm.Allgatherv(
@@ -795,12 +830,12 @@ class AnalyzeSmallData(Task):
                     MPI.DOUBLE,
                 ],
             )
-            bin_centers: np.ndarray[np.float64] = np.sort(np.unique(all_set_pts))
+            bin_centers: npt.NDArray[np.float64] = np.sort(np.unique(all_set_pts))
             nbins: int = len(bin_centers)
         else:
             raise RuntimeError("Set points not provided/not found!")
 
-        edges: np.ndarray[np.float64] = np.empty(nbins + 1)
+        edges: npt.NDArray[np.float64] = np.empty(nbins + 1)
         edges[1:-1] = (bin_centers[1:] + bin_centers[:-1]) / 2
         # How to handle the ends?
         # Lower bin inclusive, upper not (except last)
@@ -811,7 +846,7 @@ class AnalyzeSmallData(Task):
 
     def _calc_ccm_bins_by_unique(
         self, nbins: int = 50
-    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64]]:
+    ) -> Tuple[int, npt.NDArray[np.float64]]:
         """Calculate bin edges based on unique CCM_E recorded values.
 
         Args:
@@ -820,9 +855,9 @@ class AnalyzeSmallData(Task):
         Returns:
             nbins (int): Number of bins.
 
-            b_edges (np.ndarray[np.float64]): Bin edges.
+            b_edges (npt.NDArray[np.float64]): Bin edges.
         """
-        all_ccm_values: np.ndarray[np.float64] = np.zeros(
+        all_ccm_values: npt.NDArray[np.float64] = np.zeros(
             np.sum(self._events_per_rank), dtype=np.float64
         )
         self._mpi_comm.Allgatherv(
@@ -834,23 +869,23 @@ class AnalyzeSmallData(Task):
                 MPI.DOUBLE,
             ],
         )
-        unique: np.ndarray[np.float64] = np.unique(all_ccm_values)
+        unique: npt.NDArray[np.float64] = np.unique(all_ccm_values)
         del all_ccm_values
         nbins = np.min([nbins, len(unique)])
-        b_edges = np.histogram_bin_edges(unique, bins=nbins)
+        b_edges: npt.NDArray[np.float64] = np.histogram_bin_edges(unique, bins=nbins)
         return nbins, b_edges
 
-    def _calc_scan_bins(self, nbins: int = 51) -> np.ndarray[np.float64]:
+    def _calc_scan_bins(self, nbins: int = 51) -> npt.NDArray[np.float64]:
         """Calculate a set of scan bins.
 
         Args:
             nbins (int): Number of bins to create.
 
         Returns:
-            scan_bins (np.ndarray[np.float64]): 1D set of scan bins.
+            scan_bins (npt.NDArray[np.float64]): 1D set of scan bins.
         """
         # Create a full set of scan values
-        all_scan_values: np.ndarray[np.float64] = np.zeros(
+        all_scan_values: npt.NDArray[np.float64] = np.zeros(
             np.sum(self._events_per_rank), dtype=np.float64
         )
         self._mpi_comm.Allgatherv(
@@ -863,7 +898,7 @@ class AnalyzeSmallData(Task):
             ],
         )
         all_scan_values = np.nan_to_num(all_scan_values)
-        scan_bins: np.ndarray[np.float64]
+        scan_bins: npt.NDArray[np.float64]
         if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
             scan_bins = np.histogram_bin_edges(np.unique(all_scan_values), bins=nbins)
         elif self._scan_var_name is not None:
@@ -877,7 +912,9 @@ class AnalyzeSmallData(Task):
 
     def _calc_scan_binned_difference_xss(
         self,
-    ) -> Tuple[np.ndarray[np.float64], np.ndarray[np.float64], np.ndarray[np.float64]]:
+    ) -> Tuple[
+        npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]
+    ]:
         """Calculate the binned difference scattering.
 
         Calculates the 1D difference scattering for each bin of a scan variable.
@@ -885,36 +922,36 @@ class AnalyzeSmallData(Task):
         the laser on profiles.
 
         Returns:
-            bins (np.ndarray[np.float64]): 1D array of scan bins used.
+            bins (npt.NDArray[np.float64]): 1D array of scan bins used.
 
-            diff (np.ndarray[np.float64]): 2D binned difference scattering of shape
+            diff (npt.NDArray[np.float64]): 2D binned difference scattering of shape
                 (q_bins, scan_bins)
 
-            laser_on (np.ndarray[np.float64]): 2D laser on scattering profiles
+            laser_on (npt.NDArray[np.float64]): 2D laser on scattering profiles
                 of shape (n_events_las_on, q_bins)
         """
-        profiles: np.ndarray[np.float64, np.float64] = np.nansum(self._az_int, axis=1)
-        dark_mean: np.ndarray[np.float64] = self._calc_xss_dark_mean(profiles)
+        profiles: npt.NDArray[np.float64] = np.nansum(self._az_int, axis=1)
+        dark_mean: npt.NDArray[np.float64] = self._calc_xss_dark_mean(profiles)
         if len(np.unique(dark_mean)) > 1:
             # Can be len == 1 if all nan
             profiles -= dark_mean
-        norm: np.ndarray[np.float64] = self._calc_norm_by_qrange()
+        norm: npt.NDArray[np.float64] = self._calc_norm_by_qrange()
         profiles = (profiles.T / np.nanmean(norm, axis=-1).T).T
         del dark_mean
         del norm
 
-        filter_las_on: np.ndarray[np.float64] = self._aggregate_filters()
-        filter_las_off: np.ndarray[np.float64] = self._aggregate_filters(
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        normed_xss_las_on: np.ndarray[np.float64] = profiles[filter_las_on]
-        normed_xss_las_off: np.ndarray[np.float64] = profiles[filter_las_off]
+        normed_xss_las_on: npt.NDArray[np.float64] = profiles[filter_las_on]
+        normed_xss_las_off: npt.NDArray[np.float64] = profiles[filter_las_off]
 
-        bins: np.ndarray[np.float64] = self._calc_scan_bins()
-        binned_on: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        binned_off: np.ndarray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        scanvals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
-        scanvals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
+        bins: npt.NDArray[np.float64] = self._calc_scan_bins()
+        binned_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        binned_off: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        scanvals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]
+        scanvals_las_off: npt.NDArray[np.float64] = self._scan_values[filter_las_off]
 
         idx: int
         scan_bin: float
@@ -922,10 +959,10 @@ class AnalyzeSmallData(Task):
             if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
                 if idx == len(bins) - 1:
                     continue
-                mask_on: np.ndarray[np.bool_] = (scanvals_las_on >= scan_bin) * (
+                mask_on: npt.NDArray[np.bool_] = (scanvals_las_on >= scan_bin) * (
                     scanvals_las_on < bins[idx + 1]
                 )
-                mask_off: np.ndarray[np.bool_] = (scanvals_las_off >= scan_bin) * (
+                mask_off: npt.NDArray[np.bool_] = (scanvals_las_off >= scan_bin) * (
                     scanvals_las_off < bins[idx + 1]
                 )
                 binned_on[:, idx] = np.nanmean(normed_xss_las_on[mask_on], axis=0)
@@ -937,7 +974,7 @@ class AnalyzeSmallData(Task):
                 binned_off[:, idx] = np.nanmean(
                     normed_xss_las_off[(scanvals_las_off == scan_bin)], axis=0
                 )
-        diff: np.ndarray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
+        diff: npt.NDArray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
             binned_off
         )
         return bins, diff, normed_xss_las_on
@@ -945,10 +982,10 @@ class AnalyzeSmallData(Task):
     def _calc_scan_binned_difference_xas(
         self,
     ) -> Tuple[
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
-        Optional[np.ndarray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
+        Optional[npt.NDArray[np.float64]],
     ]:
         """Calculate the binned difference absorption.
 
@@ -958,47 +995,49 @@ class AnalyzeSmallData(Task):
         Returns None for all values if the final number of bins is small (<=2).
 
         Returns:
-            bins (Optional[np.ndarray[np.float64]]): 1D array of scan bins used.
+            bins (Optional[npt.NDArray[np.float64]]): 1D array of scan bins used.
 
-            diff (Optional[np.ndarray[np.float64]]): 1D difference absorption.
+            diff (Optional[npt.NDArray[np.float64]]): 1D difference absorption.
 
-            laser_off (Optional[np.ndarray[np.float64]]): 1D laser on absorption.
+            laser_off (Optional[npt.NDArray[np.float64]]): 1D laser on absorption.
 
-            laser_off (Optional[np.ndarray[np.float64]]): 1D laser off absorption.
+            laser_off (Optional[npt.NDArray[np.float64]]): 1D laser off absorption.
         """
-        bins: np.ndarray[np.float64] = self._calc_scan_bins()
+        bins: npt.NDArray[np.float64] = self._calc_scan_bins()
         if len(bins) <= 2:
             return None, None, None, None
-        filter_las_on: np.ndarray = self._aggregate_filters()
-        filter_las_off: np.ndarray = self._aggregate_filters(
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        norm: np.ndarray[np.float64] = self._xray_intensity
-        normed_xas: np.ndarray[np.float64] = self._xas_raw / norm
-        normed_xas_las_on: np.ndarray[np.float64] = normed_xas[filter_las_on]
-        normed_xas_las_off: np.ndarray[np.float64] = normed_xas[filter_las_off]
+        norm: npt.NDArray[np.float64] = self._xray_intensity
+        normed_xas: npt.NDArray[np.float64] = self._xas_raw / norm
+        normed_xas_las_on: npt.NDArray[np.float64] = normed_xas[filter_las_on]
+        normed_xas_las_off: npt.NDArray[np.float64] = normed_xas[filter_las_off]
 
-        scan_vals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
-        scan_vals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
+        scan_vals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]
+        scan_vals_las_off: npt.NDArray[np.float64] = self._scan_values[filter_las_off]
 
         lxt_fast_scan: bool = (
             self._scan_var_name is not None and "lxt_fast" in self._scan_var_name
         )
+        binned_xas_las_on: npt.NDArray[np.float64]
+        binned_xas_las_off: npt.NDArray[np.float64]
         if lxt_fast_scan:
-            binned_xas_las_on: np.ndarray[np.float64] = np.zeros(len(bins) - 1)
-            binned_xas_las_off: np.ndarray[np.float64] = np.zeros(len(bins) - 1)
+            binned_xas_las_on = np.zeros(len(bins) - 1)
+            binned_xas_las_off = np.zeros(len(bins) - 1)
         else:
-            binned_xas_las_on: np.ndarray[np.float64] = np.zeros(len(bins))
-            binned_xas_las_off: np.ndarray[np.float64] = np.zeros(len(bins))
+            binned_xas_las_on = np.zeros(len(bins))
+            binned_xas_las_off = np.zeros(len(bins))
 
         for idx, bin_or_bin_edge in enumerate(bins):
             if lxt_fast_scan:
                 if idx == len(bins) - 1:
                     continue
-                mask_on: np.ndarray[np.float64] = (
+                mask_on: npt.NDArray[np.float64] = (
                     scan_vals_las_on >= bin_or_bin_edge
                 ) * (scan_vals_las_on < bins[idx + 1])
-                mask_off: np.ndarray[np.float64] = (
+                mask_off: npt.NDArray[np.float64] = (
                     scan_vals_las_off >= bin_or_bin_edge
                 ) * (scan_vals_las_off < bins[idx + 1])
                 binned_xas_las_on[idx] = np.mean(normed_xas_las_on[mask_on])
@@ -1011,16 +1050,16 @@ class AnalyzeSmallData(Task):
                     normed_xas_las_off[scan_vals_las_off == bin_or_bin_edge]
                 )
 
-        diff: np.ndarray[np.float64] = binned_xas_las_on - binned_xas_las_off
+        diff: npt.NDArray[np.float64] = binned_xas_las_on - binned_xas_las_off
         return bins, diff, binned_xas_las_on, binned_xas_las_off
 
     def _calc_scan_binned_difference_xes(
         self,
     ) -> Tuple[
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
-        np.ndarray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
     ]:
         """Calculate the binned difference emission.
 
@@ -1029,53 +1068,47 @@ class AnalyzeSmallData(Task):
         axis is energy.
 
         Returns:
-            bins (np.ndarray[np.float64]): 1D array of scan bins used.
+            bins (npt.NDArray[np.float64]): 1D array of scan bins used.
 
-            diff (np.ndarray[np.float64]): 2D difference emission.
+            diff (npt.NDArray[np.float64]): 2D difference emission.
 
-            laser_off (np.ndarray[np.float64]): 2D laser on emission.
+            laser_off (npt.NDArray[np.float64]): 2D laser on emission.
 
-            laser_off (np.ndarray[np.float64]): 2D laser off emission.
+            laser_off (npt.NDArray[np.float64]): 2D laser off emission.
         """
-        filter_las_on: np.ndarray = self._aggregate_filters()
-        filter_las_off: np.ndarray = self._aggregate_filters(
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        norm: np.ndarray[np.float64] = self._xray_intensity
-        normed_xes: np.ndarray[np.float64] = (self._xes.T / norm).T
-        normed_xes_las_on: np.ndarray[np.float64] = normed_xes[filter_las_on]
-        normed_xes_las_off: np.ndarray[np.float64] = normed_xes[filter_las_off]
+        norm: npt.NDArray[np.float64] = self._xray_intensity
+        normed_xes: npt.NDArray[np.float64] = (self._xes.T / norm).T
+        normed_xes_las_on: npt.NDArray[np.float64] = normed_xes[filter_las_on]
+        normed_xes_las_off: npt.NDArray[np.float64] = normed_xes[filter_las_off]
 
-        scan_vals_las_on: np.ndarray[np.float64] = self._scan_values[filter_las_on]
-        scan_vals_las_off: np.ndarray[np.float64] = self._scan_values[filter_las_off]
-        bins: np.ndarray[np.float64] = self._calc_scan_bins()
+        scan_vals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]
+        scan_vals_las_off: npt.NDArray[np.float64] = self._scan_values[filter_las_off]
+        bins: npt.NDArray[np.float64] = self._calc_scan_bins()
 
         lxt_fast_scan: bool = (
             self._scan_var_name is not None and "lxt_fast" in self._scan_var_name
         )
+        binned_xes_las_on: npt.NDArray[np.float64]
+        binned_xes_las_off: npt.NDArray[np.float64]
         if lxt_fast_scan:
-            binned_xes_las_on: np.ndarray[np.float64] = np.zeros(
-                (normed_xes_las_on.shape[1], len(bins) - 1)
-            )
-            binned_xes_las_off: np.ndarray[np.float64] = np.zeros(
-                (normed_xes_las_off.shape[1], len(bins) - 1)
-            )
+            binned_xes_las_on = np.zeros((normed_xes_las_on.shape[1], len(bins) - 1))
+            binned_xes_las_off = np.zeros((normed_xes_las_off.shape[1], len(bins) - 1))
         else:
-            binned_xes_las_on: np.ndarray[np.float64] = np.zeros(
-                (normed_xes_las_on.shape[1], len(bins))
-            )
-            binned_xes_las_off: np.ndarray[np.float64] = np.zeros(
-                (normed_xes_las_off.shape[1], len(bins))
-            )
+            binned_xes_las_on = np.zeros((normed_xes_las_on.shape[1], len(bins)))
+            binned_xes_las_off = np.zeros((normed_xes_las_off.shape[1], len(bins)))
 
         for idx, bin_or_bin_edge in enumerate(bins):
             if lxt_fast_scan:
                 if idx == len(bins) - 1:
                     continue
-                mask_on: np.ndarray[np.float64] = (
+                mask_on: npt.NDArray[np.float64] = (
                     scan_vals_las_on >= bin_or_bin_edge
                 ) * (scan_vals_las_on < bins[idx + 1])
-                mask_off: np.ndarray[np.float64] = (
+                mask_off: npt.NDArray[np.float64] = (
                     scan_vals_las_off >= bin_or_bin_edge
                 ) * (scan_vals_las_off < bins[idx + 1])
                 binned_xes_las_on[:, idx] = np.mean(normed_xes_las_on[mask_on], axis=0)
@@ -1090,9 +1123,9 @@ class AnalyzeSmallData(Task):
                     normed_xes_las_off[scan_vals_las_off == bin_or_bin_edge], axis=0
                 )
 
-        diff: np.ndarray[np.float64] = np.nan_to_num(binned_xes_las_on) - np.nan_to_num(
-            binned_xes_las_off
-        )
+        diff: npt.NDArray[np.float64] = np.nan_to_num(
+            binned_xes_las_on
+        ) - np.nan_to_num(binned_xes_las_off)
         return bins, diff, binned_xes_las_on, binned_xes_las_off
 
     # Plots
@@ -1101,27 +1134,27 @@ class AnalyzeSmallData(Task):
     # XSS
     def plot_avg_xss(
         self,
-        laser_on: np.ndarray[np.float64],
-        q_vals: np.ndarray[np.float64],
-        phis: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        q_vals: npt.NDArray[np.float64],
+        phis: npt.NDArray[np.float64],
     ) -> plt.Figure: ...
 
     def plot_difference_xss_hv(
         self,
-        bins: np.ndarray[np.float64],
-        q_vals: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        bins: npt.NDArray[np.float64],
+        q_vals: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
         scan_var_name: str,
     ) -> pn.GridSpec:
         """Plot the binned difference scattering.
 
         Args:
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            q_vals (np.ndarray[np.float64]): 1D set of Q bins.
+            q_vals (npt.NDArray[np.float64]): 1D set of Q bins.
 
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
                 (q_bins, scan_bins).
 
             scan_var_name (str): Name of the scan variable (for titles, etc.).
@@ -1143,8 +1176,8 @@ class AnalyzeSmallData(Task):
             hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
         ).opts(shared_axes=False)
         grid[:2, :2] = contours
-        xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("dS", "dS"))
+        xdim = hv.Dimension(("Q", "Q"))
+        ydim = hv.Dimension(("dS", "dS"))
         diff_curves: hv.Overlay
         diff_curves = hv.Curve((q_vals, diff[:, 0]))
         for i, _ in enumerate(bins):
@@ -1163,33 +1196,34 @@ class AnalyzeSmallData(Task):
 
     def plot_xss_overlap_fit(
         self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> plt.Figure:
         """Plot the overlap fit to a slice of the binned difference.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 scattering profile.
 
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
                 (q_bins, scan_bins).
 
         Returns:
             plot (plt.Figure): Plotted overlap fit.
         """
         fig, ax = plt.subplots(1, 1, figsize=(6, 3), dpi=200)
+        raw_curve: npt.NDArray[np.float64]
+        msg: str
         if self._scan_var_name is not None and "lxt" in self._scan_var_name:
-            raw_curve: np.ndarray[np.float64]
-            trace: np.ndarray[np.float64]
+            trace: npt.NDArray[np.float64]
             center: int
             fwhm: float
             raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
-            msg: str = (
+            msg = (
                 f"Scan Var: {self._scan_var_name}\n"
                 f"Overlap Position: {bins[center]}\n"
                 f"FWHM: {fwhm}"
@@ -1203,10 +1237,9 @@ class AnalyzeSmallData(Task):
             ax.set_ylabel(r"$\Delta$S")
             plt.legend(loc=0, frameon=False)
         else:
-            raw_curve: np.ndarray[np.float64]
-            opt: np.ndarray[np.float64]
+            opt: npt.NDArray[np.float64]
             raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
-            msg: str = (
+            msg = (
                 f"Scan Var: {self._scan_var_name}\n"
                 f"Overlap Position: {opt[1]}\n"
                 f"FWHM: {sigma_to_fwhm(opt[2])}"
@@ -1222,21 +1255,21 @@ class AnalyzeSmallData(Task):
 
     def plot_all_xss(
         self,
-        laser_on: np.ndarray[np.float64],
-        bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
         scan_var_name: str,
     ) -> pn.Tabs:
         """Plot all relevant scattering plots.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 scattering profile.
 
-            bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 2D difference signal of shape
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
                 (q_bins, scan_bins).
 
             scan_var_name (str): Name of the scan variable (for titles, etc.).
@@ -1263,24 +1296,24 @@ class AnalyzeSmallData(Task):
     # XAS
     def plot_all_xas(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        ccm_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        ccm_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Plot XAS and optionally EXAFS
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 absorption spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 absorption spectrum.
 
-            ccm_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            ccm_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference absorption.
+            diff (npt.NDArray[np.float64]): 1D difference absorption.
 
         Returns:
             plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
@@ -1301,24 +1334,24 @@ class AnalyzeSmallData(Task):
 
     def plot_std_xas_hv(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        ccm_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        ccm_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.GridSpec:
         """Plot relevant XAS plots.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 absorption spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 absorption spectrum.
 
-            ccm_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            ccm_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference absorption.
+            diff (npt.NDArray[np.float64]): 1D difference absorption.
 
         Returns:
             plot (pn.GridSpec): Laser on/off and difference XAS plots.
@@ -1355,26 +1388,26 @@ class AnalyzeSmallData(Task):
 
     def plot_xas_scan_hv(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> Optional[pn.Tabs]:
         """Plot scan binned XAS data.
 
         Currently handles lxe_opa power titration and t0 (lxt_fast) XAS scans.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 absorption spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 absorption spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference absorption.
+            diff (npt.NDArray[np.float64]): 1D difference absorption.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1388,27 +1421,28 @@ class AnalyzeSmallData(Task):
             )
         elif "lxt_fast" in self._scan_var_name:
             return self.plot_xas_lxt_fast_scan(laser_on, laser_off, scan_bins, diff)
+        return None
 
     def plot_xas_lxt_fast_scan(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Produce a plot of an lxt_fast scan for time zero (or real signal).
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 absorption spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 absorption spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference absorption.
+            diff (npt.NDArray[np.float64]): 1D difference absorption.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1418,7 +1452,7 @@ class AnalyzeSmallData(Task):
             ("Normalized A", "Normalized A")
         )
 
-        bin_centers: np.ndarray[np.float64] = (scan_bins[:-1] + scan_bins[1:]) / 2
+        bin_centers: npt.NDArray[np.float64] = (scan_bins[:-1] + scan_bins[1:]) / 2
 
         on_pts: hv.Points = hv.Points(
             (bin_centers, laser_on), kdims=[xdim, ydim], label="Laser on"
@@ -1453,24 +1487,24 @@ class AnalyzeSmallData(Task):
 
     def plot_xas_power_titration_scan(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Produce a plot of the lxe_opa power titration.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 absorption spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 absorption spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference absorption.
+            diff (npt.NDArray[np.float64]): 1D difference absorption.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1514,24 +1548,24 @@ class AnalyzeSmallData(Task):
     # XES
     def plot_xes_hv(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        energy_bins: Optional[np.ndarray[np.float64]],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        energy_bins: Optional[npt.NDArray[np.float64]],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Plot XES and difference XES. In the future will provide other plots.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 emission spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 emission spectrum.
 
-            energy_bins (Optional[np.ndarray[np.float64]]): 1D set of bins used
+            energy_bins (Optional[npt.NDArray[np.float64]]): 1D set of bins used
                 for the energy axis. If None, will just use pixels for that axis.
 
-            diff (np.ndarray[np.float64]): 1D difference emission.
+            diff (npt.NDArray[np.float64]): 1D difference emission.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1546,24 +1580,24 @@ class AnalyzeSmallData(Task):
 
     def plot_std_xes_hv(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        energy_bins: Optional[np.ndarray[np.float64]],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        energy_bins: Optional[npt.NDArray[np.float64]],
+        diff: npt.NDArray[np.float64],
     ) -> pn.GridSpec:
         """Plot XES and difference XES.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 emission spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 emission spectrum.
 
-            energy_bins (Optional[np.ndarray[np.float64]]): 1D set of bins used
+            energy_bins (Optional[npt.NDArray[np.float64]]): 1D set of bins used
                 for the energy axis. If None, will just use pixels for that axis.
 
-            diff (np.ndarray[np.float64]): 1D difference emission.
+            diff (npt.NDArray[np.float64]): 1D difference emission.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1571,7 +1605,7 @@ class AnalyzeSmallData(Task):
         xdim: hv.core.dimension.Dimension = hv.Dimension(("Energy", "Energy"))
         ydim: hv.core.dimension.Dimension = hv.Dimension(("I", "I"))
 
-        bins: np.ndarray[Union[np.int64, np.float64]]
+        bins: npt.NDArray[Union[np.int64, np.float64]]
         if energy_bins is None:
             bins = np.arange(len(laser_on))
         else:
@@ -1605,26 +1639,26 @@ class AnalyzeSmallData(Task):
 
     def plot_xes_scan_hv(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> Optional[pn.Tabs]:
         """Plot scan binned XES data.
 
         Currently handles lxt and lxt_fast XES scans.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 emission spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 emission spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference emission.
+            diff (npt.NDArray[np.float64]): 1D difference emission.
 
         Returns:
             plot (Optional[pn.Tabs]): Plotted binned difference. Returns None if
@@ -1637,27 +1671,28 @@ class AnalyzeSmallData(Task):
             return self.plot_xes_lxt_fast_scan(laser_on, laser_off, scan_bins, diff)
         elif "lxt" in self._scan_var_name:
             return self.plot_xes_lxt_scan(laser_on, laser_off, scan_bins, diff)
+        return None
 
     def plot_xes_lxt_fast_scan(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Plot lxt_fast scan binned XES data.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 emission spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 emission spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference emission.
+            diff (npt.NDArray[np.float64]): 1D difference emission.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1668,7 +1703,7 @@ class AnalyzeSmallData(Task):
             ("Energy (Pixel)", "Energy (Pixel)")
         )
 
-        bin_centers: np.ndarray[np.float_] = (scan_bins[:1] + scan_bins[1:]) / 2
+        bin_centers: npt.NDArray[np.float_] = (scan_bins[:1] + scan_bins[1:]) / 2
         diff_img: hv.Image = hv.Image(
             (
                 bin_centers,
@@ -1685,10 +1720,8 @@ class AnalyzeSmallData(Task):
         shared.opts(shared_axes=False)
         grid[:2, :2] = shared
 
-        xdim: hv.core.dimension.Dimension = hv.Dimension(
-            ("Energy (Pixel)", "Energy (Pixel)")
-        )
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("dI", "dI"))
+        xdim = hv.Dimension(("Energy (Pixel)", "Energy (Pixel)"))
+        ydim = hv.Dimension(("dI", "dI"))
 
         diff_curves: hv.Curve = hv.Curve((range(len(diff[:, 0])), diff[:, 0]))
         for idx, _ in enumerate(bin_centers):
@@ -1703,24 +1736,24 @@ class AnalyzeSmallData(Task):
 
     def plot_xes_lxt_scan(
         self,
-        laser_on: np.ndarray[np.float64],
-        laser_off: np.ndarray[np.float64],
-        scan_bins: np.ndarray[np.float64],
-        diff: np.ndarray[np.float64],
+        laser_on: npt.NDArray[np.float64],
+        laser_off: npt.NDArray[np.float64],
+        scan_bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
     ) -> pn.Tabs:
         """Plot lxt scan binned XES data.
 
         Args:
-            laser_on (np.ndarray[np.float64]): 1D corrected average laser on
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
                 emission spectrum.
 
-            laser_off (np.ndarray[np.float64]): 1D corrected average laser off
+            laser_off (npt.NDArray[np.float64]): 1D corrected average laser off
                 emission spectrum.
 
-            scan_bins (np.ndarray[np.float64]): 1D set of bins used for difference
+            scan_bins (npt.NDArray[np.float64]): 1D set of bins used for difference
                 signal.
 
-            diff (np.ndarray[np.float64]): 1D difference emission.
+            diff (npt.NDArray[np.float64]): 1D difference emission.
 
         Returns:
             plot (pn.Tabs): Plotted binned difference.
@@ -1747,10 +1780,8 @@ class AnalyzeSmallData(Task):
         shared.opts(shared_axes=False)
         grid[:2, :2] = shared
 
-        xdim: hv.core.dimension.Dimension = hv.Dimension(
-            ("Energy (Pixel)", "Energy (Pixel)")
-        )
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("dI", "dI"))
+        xdim = hv.Dimension(("Energy (Pixel)", "Energy (Pixel)"))
+        ydim = hv.Dimension(("dI", "dI"))
 
         diff_curves: hv.Curve = hv.Curve((range(len(diff[:, 0])), diff[:, 0]))
         for idx, _ in enumerate(scan_bins):

--- a/lute/tasks/dataclasses.py
+++ b/lute/tasks/dataclasses.py
@@ -65,7 +65,7 @@ class TaskResult:
 
         task_status (TaskStatus): Status of associated task.
 
-        summary (str): Short message/summary associated with the result.
+        summary (Any): Short (usually text message) summary associated with the result.
 
         payload (Any): Actual result. May be data in any format.
 
@@ -78,7 +78,7 @@ class TaskResult:
 
     task_name: str
     task_status: TaskStatus
-    summary: str
+    summary: Any
     payload: Any
     impl_schemas: Optional[str] = None
 

--- a/lute/tasks/dataclasses.py
+++ b/lute/tasks/dataclasses.py
@@ -105,7 +105,7 @@ class ElogSummaryPlots:
     """
 
     display_name: str
-    figures: Union[pn.Tabs, hv.Image, plt.Figure, bytes]  # noqa: F821
+    figures: Union[pn.Tabs, hv.Image, plt.Figure, bytes]  # type: ignore # noqa: F821
 
     def __post_init__(self) -> None:
         self._setup_figures()

--- a/lute/tasks/dataclasses.py
+++ b/lute/tasks/dataclasses.py
@@ -105,7 +105,7 @@ class ElogSummaryPlots:
     """
 
     display_name: str
-    figures: Union[pn.Tabs, hv.Image, plt.Figure, bytes]
+    figures: Union[pn.Tabs, hv.Image, plt.Figure, bytes]  # noqa: F821
 
     def __post_init__(self) -> None:
         self._setup_figures()

--- a/lute/tasks/geometry.py
+++ b/lute/tasks/geometry.py
@@ -14,16 +14,16 @@ import logging
 import itertools
 from typing import List, Optional, Tuple, Union, Any, cast
 
-import h5py
-import holoviews as hv
-import lmfit
+import h5py  # type: ignore
+import holoviews as hv  # type: ignore
+import lmfit  # type: ignore
 import numpy as np
 import numpy.typing as npt
 import panel as pn
-import psana
+import psana  # type: ignore
 from mpi4py import MPI
-from scipy import sparse
-from scipy.signal import find_peaks
+from scipy import sparse  # type: ignore
+from scipy.signal import find_peaks  # type: ignore
 from lute.io.models.geometry import OptimizeAgBhGeometryExhaustiveParameters
 from lute.execution.logging import get_logger
 from lute.tasks._geometry import geometry_optimize_residual, deploy_geometry
@@ -149,7 +149,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _extract_mask(
         self, mask_path: Optional[str]
-    ) -> Optional[npt.NDArray[np.float64]]:
+    ) -> Optional[npt.NDArray[np.bool_]]:
         """Extract a mask.
 
         May take a smalldata file or numpy array.
@@ -158,14 +158,14 @@ class OptimizeAgBhGeometryExhaustive(Task):
             mask_path (str): Path to the object containing the mask.
 
         Returns:
-            mask (Optional[npt.NDArray[np.float64]]): The extracted mask.
+            mask (Optional[npt.NDArray[np.bool_]]): The extracted mask.
                 Returns None if no powder could be extracted and no specific error
                 was encountered.
         """
         self._task_parameters = cast(
             OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
         )
-        mask: Optional[npt.NDArray[bool]] = None
+        mask: Optional[npt.NDArray[np.bool_]] = None
         is_valid: bool
         dtype: Optional[str]
         if isinstance(self._task_parameters.mask, str):
@@ -175,7 +175,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
             elif is_valid and dtype == "smd":
                 h5: h5py.File
                 with h5py.File(mask_path) as h5:
-                    unassembled: npt.NDArray[np.float64] = h5[
+                    unassembled: npt.NDArray[np.bool_] = h5[
                         f"UserDataCfg/{self._task_parameters.detname}/mask"
                     ][()]
                     if unassembled.shape == 2:
@@ -282,7 +282,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
             OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
         )
         if self._task_parameters.center_guess is not None:
-            return self._task_parameters.center_guess
+            return np.array(self._task_parameters.center_guess)
         return np.array(powder.shape) / 2.0
 
     def _center_guesses(
@@ -322,7 +322,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
     def _radial_profile(
         self,
         powder: npt.NDArray[np.float64],
-        mask: Optional[npt.NDArray[np.float64]],
+        mask: Optional[npt.NDArray[np.bool_]],
         center: Tuple[float, float],
         threshold: float = 10.0,
         filter_profile: bool = False,
@@ -366,7 +366,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
             radius_map = np.where(mask == 1, radius_map, 0)
 
         radius_map_int: npt.NDArray[np.int64] = radius_map.astype(np.int64)
-        tbin: npt.NDArray[np.float64] = np.bincount(
+        tbin: npt.NDArray[np.int64] = np.bincount(
             radius_map_int.ravel(), powder.ravel()
         )
         nr: npt.NDArray[np.int64] = np.bincount(radius_map_int.ravel())
@@ -527,7 +527,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
     def _opt_geom(
         self,
         powder: npt.NDArray[np.float64],
-        mask: npt.NDArray[np.uint64],
+        mask: Optional[npt.NDArray[np.bool_]],
         params_guess: Tuple[int, Tuple[float, float], float],
         n_iterations: int,
         wavelength: float,
@@ -538,8 +538,8 @@ class OptimizeAgBhGeometryExhaustive(Task):
         Args:
             powder (npt.NDArray[np.float64]): 2-D assembled powder image.
 
-            mask (npt.NDArray[np.float64]): Corresponding binary mask for the
-                powder image.
+            mask (Optional[npt.NDArray[np.float64]]): Corresponding binary mask
+                for the powder image.
 
             params_guess (Tuple[int, Tuple[float, float], float]): Initial guesses.
                 In format: (n_peaks, (center_x, center_y), distance).
@@ -619,11 +619,13 @@ class OptimizeAgBhGeometryExhaustive(Task):
         wavelength_angs: float
         pixel_size_mm, wavelength_angs = self._get_pixel_size_and_wavelength(ds, det)
 
-        powder: npt.NDArray[np.float64] = self._extract_powder(
+        powder: Optional[npt.NDArray[np.float64]] = self._extract_powder(
             self._task_parameters.powder
         )
+        if powder is None:
+            raise RuntimeError("Unable to extract powder. Cannot continue.")
 
-        mask: Optional[npt.NDArray[np.float64]] = self._extract_mask(
+        mask: Optional[npt.NDArray[np.bool_]] = self._extract_mask(
             self._task_parameters.mask
         )
         powder[powder > self._task_parameters.threshold] = 0
@@ -686,14 +688,14 @@ class OptimizeAgBhGeometryExhaustive(Task):
         self._mpi_comm.Barrier()
 
         # Gather all results
-        final_scores: Union[List[float], List[List[float]]] = self._mpi_comm.gather(
-            final_scores_by_rank, root=0
+        final_scores: Optional[Union[List[float], List[List[float]]]] = (
+            self._mpi_comm.gather(final_scores_by_rank, root=0)
         )
-        final_distances: Union[List[float], List[List[float]]] = self._mpi_comm.gather(
-            final_distances_by_rank, root=0
+        final_distances: Optional[Union[List[float], List[List[float]]]] = (
+            self._mpi_comm.gather(final_distances_by_rank, root=0)
         )
-        final_centers: Union[
-            List[Tuple[float, float]], List[List[Tuple[float, float]]]
+        final_centers: Optional[
+            Union[List[Tuple[float, float]], List[List[Tuple[float, float]]]]
         ] = self._mpi_comm.gather(final_centers_by_rank, root=0)
 
         # Flatten nested lists
@@ -760,7 +762,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
         distance: float,
         wavelength: float,
         pixel_size: float,
-        mask: Optional[npt.NDArray[np.float64]] = None,
+        mask: Optional[npt.NDArray[np.bool_]] = None,
     ) -> pn.Tabs:
         radial_profile: npt.NDArray[np.float64] = self._radial_profile(
             powder, mask, center

--- a/lute/tasks/geometry.py
+++ b/lute/tasks/geometry.py
@@ -12,19 +12,19 @@ __author__ = "Gabriel Dorlhiac"
 import os
 import logging
 import itertools
-from typing import List, Optional, Tuple, Union, Any
+from typing import List, Optional, Tuple, Union, Any, cast
 
 import h5py
 import holoviews as hv
 import lmfit
 import numpy as np
+import numpy.typing as npt
 import panel as pn
 import psana
 from mpi4py import MPI
 from scipy import sparse
 from scipy.signal import find_peaks
-
-from lute.io.models.base import TaskParameters
+from lute.io.models.geometry import OptimizeAgBhGeometryExhaustiveParameters
 from lute.execution.logging import get_logger
 from lute.tasks._geometry import geometry_optimize_residual, deploy_geometry
 from lute.tasks.task import Task
@@ -36,7 +36,9 @@ logger: logging.Logger = get_logger(__name__)
 class OptimizeAgBhGeometryExhaustive(Task):
     """Task to perform geometry optimization."""
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: OptimizeAgBhGeometryExhaustiveParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
         hv.extension("bokeh")
         pn.extension()
@@ -80,7 +82,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
         return is_valid_path, powder_type
 
-    def _extract_powder(self, powder_path: str) -> Optional[np.ndarray[np.float64]]:
+    def _extract_powder(self, powder_path: str) -> Optional[npt.NDArray[np.float64]]:
         """Extract a powder image.
 
         May take a smalldata file or numpy array.
@@ -89,11 +91,14 @@ class OptimizeAgBhGeometryExhaustive(Task):
             powder_path (str): Path to the object containing the powder image.
 
         Returns:
-            powder (Optional[np.ndarray[np.float64]]): The extracted powder image.
+            powder (Optional[npt.NDArray[np.float64]]): The extracted powder image.
                 Returns None if no powder could be extracted and no specific error
                 was encountered.
         """
-        powder: Optional[np.ndarray[np.float64]] = None
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
+        powder: Optional[npt.NDArray[np.float64]] = None
         if isinstance(powder_path, str):
             is_valid: bool
             dtype: Optional[str]
@@ -103,17 +108,17 @@ class OptimizeAgBhGeometryExhaustive(Task):
             elif is_valid and dtype == "smd":
                 h5: h5py.File
                 with h5py.File(powder_path) as h5:
-                    unassembled: np.ndarray[np.float64] = h5[
+                    unassembled: npt.NDArray[np.float64] = h5[
                         f"Sums/{self._task_parameters.detname}_calib"
                     ][()]
                     if unassembled.shape == 2:
                         # E.g. Rayonix
                         powder = unassembled
                     else:
-                        ix: np.ndarray[np.uint64] = h5[
+                        ix: npt.NDArray[np.uint64] = h5[
                             f"UserDataCfg/{self._task_parameters.detname}/ix"
                         ][()]
-                        iy: np.ndarray[np.uint64] = h5[
+                        iy: npt.NDArray[np.uint64] = h5[
                             f"UserDataCfg/{self._task_parameters.detname}/iy"
                         ][()]
 
@@ -144,7 +149,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _extract_mask(
         self, mask_path: Optional[str]
-    ) -> Optional[np.ndarray[np.float64]]:
+    ) -> Optional[npt.NDArray[np.float64]]:
         """Extract a mask.
 
         May take a smalldata file or numpy array.
@@ -153,11 +158,14 @@ class OptimizeAgBhGeometryExhaustive(Task):
             mask_path (str): Path to the object containing the mask.
 
         Returns:
-            mask (Optional[np.ndarray[np.float64]]): The extracted mask.
+            mask (Optional[npt.NDArray[np.float64]]): The extracted mask.
                 Returns None if no powder could be extracted and no specific error
                 was encountered.
         """
-        mask: Optional[np.ndarray[bool]] = None
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
+        mask: Optional[npt.NDArray[bool]] = None
         is_valid: bool
         dtype: Optional[str]
         if isinstance(self._task_parameters.mask, str):
@@ -167,17 +175,17 @@ class OptimizeAgBhGeometryExhaustive(Task):
             elif is_valid and dtype == "smd":
                 h5: h5py.File
                 with h5py.File(mask_path) as h5:
-                    unassembled: np.ndarray[np.float64] = h5[
+                    unassembled: npt.NDArray[np.float64] = h5[
                         f"UserDataCfg/{self._task_parameters.detname}/mask"
                     ][()]
                     if unassembled.shape == 2:
                         # E.g. Rayonix
                         mask = unassembled
                     else:
-                        ix: np.ndarray[np.uint64] = h5[
+                        ix: npt.NDArray[np.uint64] = h5[
                             f"UserDataCfg/{self._task_parameters.detname}/ix"
                         ][()]
-                        iy: np.ndarray[np.uint64] = h5[
+                        iy: npt.NDArray[np.uint64] = h5[
                             f"UserDataCfg/{self._task_parameters.detname}/iy"
                         ][()]
 
@@ -221,6 +229,9 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
             wavelength (float): X-ray wavelength in Angstroms.
         """
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         pixel_size: float
         if self._task_parameters.detname.lower() == "rayonix":
             pixel_size = ds.env().configStore().get(psana.Rayonix.ConfigV2).pixelWidth()
@@ -241,6 +252,9 @@ class OptimizeAgBhGeometryExhaustive(Task):
             distance (float): Estimated distance, or user-provided guess if one
                 was present in the TaskParameters.
         """
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         if self._task_parameters.distance_guess is not None:
             return self._task_parameters.distance_guess
         exp: str = self._task_parameters.lute_config.experiment
@@ -250,26 +264,29 @@ class OptimizeAgBhGeometryExhaustive(Task):
         return -1 * np.mean(det.coords_z(run)) / 1e3
 
     def _initial_image_center(
-        self, powder: np.ndarray[np.float64]
-    ) -> np.ndarray[np.float64]:
+        self, powder: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
         """Estimate a beam center.
 
         Will estimate the center as the powder image center if no guess is
         provided, otherwise this method returns the provided guess.
 
         Args:
-            powder (np.ndarray[np.float64]): Powder image.
+            powder (npt.NDArray[np.float64]): Powder image.
 
         Returns:
-            center (np.ndarray[np.float64]): Estimated center, or user-provided
+            center (npt.NDArray[np.float64]): Estimated center, or user-provided
                 guess if one was present in the TaskParameters.
         """
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         if self._task_parameters.center_guess is not None:
             return self._task_parameters.center_guess
         return np.array(powder.shape) / 2.0
 
     def _center_guesses(
-        self, powder: np.ndarray[np.float64]
+        self, powder: npt.NDArray[np.float64]
     ) -> List[Tuple[float, float]]:
         """Return starting beam center points based on dx/dy parameters.
 
@@ -279,17 +296,20 @@ class OptimizeAgBhGeometryExhaustive(Task):
         model.
 
         Args:
-            powder (np.ndarray[np.float64]): Powder image.
+            powder (npt.NDArray[np.float64]): Powder image.
 
         Returns:
             guesses (List[Tuple[float,float]]): Starting guesses for the beam
                 center optimization routine.
         """
-        initial_center: np.ndarray[np.float64] = self._initial_image_center(powder)
-        dx: Tuple[int, int, int] = self._task_parameters.dx
-        dy: Tuple[int, int, int] = self._task_parameters.dy
-        x_offsets: np.ndarray[np.float64] = np.linspace(dx[0], dx[1], dx[2])
-        y_offsets: np.ndarray[np.float64] = np.linspace(dy[0], dy[1], dy[2])
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
+        initial_center: npt.NDArray[np.float64] = self._initial_image_center(powder)
+        dx: Tuple[float, float, int] = self._task_parameters.dx
+        dy: Tuple[float, float, int] = self._task_parameters.dy
+        x_offsets: npt.NDArray[np.float64] = np.linspace(dx[0], dx[1], dx[2])
+        y_offsets: npt.NDArray[np.float64] = np.linspace(dy[0], dy[1], dy[2])
         center_offsets: List[Tuple[float, float]] = list(
             itertools.product(x_offsets, y_offsets)
         )
@@ -301,20 +321,20 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _radial_profile(
         self,
-        powder: np.ndarray[np.float64],
-        mask: Optional[np.ndarray[np.float64]],
+        powder: npt.NDArray[np.float64],
+        mask: Optional[npt.NDArray[np.float64]],
         center: Tuple[float, float],
         threshold: float = 10.0,
         filter_profile: bool = False,
         filter_order: int = 2,
         filter_threshold: float = 0.25,
-    ) -> np.ndarray[np.float64]:
+    ) -> npt.NDArray[np.float64]:
         """Compute the radial intensity profile of an image.
 
         Args:
-            powder (np.ndarray[np.float64]): 2-D assembled powder image.
+            powder (npt.NDArray[np.float64]): 2-D assembled powder image.
 
-            mask (Optional[np.ndarray[np.float64]]): Corresponding binary mask
+            mask (Optional[npt.NDArray[np.float64]]): Corresponding binary mask
                 for the powder image.
 
             center (Tuple[float, float]): Beam center in the image, in pixels.
@@ -332,25 +352,25 @@ class OptimizeAgBhGeometryExhaustive(Task):
                 Butterworth filter, if applying it.
 
         Returns:
-            radial_profile (np.ndarray[np.float64]): 1-D array of peak intensities
+            radial_profile (npt.NDArray[np.float64]): 1-D array of peak intensities
                 for an azimuthally integrated powder image.
         """
-        y: np.ndarray[np.int64]
-        x: np.ndarray[np.int64]
+        y: npt.NDArray[np.int64]
+        x: npt.NDArray[np.int64]
         y, x = np.indices(powder.shape)
-        radius_map: np.ndarray[np.float64] = (
+        radius_map: npt.NDArray[np.float64] = (
             (x - center[0]) ** 2 + (y - center[1]) ** 2
         ) ** 0.5
 
         if mask is not None:
             radius_map = np.where(mask == 1, radius_map, 0)
 
-        radius_map_int: np.ndarray[np.int64] = radius_map.astype(np.int64)
-        tbin: np.ndarray[np.float64] = np.bincount(
+        radius_map_int: npt.NDArray[np.int64] = radius_map.astype(np.int64)
+        tbin: npt.NDArray[np.float64] = np.bincount(
             radius_map_int.ravel(), powder.ravel()
         )
-        nr: np.ndarray[np.int64] = np.bincount(radius_map_int.ravel())
-        radial_profile: np.ndarray[np.float64] = np.divide(
+        nr: npt.NDArray[np.int64] = np.bincount(radius_map_int.ravel())
+        radial_profile: npt.NDArray[np.float64] = np.divide(
             tbin, nr, out=np.zeros(nr.shape[0]), where=nr != 0
         )
         if filter_profile:
@@ -363,40 +383,40 @@ class OptimizeAgBhGeometryExhaustive(Task):
         return radial_profile
 
     def _calc_and_score_ideal_rings(
-        self, q_peaks: np.ndarray[np.float64]
-    ) -> Tuple[np.ndarray[np.float64], float]:
+        self, q_peaks: npt.NDArray[np.float64]
+    ) -> Tuple[npt.NDArray[np.float64], float]:
         """Score inter-peak distances in q-space based on known behenate pattern.
 
         Relies on the equidistance of peaks in q-space for silver behenate powder.
 
         Args:
-            q_peaks (np.ndarray[np.float64]): Positions of powder peaks in q-space
+            q_peaks (npt.NDArray[np.float64]): Positions of powder peaks in q-space
                 (inverse Angstrom). 1 dimensional.
 
         Returns:
-            rings (np.ndarray[np.float64]): Predicted positions of peaks based on
+            rings (npt.NDArray[np.float64]): Predicted positions of peaks based on
                 the best fit q-spacing. 1 dimensional.
 
             final_score (float): Final score calculated from residuals associated
                 with each q-spacin.
         """
         # Q-spacings between behenate peaks
-        delta_qs: np.ndarray[np.float64] = np.arange(0.01, 0.03, 0.00005)
+        delta_qs: npt.NDArray[np.float64] = np.arange(0.01, 0.03, 0.00005)
         order_max: int = 13
-        qround: np.ndarray[np.int64] = np.round(q_peaks, 5)
+        qround: npt.NDArray[np.int64] = np.round(q_peaks, 5)
         scores: List[float] = []
         dq: float
         for dq in delta_qs:
-            order: np.ndarray[np.float64] = qround / dq
-            remainder: np.ndarray[np.float64] = np.minimum(
+            order: npt.NDArray[np.float64] = qround / dq
+            remainder: npt.NDArray[np.float64] = np.minimum(
                 qround % dq, np.abs(dq - (qround % dq))
             )
-            score: np.ndarray[np.float64] = (
+            score: float = (
                 np.mean(remainder[np.where(order < order_max)]) / dq
             )  # %mod helps prevent half periods from scoring well
             scores.append(score)
         deltaq_current = delta_qs[np.argmin(scores)]
-        rings: np.ndarray[np.float64] = np.arange(
+        rings: npt.NDArray[np.float64] = np.arange(
             deltaq_current, deltaq_current * (order_max + 1), deltaq_current
         )
 
@@ -407,15 +427,15 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _opt_distance(
         self,
-        radial_profile: np.ndarray[np.float64],
+        radial_profile: npt.NDArray[np.float64],
         distance_guess: float,
         wavelength: float,
         pixel_size: float,
-    ) -> Tuple[np.ndarray[np.int64], np.ndarray[np.float64], float, float]:
+    ) -> Tuple[npt.NDArray[np.int64], npt.NDArray[np.float64], float, float]:
         """Optimize the detector distance.
 
         Args:
-            radial_profile (np.ndarray[np.float64]): 1-D array of peak intensities
+            radial_profile (npt.NDArray[np.float64]): 1-D array of peak intensities
                 for an azimuthally integrated powder image.
 
             distance_guess (float): Starting guess for the detector distance.
@@ -425,26 +445,26 @@ class OptimizeAgBhGeometryExhaustive(Task):
             pixel_size (float): Size of detector pixels in mm.
 
         Returns:
-            peak_indices (np.ndarray[np.int64]): 1-D array of peak indices.
+            peak_indices (npt.NDArray[np.int64]): 1-D array of peak indices.
 
-            selected_peaks (np.ndarray[np.float64]): Array of selected peaks.
+            selected_peaks (npt.NDArray[np.float64]): Array of selected peaks.
 
             new_distance (float): New, optimized, detector distance.
 
             final_score (float): Final score calculated from residuals associated
                 with each q-spacing.
         """
-        peak_indices: np.ndarray[np.int64]
+        peak_indices: npt.NDArray[np.int64]
         peak_indices, _ = find_peaks(radial_profile, prominence=1, distance=10)
-        theta: np.ndarray[np.float64] = np.arctan(
+        theta: npt.NDArray[np.float64] = np.arctan(
             np.arange(radial_profile.shape[0]) * pixel_size / distance_guess
         )
-        q_profile: np.ndarray[np.float64] = 2.0 * np.sin(theta / 2.0) / wavelength
+        q_profile: npt.NDArray[np.float64] = 2.0 * np.sin(theta / 2.0) / wavelength
 
-        rings: np.ndarray[np.float64]
+        rings: npt.NDArray[np.float64]
         final_score: float
         rings, final_score = self._calc_and_score_ideal_rings(q_profile[peak_indices])
-        peaks_predicted: np.ndarray[np.float64] = (
+        peaks_predicted: npt.NDArray[np.float64] = (
             2 * distance_guess * np.arcsin(rings * wavelength / 2.0) / pixel_size
         )
 
@@ -462,16 +482,16 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _opt_center(
         self,
-        powder: np.ndarray[np.float64],
-        indices: np.ndarray[np.int64],
+        powder: npt.NDArray[np.float64],
+        indices: npt.NDArray[np.int64],
         center_guess: Tuple[float, float],
     ) -> lmfit.minimizer.MinimizerResult:
         """Optimize the beam center position on the detector.
 
         Args:
-            powder (np.ndarray[np.float64]): 2-D assembled powder image.
+            powder (npt.NDArray[np.float64]): 2-D assembled powder image.
 
-            indices (np.ndarray[np.float64]): Indices of peaks in a radial profile
+            indices (npt.NDArray[np.float64]): Indices of peaks in a radial profile
                 of the azimuthally integrated powder image.
 
             center_guess (Tuple[float, float]): Starting guess for the beam center
@@ -482,7 +502,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
                 res.params["cx"] and res.params["cy"] contain the new beam center.
         """
         # Perform fitting - mean center and normalize image first
-        powder_norm: np.ndarray[np.float64] = (powder - np.mean(powder)) / np.std(
+        powder_norm: npt.NDArray[np.float64] = (powder - np.mean(powder)) / np.std(
             powder
         )
         params: lmfit.Parameters = lmfit.Parameters()
@@ -506,8 +526,8 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _opt_geom(
         self,
-        powder: np.ndarray[np.float64],
-        mask: np.ndarray[np.uint64],
+        powder: npt.NDArray[np.float64],
+        mask: npt.NDArray[np.uint64],
         params_guess: Tuple[int, Tuple[float, float], float],
         n_iterations: int,
         wavelength: float,
@@ -516,9 +536,9 @@ class OptimizeAgBhGeometryExhaustive(Task):
         """Optimize the detector distance and beam center.
 
         Args:
-            powder (np.ndarray[np.float64]): 2-D assembled powder image.
+            powder (npt.NDArray[np.float64]): 2-D assembled powder image.
 
-            mask (np.ndarray[np.float64]): Corresponding binary mask for the
+            mask (npt.NDArray[np.float64]): Corresponding binary mask for the
                 powder image.
 
             params_guess (Tuple[int, Tuple[float, float], float]): Initial guesses.
@@ -531,9 +551,9 @@ class OptimizeAgBhGeometryExhaustive(Task):
             pixel_size (float): Size of detector pixels in mm.
 
         Returns:
-            peak_indices (np.ndarray[np.int64]): 1-D array of peak indices.
+            peak_indices (npt.NDArray[np.int64]): 1-D array of peak indices.
 
-            selected_peaks (np.ndarray[np.float64]): Array of selected peaks.
+            selected_peaks (npt.NDArray[np.float64]): Array of selected peaks.
 
             final_scores (float): Final scores calculated from residuals associated
                 with each q-spacing for each iteration of optimization.
@@ -544,12 +564,15 @@ class OptimizeAgBhGeometryExhaustive(Task):
             calc_centers (List[Tuple[float, float]]): Optimized centers associated
                 with each score.
         """
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         n_peaks: int = self._task_parameters.n_peaks
-        radial_profile: np.ndarray[np.float64] = self._radial_profile(
+        radial_profile: npt.NDArray[np.float64] = self._radial_profile(
             powder, mask, params_guess[1]
         )
-        indices: np.ndarray[np.int64]
-        peaks: np.ndarray[np.float64]
+        indices: npt.NDArray[np.int64]
+        peaks: npt.NDArray[np.float64]
         distance: float
         final_score: float
         indices, peaks, distance, final_score = self._opt_distance(
@@ -563,7 +586,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
         center_guess: Tuple[float, float] = params_guess[1]
         for iter in range(n_iterations):
             # Select the highest intensity peaks from the first 8 in q
-            selected_indices: np.ndarray[np.int64] = indices[
+            selected_indices: npt.NDArray[np.int64] = indices[
                 np.argsort(peaks[:8])[::-1][:n_peaks]
             ]
             res: lmfit.minimizer.MinimizerResult = self._opt_center(
@@ -585,19 +608,22 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
         Requires a powder image from data acquired of Ag Behenate.
         """
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         exp: str = self._task_parameters.lute_config.experiment
-        run: Union[int, str] = self._task_parameters.lute_config.run
+        run: int = int(self._task_parameters.lute_config.run)
         ds: psana.DataSource = psana.DataSource(f"exp={exp}:run={run}")
         det: psana.Detector = psana.Detector(self._task_parameters.detname, ds.env())
         pixel_size_mm: float
         wavelength_angs: float
         pixel_size_mm, wavelength_angs = self._get_pixel_size_and_wavelength(ds, det)
 
-        powder: np.ndarray[np.float64] = self._extract_powder(
+        powder: npt.NDArray[np.float64] = self._extract_powder(
             self._task_parameters.powder
         )
 
-        mask: Optional[np.ndarray[np.float64]] = self._extract_mask(
+        mask: Optional[npt.NDArray[np.float64]] = self._extract_mask(
             self._task_parameters.mask
         )
         powder[powder > self._task_parameters.threshold] = 0
@@ -621,7 +647,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
                     for rank in range(self._mpi_size)
                 ]
             )
-            start_indices_per_rank: np.ndarray[np.int64] = np.zeros(
+            start_indices_per_rank: npt.NDArray[np.int64] = np.zeros(
                 self._mpi_size, dtype=np.int64
             )
             start_indices_per_rank[1:] = np.cumsum(parameters_per_rank[:-1])
@@ -667,7 +693,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
             final_distances_by_rank, root=0
         )
         final_centers: Union[
-            List[Tuple[float, float], List[List[Tuple[float, float]]]]
+            List[Tuple[float, float]], List[List[Tuple[float, float]]]
         ] = self._mpi_comm.gather(final_centers_by_rank, root=0)
 
         # Flatten nested lists
@@ -678,17 +704,21 @@ class OptimizeAgBhGeometryExhaustive(Task):
             return flattened
 
         if self._mpi_rank == 0:
-            final_scores = flatten(final_scores)
-            final_distances = flatten(final_distances)
-            final_centers = flatten(final_centers)
-            best_idx: int = np.argmax(final_scores)
-            best_distance: float = final_distances[best_idx]
-            best_center: Tuple[float, float] = final_centers[best_idx]
+            final_scores = flatten(cast(List[List[float]], final_scores))
+            final_distances = flatten(cast(List[List[float]], final_distances))
+            final_centers = flatten(
+                cast(List[List[Tuple[float, float]]], final_centers)
+            )
+            best_idx: int = cast(int, np.argmax(final_scores))
+            best_distance: float = cast(float, final_distances[best_idx])
+            best_center: Tuple[float, float] = cast(
+                Tuple[float, float], final_centers[best_idx]
+            )
             # Calculate resolution at edge
-            theta: np.ndarray[np.float64] = np.arctan(
+            theta: float = np.arctan(
                 np.array((powder.shape[0] / 2)) * pixel_size_mm / best_distance
             )
-            q: np.ndarray[np.float64] = 2.0 * np.sin(theta / 2.0) / wavelength_angs
+            q: float = 2.0 * np.sin(theta / 2.0) / wavelength_angs
             edge_resolution: float = 1.0 / q
 
             self._result.summary = []
@@ -699,8 +729,6 @@ class OptimizeAgBhGeometryExhaustive(Task):
                     "Detector edge resolution (A)": edge_resolution,
                 }
             )
-
-            run: int = int(self._task_parameters.lute_config.run)
 
             plots: pn.Tabs = self.plot_powder_and_summaries(
                 powder, best_center, best_distance, wavelength_angs, pixel_size_mm, mask
@@ -727,26 +755,26 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def plot_powder_and_summaries(
         self,
-        powder: np.ndarray[np.float64],
+        powder: npt.NDArray[np.float64],
         center: Tuple[float, float],
         distance: float,
         wavelength: float,
         pixel_size: float,
-        mask: Optional[np.ndarray[np.float64]] = None,
+        mask: Optional[npt.NDArray[np.float64]] = None,
     ) -> pn.Tabs:
-        radial_profile: np.ndarray[np.float64] = self._radial_profile(
+        radial_profile: npt.NDArray[np.float64] = self._radial_profile(
             powder, mask, center
         )
         peak_indices, _ = find_peaks(radial_profile, prominence=1, distance=10)
-        theta: np.ndarray[np.float64] = np.arctan(
+        theta: npt.NDArray[np.float64] = np.arctan(
             np.arange(radial_profile.shape[0]) * pixel_size / distance
         )
-        q_profile: np.ndarray[np.float64] = 2.0 * np.sin(theta / 2.0) / wavelength
+        q_profile: npt.NDArray[np.float64] = 2.0 * np.sin(theta / 2.0) / wavelength
 
-        rings: np.ndarray[np.float64]
+        rings: npt.NDArray[np.float64]
         final_score: float
         rings, final_score = self._calc_and_score_ideal_rings(q_profile[peak_indices])
-        peaks_predicted: np.ndarray[np.float64] = (
+        peaks_predicted: npt.NDArray[np.float64] = (
             2 * distance * np.arcsin(rings * wavelength / 2.0) / pixel_size
         )
         powder_grid: pn.GridSpec = self._plot_powder_and_rings(
@@ -762,9 +790,9 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _plot_radial_profile(
         self,
-        radial_profile: np.ndarray[np.float64],
-        qprofile: np.ndarray[np.float64],
-        peaks_observed: np.ndarray[np.int64],
+        radial_profile: npt.NDArray[np.float64],
+        qprofile: npt.NDArray[np.float64],
+        peaks_observed: npt.NDArray[np.int64],
     ) -> pn.GridSpec:
         xdim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
         ydim: hv.core.dimension.Dimesnion = hv.Dimension(("I", "I"))
@@ -783,11 +811,14 @@ class OptimizeAgBhGeometryExhaustive(Task):
 
     def _plot_powder_and_rings(
         self,
-        powder: np.ndarray[np.float64],
+        powder: npt.NDArray[np.float64],
         center: Tuple[float, float],
-        peaks_observed: np.ndarray[np.float64],
-        peaks_predicted: np.ndarray[np.float64],
+        peaks_observed: npt.NDArray[np.float64],
+        peaks_predicted: npt.NDArray[np.float64],
     ) -> pn.GridSpec:
+        self._task_parameters = cast(
+            OptimizeAgBhGeometryExhaustiveParameters, self._task_parameters
+        )
         dim: hv.core.dimension.Dimension = hv.Dimension(
             ("image", "Powder"),
             range=(
@@ -796,7 +827,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
             ),
         )
         # (left, bottom, right, top)
-        bounds: Tuple[int, int, int, int] = (
+        bounds: Tuple[float, float, float, float] = (
             -0.5,
             -0.5,
             powder.shape[0] - 0.5,

--- a/lute/tasks/geometry.py
+++ b/lute/tasks/geometry.py
@@ -67,7 +67,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
                 is_valid_path = True
 
             return is_valid_path, powder_type
-        except:
+        except Exception:
             ...
 
         try:
@@ -166,7 +166,7 @@ class OptimizeAgBhGeometryExhaustive(Task):
                 mask = np.load(self._task_parameters.mask)
             elif is_valid and dtype == "smd":
                 h5: h5py.File
-                with h5py.File(powder_path) as h5:
+                with h5py.File(mask_path) as h5:
                     unassembled: np.ndarray[np.float64] = h5[
                         f"UserDataCfg/{self._task_parameters.detname}/mask"
                     ][()]

--- a/lute/tasks/math.py
+++ b/lute/tasks/math.py
@@ -11,15 +11,16 @@ __all__ = ["gaussian", "sigma_to_fwhm"]
 __author__ = "Gabriel Dorlhiac"
 
 import numpy as np
+import numpy.typing as npt
 
 
 def gaussian(
-    x_vals: np.ndarray[np.float64], amp: float, x0: float, sigma: float, bkgnd: float
-) -> np.ndarray[np.float64]:
+    x_vals: npt.NDArray[np.float64], amp: float, x0: float, sigma: float, bkgnd: float
+) -> npt.NDArray[np.float64]:
     """1D Gaussian distribution with specified parameters.
 
     Args:
-        x_vals (np.ndarray[np.float64]): Values over which to calculate the
+        x_vals (npt.NDArray[np.float64]): Values over which to calculate the
             distribution.
 
         amp (float): Amplitude of the distribution.
@@ -28,11 +29,11 @@ def gaussian(
 
         sigma (float): Standard deviation of the distribution.
 
-        bkgnd (float | np.ndarray[np.float64]): Background/noise. Constant
+        bkgnd (float | npt.NDArray[np.float64]): Background/noise. Constant
             offset (float) or an array of offsets of the same length as `x_vals`.
 
     Returns:
-        distribution (np.ndarray[np.float64]): Calculated Gaussian distribution
+        distribution (npt.NDArray[np.float64]): Calculated Gaussian distribution
             based on given parameters. Same shape as x_vals.
     """
     numerator = -((x_vals - x0) ** 2)

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -10,14 +10,16 @@ __author__ = "Gabriel Dorlhiac"
 
 import os
 import time
+from typing import cast
 
 import numpy as np
-import matplotlib.pyplot as plt
+import numpy.typing as npt
+import matplotlib.pyplot as plt  # type: ignore
 from mpi4py import MPI
 
 from lute.tasks.task import Task
 from lute.tasks.dataclasses import TaskStatus
-from lute.io.models.base import TaskParameters
+from lute.io.models.mpi_tests import TestMultiNodeCommunicationParameters
 from lute.execution.ipc import Message
 
 
@@ -33,13 +35,18 @@ class TestMultiNodeCommunication(Task):
     nodes.
     """
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: TestMultiNodeCommunicationParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
         self._comm: MPI.Intracomm = MPI.COMM_WORLD
         self._rank: int = self._comm.Get_rank()
         self._world_size: int = self._comm.Get_size()
 
     def _run(self) -> None:
+        self._task_parameters = cast(
+            TestMultiNodeCommunicationParameters, self._task_parameters
+        )
         time.sleep(self._rank)
         msg: Message = Message(
             f"Rank {self._rank} of {self._world_size} sending message."
@@ -55,8 +62,8 @@ class TestMultiNodeCommunication(Task):
             msg = Message(contents=np.random.rand(arr_size))
             self._report_to_executor(msg)
         elif self._task_parameters.send_obj == "plot":
-            x: np.ndarray[np.float_] = np.linspace(0, 49, 50)
-            y: np.ndarray[np.float_] = np.random.rand(50)
+            x: npt.NDArray[np.float_] = np.linspace(0, 49, 50)
+            y: npt.NDArray[np.float_] = np.random.rand(50)
             fig, ax = plt.subplots(1, 1)
             ax.plot(x, y, label="Test")
             ax.set_title("Multi-Node Communication Test")

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -15,8 +15,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 from mpi4py import MPI
 
-from lute.tasks.task import *
-from lute.io.models.base import *
+from lute.tasks.task import Task
+from lute.tasks.dataclasses import TaskStatus
+from lute.io.models.base import TaskParameters
 from lute.execution.ipc import Message
 
 

--- a/lute/tasks/mpi_test.py
+++ b/lute/tasks/mpi_test.py
@@ -62,8 +62,8 @@ class TestMultiNodeCommunication(Task):
             msg = Message(contents=np.random.rand(arr_size))
             self._report_to_executor(msg)
         elif self._task_parameters.send_obj == "plot":
-            x: npt.NDArray[np.float_] = np.linspace(0, 49, 50)
-            y: npt.NDArray[np.float_] = np.random.rand(50)
+            x: npt.NDArray[np.float64] = np.linspace(0, 49, 50)
+            y: npt.NDArray[np.float64] = np.random.rand(50)
             fig, ax = plt.subplots(1, 1)
             ax.plot(x, y, label="Test")
             ax.set_title("Multi-Node Communication Test")

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -188,7 +188,7 @@ class CxiWriter:
 
     def write_event(
         self,
-        img: NDArray[numpy.float_],
+        img: NDArray[numpy.float64],
         peaks: Any,  # Not typed becomes it comes from psana
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
@@ -201,7 +201,7 @@ class CxiWriter:
 
         Parameters:
 
-            img (NDArray[numpy.float_]): Detector data for the event
+            img (NDArray[numpy.float64]): Detector data for the event
 
             peaks: (Any): Peak information for the event, as recovered from the PyAlgos
                 algorithm
@@ -218,10 +218,10 @@ class CxiWriter:
 
             clen (float): Camera length/detector distance.
         """
-        ch_rows: NDArray[numpy.float_] = (
+        ch_rows: NDArray[numpy.float64] = (
             peaks[:, 0] * self._raw_det_shape[-2] + peaks[:, 1]
         )
-        ch_cols: NDArray[numpy.float_] = peaks[:, 2]
+        ch_cols: NDArray[numpy.float64] = peaks[:, 2]
 
         if self._outh5["/entry_1/data_1/data"].shape[0] <= self._index:
             self._outh5["entry_1/data_1/data"].resize(self._index + 1, axis=0)
@@ -276,7 +276,7 @@ class CxiWriter:
         ] = peaks[:, 4]
 
         # Calculate and write pixel radius
-        peaks_cenx: NDArray[numpy.float_] = (
+        peaks_cenx: NDArray[numpy.float64] = (
             self._i_x[
                 numpy.array(peaks[:, 0], dtype=numpy.int64),
                 numpy.array(peaks[:, 1], dtype=numpy.int64),
@@ -285,7 +285,7 @@ class CxiWriter:
             + 0.5
             - self._ipx
         )
-        peaks_ceny: NDArray[numpy.float_] = (
+        peaks_ceny: NDArray[numpy.float64] = (
             self._i_y[
                 numpy.array(peaks[:, 0], dtype=numpy.int64),
                 numpy.array(peaks[:, 1], dtype=numpy.int64),
@@ -294,7 +294,7 @@ class CxiWriter:
             + 0.5
             - self._ipy
         )
-        peak_radius: NDArray[numpy.float_] = numpy.sqrt(
+        peak_radius: NDArray[numpy.float64] = numpy.sqrt(
             (peaks_cenx**2) + (peaks_ceny**2)
         )
         self._outh5["/entry_1/result_1/peakRadius"][
@@ -313,8 +313,8 @@ class CxiWriter:
 
     def write_non_event_data(
         self,
-        powder_hits: NDArray[numpy.float_],
-        powder_misses: NDArray[numpy.float_],
+        powder_hits: NDArray[numpy.float64],
+        powder_misses: NDArray[numpy.float64],
         mask: NDArray[numpy.uint16],
     ):
         """
@@ -322,9 +322,9 @@ class CxiWriter:
 
         Parameters:
 
-            powder_hits (NDArray[numpy.float_]): Virtual powder pattern from hits
+            powder_hits (NDArray[numpy.float64]): Virtual powder pattern from hits
 
-            powder_misses (NDArray[numpy.float_]): Virtual powder pattern from hits
+            powder_misses (NDArray[numpy.float64]): Virtual powder pattern from hits
 
             mask: (NDArray[numpy.uint16]): Pixel ask to write into the file
 
@@ -741,8 +741,8 @@ class FindPeaksPyAlgos(Task):
                         libpressio_mask=mask,
                     )
 
-                powder_hits: NDArray[numpy.float_] = numpy.zeros(det_shape)
-                powder_misses: NDArray[numpy.float_] = numpy.zeros(det_shape)
+                powder_hits: NDArray[numpy.float64] = numpy.zeros(det_shape)
+                powder_misses: NDArray[numpy.float64] = numpy.zeros(det_shape)
 
             peaks: Any = alg.peak_finder_v3r3(
                 img,

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -13,17 +13,17 @@ __author__ = "Valerio Mariani, Gabriel Dorlhiac"
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Literal, TextIO, Tuple, Optional, cast
+from typing import Any, Dict, List, Literal, TextIO, Tuple, Optional, cast, Union
 
-import h5py
-import holoviews as hv
+import h5py  # type: ignore
+import holoviews as hv  # type: ignore
 import numpy
 import panel as pn
 from mpi4py.MPI import COMM_WORLD, SUM
 from numpy.typing import NDArray
-from psalgos.pypsalgos import PyAlgos
-from psana import Detector, EventId, MPIDataSource
-from PSCalib import GeometryAccess
+from psalgos.pypsalgos import PyAlgos  # type: ignore
+from psana import Detector, EventId, MPIDataSource  # type: ignore
+from PSCalib import GeometryAccess  # type: ignore
 
 from lute.execution.ipc import Message
 from lute.io.models.sfx_find_peaks import FindPeaksPyAlgosParameters
@@ -535,7 +535,7 @@ def generate_libpressio_configuration(
     elif compressor == "sz3":
         pressio_opts = {"pressio:abs": abs_error}
 
-    lp_json = {
+    lp_json: Dict[str, Any] = {
         "compressor_id": "pressio",
         "early_config": {
             "pressio": {
@@ -689,7 +689,7 @@ class FindPeaksPyAlgos(Task):
 
                 if self._task_parameters.psana_mask:
                     mask = det.mask(
-                        self._task_parameters.run,
+                        self._task_parameters.lute_config.run,
                         calib=False,
                         status=True,
                         edges=False,
@@ -759,7 +759,7 @@ class FindPeaksPyAlgos(Task):
             ):
 
                 if self._task_parameters.compression is not None:
-                    from libpressio import PressioCompressor
+                    from libpressio import PressioCompressor  # type: ignore
 
                     libpressio_config_with_peaks = (
                         add_peaks_to_libpressio_configuration(libpressio_config, peaks)
@@ -843,7 +843,7 @@ class FindPeaksPyAlgos(Task):
             )
 
             # Write final summary file
-            f: TextIO
+            f: Union[TextIO, h5py.File]
             with open(
                 Path(self._task_parameters.outdir) / f"peakfinding{tag}.summary", "w"
             ) as f:
@@ -856,7 +856,6 @@ class FindPeaksPyAlgos(Task):
                 print(f"No. hits per rank: {num_hits_per_rank}", file=f)
 
             with h5py.File(master_fname, "r") as f:
-                f = cast(h5py.File, f)
                 final_powder_hits: NDArray[numpy.float64] = f[
                     "entry_1/data_1/powderHits"
                 ][:]

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -13,7 +13,7 @@ __author__ = "Valerio Mariani, Gabriel Dorlhiac"
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Literal, TextIO, Tuple, Optional
+from typing import Any, Dict, List, Literal, TextIO, Tuple, Optional, cast
 
 import h5py
 import holoviews as hv
@@ -26,7 +26,7 @@ from psana import Detector, EventId, MPIDataSource
 from PSCalib import GeometryAccess
 
 from lute.execution.ipc import Message
-from lute.io.models.base import TaskParameters
+from lute.io.models.sfx_find_peaks import FindPeaksPyAlgosParameters
 from lute.tasks.task import Task
 from lute.tasks.dataclasses import TaskStatus, ElogSummaryPlots
 
@@ -140,9 +140,10 @@ class CxiWriter:
             )
 
         # Peak-related entries
+        ds_x: Any
         for key in keys:
             if key == "nPeaks":
-                ds_x: Any = self._outh5.create_dataset(
+                ds_x = self._outh5.create_dataset(
                     f"/entry_1/result_1/{key}",
                     (n_events,),
                     maxshape=(None,),
@@ -151,7 +152,7 @@ class CxiWriter:
                 ds_x.attrs["minPeaks"] = min_peaks
                 ds_x.attrs["maxPeaks"] = max_peaks
             else:
-                ds_x: Any = self._outh5.create_dataset(
+                ds_x = self._outh5.create_dataset(
                     f"/entry_1/result_1/{key}",
                     (n_events, max_peaks),
                     maxshape=(None, max_peaks),
@@ -162,17 +163,16 @@ class CxiWriter:
 
         # Timestamp entries
         lcls_1: Any = self._outh5.create_group("LCLS")
-        keys: List[str] = [
+        keys = [
             "eventNumber",
             "machineTime",
             "machineTimeNanoSeconds",
             "fiducial",
             "photon_energy_eV",
         ]
-        key: str
         for key in keys:
             if key == "photon_energy_eV":
-                ds_x: Any = lcls_1.create_dataset(
+                ds_x = lcls_1.create_dataset(
                     f"{key}", (n_events,), maxshape=(None,), dtype=float
                 )
             else:
@@ -613,10 +613,13 @@ class FindPeaksPyAlgos(Task):
     writes the peak information to CXI files.
     """
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: FindPeaksPyAlgosParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
 
     def _run(self) -> None:
+        self._task_parameters = cast(FindPeaksPyAlgosParameters, self._task_parameters)
         ds: Any = MPIDataSource(
             f"exp={self._task_parameters.lute_config.experiment}:"
             f"run={self._task_parameters.lute_config.run}:smd"
@@ -686,7 +689,7 @@ class FindPeaksPyAlgos(Task):
 
                 if self._task_parameters.psana_mask:
                     mask = det.mask(
-                        self.task_parameters.run,
+                        self._task_parameters.run,
                         calib=False,
                         status=True,
                         edges=False,
@@ -698,16 +701,16 @@ class FindPeaksPyAlgos(Task):
                 hdffh: Any
                 if self._task_parameters.mask_file is not None:
                     with h5py.File(self._task_parameters.mask_file, "r") as hdffh:
-                        loaded_mask: NDArray[numpy.int] = hdffh["entry_1/data_1/mask"][
-                            :
-                        ]
+                        loaded_mask: NDArray[numpy.int64] = hdffh[
+                            "entry_1/data_1/mask"
+                        ][:]
                         mask *= loaded_mask.astype(numpy.uint16)
 
                 file_writer: CxiWriter = CxiWriter(
                     outdir=self._task_parameters.outdir,
                     rank=ds.rank,
                     exp=self._task_parameters.lute_config.experiment,
-                    run=self._task_parameters.lute_config.run,
+                    run=int(self._task_parameters.lute_config.run),
                     n_events=self._task_parameters.n_events,
                     det_shape=det_shape,
                     raw_det_shape=img.shape,
@@ -719,7 +722,7 @@ class FindPeaksPyAlgos(Task):
                     max_peaks=self._task_parameters.max_peaks,
                     tag=tag,
                 )
-                alg: Any = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
+                alg = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
                 alg.set_peak_selection_pars(
                     npix_min=self._task_parameters.npix_min,
                     npix_max=self._task_parameters.npix_max,
@@ -822,16 +825,18 @@ class FindPeaksPyAlgos(Task):
 
         COMM_WORLD.Barrier()
 
-        num_hits_per_rank: List[int] = COMM_WORLD.gather(num_hits, root=0)
-        num_hits_total: int = COMM_WORLD.reduce(num_hits, SUM)
-        num_events_total: int = COMM_WORLD.reduce(num_events, SUM)
+        num_hits_per_rank: List[int] = cast(
+            List[int], COMM_WORLD.gather(num_hits, root=0)
+        )
+        num_hits_total: int = cast(int, COMM_WORLD.reduce(num_hits, SUM))
+        num_events_total: int = cast(int, COMM_WORLD.reduce(num_events, SUM))
 
         if ds.rank == 0:
             master_fname: Path = write_master_file(
                 mpi_size=ds.size,
                 outdir=self._task_parameters.outdir,
                 exp=self._task_parameters.lute_config.experiment,
-                run=self._task_parameters.lute_config.run,
+                run=int(self._task_parameters.lute_config.run),
                 tag=tag,
                 n_hits_per_rank=num_hits_per_rank,
                 n_hits_total=num_hits_total,
@@ -851,10 +856,11 @@ class FindPeaksPyAlgos(Task):
                 print(f"No. hits per rank: {num_hits_per_rank}", file=f)
 
             with h5py.File(master_fname, "r") as f:
-                final_powder_hits: numpy.ndarray[numpy.float64] = f[
+                f = cast(h5py.File, f)
+                final_powder_hits: NDArray[numpy.float64] = f[
                     "entry_1/data_1/powderHits"
                 ][:]
-                final_powder_misses: numpy.ndarray[numpy.float64] = f[
+                final_powder_misses: NDArray[numpy.float64] = f[
                     "entry_1/data_1/powderMisses"
                 ][:]
                 f.close()
@@ -883,8 +889,8 @@ class FindPeaksPyAlgos(Task):
         self._result.task_status = TaskStatus.COMPLETED
 
     def _assemble_image(
-        self, det: Detector, img: numpy.ndarray[numpy.float64]
-    ) -> numpy.ndarray[numpy.float64]:
+        self, det: Detector, img: NDArray[numpy.float64]
+    ) -> NDArray[numpy.float64]:
         """Assemble an image based on psana geometry.
 
         Args:
@@ -898,20 +904,16 @@ class FindPeaksPyAlgos(Task):
             assembled_img(numpy.ndarray[np.float64]): Assembled 2D image.
         """
         geom: GeometryAccess = det.geometry(self._task_parameters.lute_config.run)
-        tmp: Tuple[numpy.ndarray[numpy.uint64], ...] = geom.get_pixel_coord_indexes()
-        pixel_map: numpy.ndarray[numpy.unit64] = numpy.zeros(
+        tmp: Tuple[NDArray[numpy.uint64], ...] = geom.get_pixel_coord_indexes()
+        pixel_map: NDArray[numpy.uint64] = numpy.zeros(
             tmp[0].shape[1:] + (2,), dtype=numpy.uint64
         )
         pixel_map[..., 0] = tmp[0][0]
         pixel_map[..., 1] = tmp[1][0]
-        unflattened_img: numpy.ndarray[numpy.float64] = img.reshape(
-            pixel_map.shape[:-1]
-        )
+        unflattened_img: NDArray[numpy.float64] = img.reshape(pixel_map.shape[:-1])
         idx_max_y: int = int(numpy.max(pixel_map[..., 0]) + 1)  # Adding one
         idx_max_x: int = int(numpy.max(pixel_map[..., 1]) + 1)  # casts to float
-        assembled_img: numpy.ndarray[numpy.float64] = numpy.zeros(
-            (idx_max_y, idx_max_x)
-        )
+        assembled_img: NDArray[numpy.float64] = numpy.zeros((idx_max_y, idx_max_x))
         assembled_img[pixel_map[..., 0], pixel_map[..., 1]] = unflattened_img
 
         return assembled_img
@@ -919,8 +921,8 @@ class FindPeaksPyAlgos(Task):
     def _create_powder_plots(
         self,
         det: Detector,
-        powder_hits: numpy.ndarray[numpy.float64],
-        powder_misses: numpy.ndarray[numpy.float64],
+        powder_hits: NDArray[numpy.float64],
+        powder_misses: NDArray[numpy.float64],
     ) -> pn.Tabs:
         """Create a tabbed display of hits and misses 'powder' plots.
 
@@ -937,10 +939,11 @@ class FindPeaksPyAlgos(Task):
         Returns:
             tabs (pn.Tabs): Tabbed display of the image plots.
         """
-        assembled_powder_hits: numpy.ndarray[numpy.float64] = self._assemble_image(
+        self._task_parameters = cast(FindPeaksPyAlgosParameters, self._task_parameters)
+        assembled_powder_hits: NDArray[numpy.float64] = self._assemble_image(
             det, powder_hits
         )
-        assembled_powder_misses: numpy.ndarray[numpy.float64] = self._assemble_image(
+        assembled_powder_misses: NDArray[numpy.float64] = self._assemble_image(
             det, powder_misses
         )
 

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -26,9 +26,9 @@ from psana import Detector, EventId, MPIDataSource
 from PSCalib import GeometryAccess
 
 from lute.execution.ipc import Message
-from lute.io.models.base import *
-from lute.tasks.task import *
-from lute.tasks.dataclasses import ElogSummaryPlots
+from lute.io.models.base import TaskParameters
+from lute.tasks.task import Task
+from lute.tasks.dataclasses import TaskStatus, ElogSummaryPlots
 
 hv.extension("bokeh")
 pn.extension()
@@ -363,7 +363,7 @@ class CxiWriter:
         self._outh5["/entry_1/data_1/data"].resize(
             (num_hits, data_shape[1], data_shape[2])
         )
-        self._outh5[f"/entry_1/result_1/nPeaks"].resize((num_hits,))
+        self._outh5["/entry_1/result_1/nPeaks"].resize((num_hits,))
         key: str
         for key in [
             "peakXPosRaw",
@@ -615,8 +615,6 @@ class FindPeaksPyAlgos(Task):
 
     def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
-        if self._task_parameters.compression is not None:
-            from libpressio import PressioCompressor
 
     def _run(self) -> None:
         ds: Any = MPIDataSource(
@@ -668,7 +666,7 @@ class FindPeaksPyAlgos(Task):
                 )
 
             if self._task_parameters.event_logic:
-                if not self._task_parameters.event_code in event_codes:
+                if self._task_parameters.event_code not in event_codes:
                     continue
 
             img: Any = det.calib(evt)
@@ -758,6 +756,7 @@ class FindPeaksPyAlgos(Task):
             ):
 
                 if self._task_parameters.compression is not None:
+                    from libpressio import PressioCompressor
 
                     libpressio_config_with_peaks = (
                         add_peaks_to_libpressio_configuration(libpressio_config, peaks)
@@ -767,7 +766,7 @@ class FindPeaksPyAlgos(Task):
                     )
                     compressed_img = compressor.encode(img)
                     decompressed_img = numpy.zeros_like(img)
-                    decompressed = compressor.decode(compressed_img, decompressed_img)
+                    _ = compressor.decode(compressed_img, decompressed_img)
                     img = decompressed_img
 
                 photon_energy: float

--- a/lute/tasks/sfx_index.py
+++ b/lute/tasks/sfx_index.py
@@ -10,10 +10,10 @@ __author__ = "Valerio Mariani"
 
 import shutil
 from pathlib import Path
-from typing import BinaryIO, List
+from typing import BinaryIO, List, cast
 
 from lute.execution.ipc import Message
-from lute.io.models.base import TaskParameters
+from lute.io.models.sfx_index import ConcatenateStreamFilesParameters
 from lute.tasks.task import Task
 
 
@@ -22,11 +22,13 @@ class ConcatenateStreamFiles(Task):
     Task that merges stream files located within a directory tree.
     """
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: ConcatenateStreamFilesParameters) -> None:
         super().__init__(params=params)
 
     def _run(self) -> None:
-
+        self._task_parameters = cast(
+            ConcatenateStreamFilesParameters, self._task_parameters
+        )
         stream_file_path: Path = Path(self._task_parameters.in_file)
         stream_file_list: List[Path] = list(
             stream_file_path.rglob(f"*{self._task_parameters.tag}*.stream")

--- a/lute/tasks/sfx_index.py
+++ b/lute/tasks/sfx_index.py
@@ -9,16 +9,12 @@ __all__ = ["ConcatenateStreamFiles"]
 __author__ = "Valerio Mariani"
 
 import shutil
-import sys
 from pathlib import Path
 from typing import BinaryIO, List
 
-import numpy
-from mpi4py import MPI
-
 from lute.execution.ipc import Message
-from lute.io.models.base import *
-from lute.tasks.task import *
+from lute.io.models.base import TaskParameters
+from lute.tasks.task import Task
 
 
 class ConcatenateStreamFiles(Task):

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -17,18 +17,11 @@ Classes:
 __all__ = ["AnalyzeSmallDataXSS", "AnalyzeSmallDataXAS", "AnalyzeSmallDataXES"]
 __author__ = "Gabriel Dorlhiac"
 
-import sys
-import logging
-from typing import List, Optional, Dict, Tuple, Union
+from typing import List, Optional
 
-import h5py
-import holoviews as hv
 import numpy as np
 import panel as pn
-import matplotlib.pyplot as plt
 from mpi4py import MPI
-from scipy.signal import find_peaks
-from scipy.optimize import curve_fit
 
 from lute.io.models.base import TaskParameters
 from lute.tasks.dataclasses import ElogSummaryPlots

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -17,34 +17,44 @@ Classes:
 __all__ = ["AnalyzeSmallDataXSS", "AnalyzeSmallDataXAS", "AnalyzeSmallDataXES"]
 __author__ = "Gabriel Dorlhiac"
 
-from typing import List, Optional
+from typing import List, Optional, cast
 
 import numpy as np
+import numpy.typing as npt
 import panel as pn
 from mpi4py import MPI
 
-from lute.io.models.base import TaskParameters
+from lute.io.models.smd import (
+    AnalyzeSmallDataXASParameters,
+    AnalyzeSmallDataXESParameters,
+    AnalyzeSmallDataXSSParameters,
+)
 from lute.tasks.dataclasses import ElogSummaryPlots
 from lute.tasks._smalldata import AnalyzeSmallData
 
 
 def sum_diff(
-    diff0: np.ndarray[np.float64], diff1: np.ndarray[np.float64]
-) -> np.ndarray[np.float64]:
+    diff0: npt.NDArray[np.float64], diff1: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
     return diff0 + diff1
 
 
 def laser_on_mean(
-    laser_on0: np.ndarray[np.float64], laser_on1: np.ndarray[np.float64]
-) -> np.ndarray[np.float64]:
+    laser_on0: npt.NDArray[np.float64], laser_on1: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
     return laser_on0.sum(axis=0) + laser_on1.sum(axis=0)
 
 
 class AnalyzeSmallDataXSS(AnalyzeSmallData):
     """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: AnalyzeSmallDataXSSParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
+        self._task_parameters = cast(
+            AnalyzeSmallDataXSSParameters, self._task_parameters
+        )
 
     def _pre_run(self) -> None:
         # Currently scattering data is extracted as standard since its used
@@ -52,9 +62,9 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         self._extract_standard_data()
 
     def _run(self) -> None:
-        diff: np.ndarray[np.float64]
-        bins: np.ndarray[np.float64]
-        laser_on: np.ndarray[np.float64]
+        diff: Optional[npt.NDArray[np.float64]]
+        bins: npt.NDArray[np.float64]
+        laser_on: Optional[npt.NDArray[np.float64]]
         bins, diff, laser_on = self._calc_scan_binned_difference_xss()
 
         if self._mpi_size > 1:
@@ -63,7 +73,7 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         else:
             laser_on = np.nansum(laser_on, axis=0)
 
-        if self._mpi_rank == 0:
+        if self._mpi_rank == 0 and diff is not None and laser_on is not None:
             diff /= self._mpi_size
             laser_on /= self._total_num_events
             name: str = self._scan_var_name if self._scan_var_name else "By_Event"
@@ -86,22 +96,27 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
 class AnalyzeSmallDataXAS(AnalyzeSmallData):
     """Task to analyze XAS data stored in a SmallData HDF5 file."""
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: AnalyzeSmallDataXASParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
 
     def _pre_run(self) -> None:
         # Currently scattering data is extracted as standard since its used
         # for all analysis types (XSS, XAS, XES,...)
+        self._task_parameters = cast(
+            AnalyzeSmallDataXASParameters, self._task_parameters
+        )
         self._extract_standard_data()
         self._extract_xas(self._task_parameters.xas_detname)
 
     def _run(self) -> None:
         # XAS returns two sets of binned data
         # Bins raw TR-XAS first, then bins by scan
-        diff: Optional[np.ndarray[np.float64]]
-        ccm_bins: Optional[np.ndarray[np.float64]]
-        laser_on: Optional[np.ndarray[np.float64]]
-        laser_off: Optional[np.ndarray[np.float64]]
+        diff: Optional[npt.NDArray[np.float64]]
+        ccm_bins: Optional[npt.NDArray[np.float64]]
+        laser_on: Optional[npt.NDArray[np.float64]]
+        laser_off: Optional[npt.NDArray[np.float64]]
         ccm_bins, diff, laser_on, laser_off = self._calc_binned_difference_xas()
 
         # We check None on ccm_bins because the monochromator is not always
@@ -120,35 +135,49 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
             run = 0
         plot_display_name: str
         exp_run: str
-        if self._mpi_rank == 0 and ccm_bins is not None:
+        plots: Optional[pn.Tabs]
+        if (
+            self._mpi_rank == 0
+            and ccm_bins is not None
+            and diff is not None
+            and laser_on is not None
+            and laser_off is not None
+        ):
             # Check None again
             diff /= self._mpi_size
             laser_on /= self._mpi_size
             laser_off /= self._mpi_size
-            plots: pn.Tabs = self.plot_all_xas(laser_on, laser_off, ccm_bins, diff)
+            plots = self.plot_all_xas(laser_on, laser_off, ccm_bins, diff)
             exp_run = f"{run:04d}_XAS"
             plot_display_name = f"XAS/{exp_run}"
             all_plots.append(ElogSummaryPlots(plot_display_name, plots))
 
-        scan_bins: Optional[np.ndarray[np.float64]]
+        scan_bins: Optional[npt.NDArray[np.float64]]
         scan_bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xas()
         if self._mpi_size > 1 and scan_bins is not None:
             diff = self._mpi_comm.reduce(diff, op=MPI.SUM)
             laser_on = self._mpi_comm.reduce(laser_on, op=MPI.SUM)
             laser_off = self._mpi_comm.reduce(laser_off, op=MPI.SUM)
 
-        if self._mpi_rank == 0 and scan_bins is not None:
-            plots: pn.Tabs = self.plot_xas_scan_hv(laser_on, laser_off, scan_bins, diff)
-            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
-            exp_run = f"{run:04d}_{name}_XAS"
-            if "lens" in name:
-                plot_display_name = f"lens_scans/{exp_run}"
-            elif "lxe_opa" in name:
-                plot_display_name = f"power_scans/{exp_run}"
-            else:
-                plot_display_name = f"time_scans/{exp_run}"
+        if (
+            self._mpi_rank == 0
+            and scan_bins is not None
+            and diff is not None
+            and laser_on is not None
+            and laser_off is not None
+        ):
+            plots = self.plot_xas_scan_hv(laser_on, laser_off, scan_bins, diff)
+            if plots is not None:
+                name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+                exp_run = f"{run:04d}_{name}_XAS"
+                if "lens" in name:
+                    plot_display_name = f"lens_scans/{exp_run}"
+                elif "lxe_opa" in name:
+                    plot_display_name = f"power_scans/{exp_run}"
+                else:
+                    plot_display_name = f"time_scans/{exp_run}"
 
-            all_plots.append(ElogSummaryPlots(plot_display_name, plots))
+                all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots
 
     def _post_run(self) -> None: ...
@@ -157,21 +186,26 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
 class AnalyzeSmallDataXES(AnalyzeSmallData):
     """Task to analyze XES data stored in a SmallData HDF5 file."""
 
-    def __init__(self, *, params: TaskParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: AnalyzeSmallDataXESParameters, use_mpi: bool = True
+    ) -> None:
         super().__init__(params=params, use_mpi=use_mpi)
 
     def _pre_run(self) -> None:
         # Currently scattering data is extracted as standard since its used
         # for all analysis types (XSS, XAS, XES,...)
+        self._task_parameters = cast(
+            AnalyzeSmallDataXESParameters, self._task_parameters
+        )
         self._extract_standard_data()
         self._extract_xes(self._task_parameters.xes_detname)
 
     def _run(self) -> None:
         # XES returns two sets of data
         # Average TR-XES first, then bins by scan variable
-        diff: np.ndarray[np.float64]
-        laser_on: np.ndarray[np.float64]
-        laser_off: np.ndarray[np.float64]
+        diff: Optional[npt.NDArray[np.float64]]
+        laser_on: Optional[npt.NDArray[np.float64]]
+        laser_off: Optional[npt.NDArray[np.float64]]
         diff, laser_on, laser_off = self._calc_avg_difference_xes()
 
         if self._mpi_size > 1:
@@ -187,35 +221,47 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
             run = 0
         plot_display_name: str
         exp_run: str
-        if self._mpi_rank == 0:
+        plots: Optional[pn.Tabs]
+        if (
+            self._mpi_rank == 0
+            and diff is not None
+            and laser_on is not None
+            and laser_off is not None
+        ):
             diff /= self._mpi_size
             laser_on /= self._mpi_size
             laser_off /= self._mpi_size
-            energy_bins: Optional[np.ndarray[np.float64]] = None
-            plots: pn.Tabs = self.plot_xes_hv(laser_on, laser_off, energy_bins, diff)
+            energy_bins: Optional[npt.NDArray[np.float64]] = None
+            plots = self.plot_xes_hv(laser_on, laser_off, energy_bins, diff)
             exp_run = f"{run:04d}_XES"
             plot_display_name = f"XES/{exp_run}"
             all_plots.append(ElogSummaryPlots(plot_display_name, plots))
 
-        scan_bins: np.ndarray[np.float64]
+        scan_bins: npt.NDArray[np.float64]
         scan_bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xes()
         if self._mpi_size > 1:
             diff = self._mpi_comm.reduce(diff, op=MPI.SUM)
             laser_on = self._mpi_comm.reduce(laser_on, op=MPI.SUM)
             laser_off = self._mpi_comm.reduce(laser_off, op=MPI.SUM)
 
-        if self._mpi_rank == 0:
-            plots: pn.Tabs = self.plot_xes_scan_hv(laser_on, laser_off, scan_bins, diff)
-            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
-            exp_run = f"{run:04d}_{name}_XES"
-            if "lens" in name:
-                plot_display_name = f"lens_scans/{exp_run}"
-            elif "lxe_opa" in name:
-                plot_display_name = f"power_scans/{exp_run}"
-            else:
-                plot_display_name = f"time_scans/{exp_run}"
+        if (
+            self._mpi_rank == 0
+            and diff is not None
+            and laser_on is not None
+            and laser_off is not None
+        ):
+            plots = self.plot_xes_scan_hv(laser_on, laser_off, scan_bins, diff)
+            if plots is not None:
+                name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+                exp_run = f"{run:04d}_{name}_XES"
+                if "lens" in name:
+                    plot_display_name = f"lens_scans/{exp_run}"
+                elif "lxe_opa" in name:
+                    plot_display_name = f"power_scans/{exp_run}"
+                else:
+                    plot_display_name = f"time_scans/{exp_run}"
 
-            all_plots.append(ElogSummaryPlots(plot_display_name, plots))
+                all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots
 
     def _post_run(self) -> None: ...

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -18,6 +18,7 @@ import signal
 
 from lute.io.models.base import (
     TaskParameters,
+    ThirdPartyParameters,
     TemplateParameters,
     TemplateConfig,
     AnalysisHeader,
@@ -221,7 +222,7 @@ class Task(ABC):
 class ThirdPartyTask(Task):
     """A `Task` interface to analysis with binary executables."""
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: ThirdPartyParameters) -> None:
         """Initialize a Task.
 
         Args:
@@ -246,6 +247,8 @@ class ThirdPartyTask(Task):
                 TaskParameters model definition.
         """
         super().__init__(params=params)
+        if not hasattr(self._task_parameters, "executable"):
+            raise RuntimeError("ThirdPartyTask must have executable defined!")
         self._cmd = self._task_parameters.executable
         self._args_list: List[str] = [self._cmd]
         self._template_context: Dict[str, Any] = {}
@@ -280,6 +283,9 @@ class ThirdPartyTask(Task):
         """
         from jinja2 import Environment, FileSystemLoader, Template
 
+        if not hasattr(self._task_parameters, "lute_template_cfg"):
+            raise RuntimeError("Missing lute_template_cfg! Cannot compile template!")
+
         out_file: str = self._task_parameters.lute_template_cfg.output_path
         template_name: str = self._task_parameters.lute_template_cfg.template_name
 
@@ -290,7 +296,7 @@ class ThirdPartyTask(Task):
                 "LUTE_PATH is None in Task process! Using relative path for templates!",
                 category=UserWarning,
             )
-            template_dir: str = "../../config/templates"
+            template_dir = "../../config/templates"
         else:
             template_dir = f"{lute_path}/config/templates"
         environment: Environment = Environment(loader=FileSystemLoader(template_dir))
@@ -318,16 +324,17 @@ class ThirdPartyTask(Task):
         identified.
         """
         super()._pre_run()
-        full_schema: Dict[str, Union[str, Dict[str, Any]]] = (
-            self._task_parameters.schema()
-        )
+        full_schema: Dict[str, Any] = self._task_parameters.schema()
         short_flags_use_eq: bool
         long_flags_use_eq: bool
         if hasattr(self._task_parameters.Config, "short_flags_use_eq"):
-            short_flags_use_eq: bool = self._task_parameters.Config.short_flags_use_eq
-            long_flags_use_eq: bool = self._task_parameters.Config.long_flags_use_eq
+            short_flags_use_eq = self._task_parameters.Config.short_flags_use_eq
         else:
             short_flags_use_eq = False
+
+        if hasattr(self._task_parameters.Config, "long_flags_use_eq"):
+            long_flags_use_eq = self._task_parameters.Config.long_flags_use_eq
+        else:
             long_flags_use_eq = False
         for param, value in self._task_parameters.dict().items():
             # Clunky test with __dict__[param] because compound model-types are

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -22,9 +22,14 @@ from lute.io.models.base import (
     TemplateConfig,
     AnalysisHeader,
 )
-from lute.execution.ipc import *
+from lute.execution.ipc import (
+    Message,
+    PipeCommunicator,
+    SocketCommunicator,
+    Communicator,
+)
 from lute.execution.debug_utils import LUTE_DEBUG_EXIT
-from lute.tasks.dataclasses import *
+from lute.tasks.dataclasses import TaskResult, TaskStatus
 
 if __debug__:
     warnings.simplefilter("default")

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -240,7 +240,8 @@ def compare_hkl_fom_summary(
         figure_display_name (str): Display name of the figure in the eLog.
     """
     import numpy as np
-    import holoviews as hv
+    import numpy.typing as npt
+    import holoviews as hv  # type: ignore
     import panel as pn
 
     with open(shell_file, "r") as f:
@@ -248,7 +249,7 @@ def compare_hkl_fom_summary(
 
     header: str = lines[0]
     fom: str = header.split()[2]
-    shells_arr: np.ndarray[np.float64] = np.loadtxt(lines[1:])
+    shells_arr: npt.NDArray[np.float64] = np.loadtxt(lines[1:])
     run_params: Dict[str, str] = {fom: str(shells_arr[1])}
     if shells_arr.ndim == 1:
         return run_params, None
@@ -260,7 +261,7 @@ def compare_hkl_fom_summary(
     )
     ydim: hv.core.dimension.Dimension = hv.Dimension((fom, fom))
 
-    angs_bins: np.ndarray[np.float64] = 10.0 / shells_arr[:, 0]
+    angs_bins: npt.NDArray[np.float64] = 10.0 / shells_arr[:, 0]
     pts: hv.Points = hv.Points((angs_bins, shells_arr[:, 1]), kdims=[xdim, ydim])
     grid: pn.GridSpec = pn.GridSpec(name="Figures of Merit")
     grid[:2, :2] = pts

--- a/lute/tasks/test.py
+++ b/lute/tasks/test.py
@@ -16,11 +16,17 @@ __all__ = ["Test", "TestSocket", "TestWriteOutput", "TestReadOutput"]
 __author__ = "Gabriel Dorlhiac"
 
 import time
+from typing import cast
 
 import numpy as np
 
 from lute.tasks.task import Task
-from lute.io.models.base import TaskParameters
+from lute.io.models.tests import (
+    TestParameters,
+    TestSocketParameters,
+    TestWriteOutputParameters,
+    TestReadOutputParameters,
+)
 from lute.tasks.dataclasses import TaskStatus
 from lute.execution.ipc import Message
 
@@ -28,10 +34,11 @@ from lute.execution.ipc import Message
 class Test(Task):
     """Simple test Task to ensure subprocess and pipe-based IPC work."""
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: TestParameters) -> None:
         super().__init__(params=params)
 
     def _run(self) -> None:
+        self._task_parameters = cast(TestParameters, self._task_parameters)
         for i in range(10):
             time.sleep(1)
             msg: Message = Message(contents=f"Test message {i}")
@@ -48,21 +55,21 @@ class Test(Task):
 class TestSocket(Task):
     """Simple test Task to ensure basic IPC over Unix sockets works."""
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: TestSocketParameters) -> None:
         super().__init__(params=params)
 
     def _run(self) -> None:
+        self._task_parameters = cast(TestSocketParameters, self._task_parameters)
         for i in range(self._task_parameters.num_arrays):
             msg: Message = Message(contents=f"Sending array {i}")
             self._report_to_executor(msg)
             time.sleep(0.05)
-            msg: Message = Message(
-                contents=np.random.rand(self._task_parameters.array_size)
-            )
+            msg = Message(contents=np.random.rand(self._task_parameters.array_size))
             self._report_to_executor(msg)
 
     def _post_run(self) -> None:
         super()._post_run()
+        self._task_parameters = cast(TestSocketParameters, self._task_parameters)
         self._result.summary = f"Sent {self._task_parameters.num_arrays} arrays"
         self._result.payload = np.random.rand(self._task_parameters.array_size)
         self._result.task_status = TaskStatus.COMPLETED
@@ -71,10 +78,11 @@ class TestSocket(Task):
 class TestWriteOutput(Task):
     """Simple test Task to write output other Tasks depend on."""
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: TestWriteOutputParameters) -> None:
         super().__init__(params=params)
 
     def _run(self) -> None:
+        self._task_parameters = cast(TestWriteOutputParameters, self._task_parameters)
         for i in range(self._task_parameters.num_vals):
             # Doing some calculations...
             time.sleep(0.05)
@@ -84,6 +92,7 @@ class TestWriteOutput(Task):
 
     def _post_run(self) -> None:
         super()._post_run()
+        self._task_parameters = cast(TestWriteOutputParameters, self._task_parameters)
         work_dir: str = self._task_parameters.lute_config.work_dir
         out_file: str = f"{work_dir}/{self._task_parameters.outfile_name}"
         array: np.ndarray = np.random.rand(self._task_parameters.num_vals)
@@ -99,10 +108,11 @@ class TestReadOutput(Task):
     Its pydantic model relies on a database access to retrieve the output file.
     """
 
-    def __init__(self, *, params: TaskParameters) -> None:
+    def __init__(self, *, params: TestReadOutputParameters) -> None:
         super().__init__(params=params)
 
     def _run(self) -> None:
+        self._task_parameters = cast(TestReadOutputParameters, self._task_parameters)
         _: np.ndarray = np.loadtxt(self._task_parameters.in_file, delimiter=",")
         self._report_to_executor(msg=Message(contents="Successfully loaded data!"))
         for i in range(5):

--- a/lute/tasks/test.py
+++ b/lute/tasks/test.py
@@ -103,7 +103,7 @@ class TestReadOutput(Task):
         super().__init__(params=params)
 
     def _run(self) -> None:
-        array: np.ndarray = np.loadtxt(self._task_parameters.in_file, delimiter=",")
+        _: np.ndarray = np.loadtxt(self._task_parameters.in_file, delimiter=",")
         self._report_to_executor(msg=Message(contents="Successfully loaded data!"))
         for i in range(5):
             time.sleep(1)

--- a/lute/tasks/util/html.py
+++ b/lute/tasks/util/html.py
@@ -3,7 +3,9 @@
 This includes HTML templates and associated functions.
 """
 
-__all__ = []
+from typing import List
+
+__all__: List[str] = []
 __author__ = "Gabriel Dorlhiac"
 
 DIMPLE_HTML: str = """

--- a/run_task.py
+++ b/run_task.py
@@ -4,8 +4,8 @@ import logging
 import os
 from typing import List
 
-from lute.io.config import *
-from lute.execution.executor import *
+from lute.execution.executor import BaseExecutor, Executor
+from lute import managed_tasks
 
 if __debug__:
     logging.basicConfig(level=logging.DEBUG)
@@ -37,14 +37,10 @@ task_name: str = args.taskname
 # Environment variables need to be set before importing Executors
 os.environ["LUTE_CONFIGPATH"] = config
 
-from lute import managed_tasks
-
 if hasattr(managed_tasks, task_name):
     managed_task: Executor = getattr(managed_tasks, task_name)
 else:
     import difflib
-
-    from lute.execution.executor import BaseExecutor
 
     logger.error(f"{task_name} unrecognized!")
     valid_names: List[str] = [

--- a/subprocess_task.py
+++ b/subprocess_task.py
@@ -20,7 +20,7 @@ def get_task() -> Optional[Task]:
     return None
 
 
-def timeout_handler(signum: int, frame: types.FrameType) -> None:
+def timeout_handler(signum: int, frame: Optional[types.FrameType]) -> Any:
     """Log and exit gracefully on Task timeout."""
     task: Optional[Task] = get_task()
     if task:

--- a/subprocess_task.py
+++ b/subprocess_task.py
@@ -7,7 +7,7 @@ from typing import Type, Optional, Dict, Any
 
 from lute.tasks.task import Task, ThirdPartyTask
 from lute.execution.ipc import Message
-from lute.io.config import *
+from lute.io.config import parse_config
 from lute.io.models.base import TaskParameters, ThirdPartyParameters
 
 
@@ -65,7 +65,7 @@ else:
 
     try:
         TaskType = import_task(task_name)
-    except TaskNotFoundError as err:
+    except TaskNotFoundError:
         logger.debug(
             (
                 f"Task {task_name} not found! Things to double check:\n"

--- a/utilities/src/dbview/dbview.py
+++ b/utilities/src/dbview/dbview.py
@@ -1,19 +1,33 @@
 import os
+import sys
 import sqlite3
 import argparse
 import importlib.util
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional, cast
+from typing_extensions import TypeAlias
 from types import ModuleType
 
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Footer, Header, DataTable, TabbedContent
 
-spec: importlib.machinery.ModuleSpec = importlib.util.spec_from_file_location(
+ModuleSpec: TypeAlias = "importlib.machinery.ModuleSpec"
+Loader: TypeAlias = "importlib.machinery.SourceFileLoader"
+
+spec: Optional[ModuleSpec] = importlib.util.spec_from_file_location(
     "_sqlite", f"{os.environ.get('LUTE_BASE', '')}/lute/io/_sqlite.py"
 )
-_sqlite: ModuleType = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(_sqlite)
+if spec is None:
+    print("SQLite interface module not found! Exiting.")
+    sys.exit(-1)
+
+_sqlite: ModuleType = importlib.util.module_from_spec(cast(ModuleSpec, spec))
+loader: Optional[Loader] = cast(Loader, cast(ModuleSpec, spec).loader)
+if loader is not None:
+    cast(Loader, loader.exec_module(_sqlite))
+else:
+    print("Unable to generate loader for module! Exiting.")
+    sys.exit(-1)
 
 parser: argparse.ArgumentParser = argparse.ArgumentParser(
     prog="DBView",
@@ -58,7 +72,7 @@ class DBView(App):
 
     def pull_table_data(self, table: DataTable) -> DataTable:
         """Query database for all rows in a table and add to display."""
-        table_name: str = table.id[5:]
+        table_name: str = table.id[5:] if table.id is not None else "<UNKNOWN>"
         table.add_columns(*_sqlite._get_table_cols(self._con, table_name))
         rows: List[Tuple[Any, ...]] = _sqlite._get_all_rows_for_table(
             self._con, table_name

--- a/utilities/src/help/task_parameters.py
+++ b/utilities/src/help/task_parameters.py
@@ -105,7 +105,10 @@ def _format_parameter_row(
     if validators is not None:
         msg = f"{msg}\n\tValidators:"
         for validator in validators:
-            msg = f"{msg}\n\t\t- {validator.func.__name__}"
+            if hasattr(validator, "func") and hasattr(validator.func, "__name__"):
+                msg = f"{msg}\n\t\t- {validator.func.__name__}"
+            else:
+                msg = f"{msg}\n\t\t- <CANNOT PARSE NAME>"
     msg = f"{msg}\n\n"
     return msg
 
@@ -121,7 +124,9 @@ if __name__ == "__main__":
         managed_task_map: Dict[str, List[str]] = {}
         for key in dir(managed_tasks):
             obj: Any = getattr(managed_tasks, key)
-            if isinstance(obj, managed_tasks.BaseExecutor):
+            if hasattr(managed_tasks, "BaseExecutor") and isinstance(
+                obj, managed_tasks.BaseExecutor
+            ):
                 task_name = obj._analysis_desc.task_result.task_name
                 if task_name in managed_task_map:
                     managed_task_map[task_name].append(key)
@@ -188,8 +193,9 @@ if __name__ == "__main__":
         if required_parameters is not None:
             out_msg = f"{out_msg}Required Parameters:\n--------------------\n"
             for param in required_parameters:
+                # Ignoring mypy since the typing seems wrong. This is a list | None
                 validators = (
-                    parameter_model.__validators__[param[0]]
+                    parameter_model.__validators__[param[0]]  # type: ignore
                     if param[0] in parameter_model.__validators__
                     else None
                 )
@@ -199,13 +205,15 @@ if __name__ == "__main__":
             out_msg = f"{out_msg}\n\n"
 
         out_msg = f"{out_msg}All Parameters:\n---------------\n"
-        for param in parameter_schema["properties"]:
+        pname: str
+        for pname in parameter_schema["properties"]:
+            # Ignoring mypy since the typing seems wrong. This is a list | None
             validators = (
-                parameter_model.__validators__[param]
-                if param in parameter_model.__validators__
+                parameter_model.__validators__[pname]  # type: ignore
+                if pname in parameter_model.__validators__
                 else None
             )
-            out_msg = f"{out_msg}{_format_parameter_row(param, parameter_schema['properties'][param], validators)}"
+            out_msg = f"{out_msg}{_format_parameter_row(pname, parameter_schema['properties'][pname], validators)}"
 
         if "definitions" in parameter_schema and parameter_schema["definitions"]:
             definitions: List[str] = [
@@ -217,10 +225,10 @@ if __name__ == "__main__":
                 out_msg = f"{out_msg}Template Parameters:\n--------------------\n"
                 for defn in definitions:
                     out_msg = f"{out_msg}{defn}:\n"
-                    for param in parameter_schema["definitions"][defn]["properties"]:
+                    for pname in parameter_schema["definitions"][defn]["properties"]:
                         row: str = _format_parameter_row(
-                            param,
-                            parameter_schema["definitions"][defn]["properties"][param],
+                            pname,
+                            parameter_schema["definitions"][defn]["properties"][pname],
                         )
                         out_msg = f"{out_msg}{row}"
         print(out_msg)

--- a/utilities/src/help/task_parameters.py
+++ b/utilities/src/help/task_parameters.py
@@ -1,8 +1,8 @@
 import sys
 import argparse
 import logging
-from typing import Dict, Optional, List, Set, Tuple, Any, Callable
-from typing_extensions import TypedDict
+from typing import Dict, Optional, List, Set, Tuple, Any, Callable, Generic, Union, cast
+from typing_extensions import TypedDict, TypeVar
 
 import pprint
 
@@ -10,13 +10,18 @@ import lute.io.models
 from lute.io.models.base import TaskParameters
 from lute import managed_tasks
 
+T = TypeVar("T")
+
+
+class OptionalDictKey(Generic[T]): ...
+
 
 class PropertyDict(TypedDict):
     default: str
     description: str
     title: str
-    type: Optional[str]
-    anyOf: Optional[List[Dict[str, str]]]  # Either an anyOf or type per property
+    type: OptionalDictKey[str]
+    anyOf: OptionalDictKey[List[Dict[str, str]]]  # Either an anyOf or type per property
     # Generally only for ThirdPartyTasks
     rename_param: Optional[str]
     flag_type: Optional[str]
@@ -70,7 +75,8 @@ def _format_parameter_row(
     validators: Optional[List[Callable]] = None,
 ) -> str:
     """Take a property dictionary for a parameter and format it for printing."""
-    typeinfo: str
+    # Either type or anyOf exists but not both
+    typeinfo: Union[str, OptionalDictKey]
     if "type" in param_description:
         typeinfo = param_description["type"]
     elif "anyOf" in param_description:  # anyOf is present instead
@@ -106,15 +112,17 @@ def _format_parameter_row(
 
 if __name__ == "__main__":
     args: argparse.Namespace = parser.parse_args()
+    task_name: str
+    parameter_schema: ModelSchema
     if args.list:
-        logger.info(f"Fetching Task list.")
+        logger.info("Fetching Task list.")
         # Construct Task <-> Executor mapping
         # [task_name, [managed_task1, managed_task2, ...]
         managed_task_map: Dict[str, List[str]] = {}
         for key in dir(managed_tasks):
             obj: Any = getattr(managed_tasks, key)
             if isinstance(obj, managed_tasks.BaseExecutor):
-                task_name: str = obj._analysis_desc.task_result.task_name
+                task_name = obj._analysis_desc.task_result.task_name
                 if task_name in managed_task_map:
                     managed_task_map[task_name].append(key)
                 else:
@@ -127,14 +135,14 @@ if __name__ == "__main__":
                 "TaskParameters",
                 "TemplateParameters",
             ):
-                task_name: str = key.replace("Parameters", "")
+                task_name = key.replace("Parameters", "")
                 task_list_msg = f"{task_list_msg}\n\n- {task_name}\n"
                 task_list_msg = f"{task_list_msg}  Current Managed Tasks:"
                 if task_name in managed_task_map:
                     for mgd_task in managed_task_map[task_name]:
                         task_list_msg = f"{task_list_msg} {mgd_task},"
-                obj: TaskParameters = getattr(lute.io.models, key)
-                parameter_schema: ModelSchema = obj.schema()
+                params_obj: TaskParameters = getattr(lute.io.models, key)
+                parameter_schema = cast(ModelSchema, params_obj.schema())
                 description: str = parameter_schema["description"]
                 for line in description.split("\n"):
                     new_line: str
@@ -146,7 +154,7 @@ if __name__ == "__main__":
 
         print(task_list_msg)
 
-    task_name: str = args.Task
+    task_name = args.Task
     if task_name:
         model_name: str = f"{task_name}Parameters"
 
@@ -158,7 +166,7 @@ if __name__ == "__main__":
             sys.exit(-1)
 
         # For types need to check for key `type` or a list of dicts `anyOf=[{'type': ...}, {'type': ...}]`
-        parameter_schema: ModelSchema = parameter_model.schema()
+        parameter_schema = cast(ModelSchema, parameter_model.schema())
         if args.full_schema:
             pprint.pprint(parameter_schema)
             sys.exit(0)

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -59,14 +59,14 @@ class RequestOnlyOperator(BaseOperator):
                 contains a list of available variables and their description.
         """
         # logger.info(f"Attempting to run at {self.get_location(context)}...")
-        logger.info(f"Attempting to run at S3DF.")
+        logger.info("Attempting to run at S3DF.")
         dagrun_config: Dict[str, Union[str, Dict[str, Union[str, int, List[str]]]]] = (
             context.get("dag_run").conf
         )
         jid_job_definition: Dict[str, str] = {
             "_id": str(uuid.uuid4()),
             "name": self.task_id,
-            "executable": f"myexecutable.sh",
+            "executable": "myexecutable.sh",
             "trigger": "MANUAL",
             "location": dagrun_config.get("ARP_LOCATION", "S3DF"),
             "parameters": "--partition=milano --account=lcls:data",
@@ -320,11 +320,11 @@ class JIDSlurmOperator(BaseOperator):
                 properly handled by the Airflow server.
         """
         logger.debug(f"{resp.status_code}: {resp.content}")
-        if not resp.status_code in (200,):
+        if resp.status_code not in (200,):
             raise AirflowException(f"Bad response from JID {resp}: {resp.content}")
         try:
             json: Dict[str, Union[str, int]] = resp.json()
-            if not json.get("success", "") in (True,):
+            if json.get("success", "") not in (True,):
                 raise AirflowException(f"Error from JID {resp}: {resp.content}")
             value: Dict[str, Any] = json.get("value")
 
@@ -401,7 +401,7 @@ class JIDSlurmOperator(BaseOperator):
                 contains a list of available variables and their description.
         """
         # logger.info(f"Attempting to run at {self.get_location(context)}...")
-        logger.info(f"Attempting to run at S3DF.")
+        logger.info("Attempting to run at S3DF.")
         control_doc = self.create_control_doc(context)
         logger.info(control_doc)
         logger.info(f"{self.jid_api_location}/{self.jid_api_endpoints['start_job']}")

--- a/workflows/airflow/test_dynamic.py
+++ b/workflows/airflow/test_dynamic.py
@@ -63,7 +63,7 @@ def test_dynamic():
         )
         if wf_dict is not None:
             task_list: List[JIDSlurmOperator] = []
-            first_task: JIDSlurmOperator = create_links(wf_dict, task_list=task_list)
+            _: JIDSlurmOperator = create_links(wf_dict, task_list=task_list)
 
     @task(trigger_rule=TriggerRule.ALL_DONE)
     def delete_workflow(**context):


### PR DESCRIPTION
# Description

This PR brings the code base inline with flake8 coding standards and passes mypy static analysis.

## Checklist
- [x] Updates for flake8
- [x] Updates for mypy
- [x] Action for linting with `ruff` and type checking with `mypy`

## PR Type:
- [x] Style/Maintenance
- [x] CI/CD

## Address issues:

# Testing
Tested most managed Tasks and basic functionality to ensure nothing was affected by the code changes.
```bash
[dorlhiac@sdfiana004 /sdf/scratch/users/d/dorlhiac/lute]$> git status
On branch MNT/lint
Your branch is up to date with 'origin/MNT/lint'.
```

## Individual Tasks
## Workflows
### `test`
Runs `BinaryErrTester`, `BinaryTester`, `ReadTester`, `SocketTester`, `Tester`, `WriteTester`

#### Correct Config YAML Should Fail due to `BinaryErrTester` but all other `Task`s Succeed
**Command**
```bash
/sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py --test --debug -w test -c /sdf/scratch/users/d/dorlhiac/lute/config/test.yaml --partition=milano --account=lcls:mfxx49820 --ntasks=5 --nodes=1 -e mfxx49820 -r 14
```

**Logs**
```bash
INFO:Launch_Airflow:Providing logs for BinaryErrTester
--------------------------------------------------
INFO:lute.execution.ipc:Will use TCP (ZMQ).
DEBUG:lute.execution.ipc:Executor bound port 39939
INFO:lute.execution.executor:Beginning Thread Creation
---------------------------------
Going to begin task.
>>Child 1035310848 still working.
>>Child 1026918144 still working.
>>Child 1018525440 still working.
Still waiting on child task(s)...
>>Child 1010132736 still working.
# ............
INFO:lute.execution.executor:>>Child 1018525440 still working.
>>Child 1026918144 still working.
>>Child 1035310848 still working.
>>Child 1010132736 still working.

INFO:lute.execution.executor:---------------------------------
ALL THREADS COMPLETE.

WARNING:lute.execution.executor:Task failed with return code: 1
# ................................
lt.impl_schemas"', '"valid_flag"']
		[15, 270, '/sdf/scratch/users/d/dorlhiac/test_output.txt', 'COMPLETED', 'Was able to load data.', 'This Task produces no output.', None, 1]
DEBUG:lute.execution.ipc:Stopping socket reader thread.
DEBUG:lute.execution.ipc:Closed reading thread.

--------------------------------------------------
INFO:Launch_Airflow:End of logs for ReadTester
INFO:Launch_Airflow:DAG exited: failed
DEBUG:Launch_Airflow:Removing duplicate Kerberos credentials.
```

#### Incorrect Config YAML Should Fail Immediately
**Command**
```bash
> /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py --test --debug -w test -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/mfx.yaml --partition=milano --account=lcls:mfxx49820 --ntasks=5 --nodes=1 -e mfxx49820 -r 14
```

**End of Logs**
```bash
INFO:lute.execution.executor:/sdf/scratch/users/d/dorlhiac/lute/lute/io/config.py:189: UserWarning: Test has no parameter definitions in YAML file. Attempting default parameter initialization.
  warnings.warn(
 (Traceback (most recent call last):
  File "/sdf/scratch/users/d/dorlhiac/lute//subprocess_task.py", line 57, in <module>
    task_parameters: TaskParameters = parse_config(task_name=task_name, config_path=config)
  File "/sdf/scratch/users/d/dorlhiac/lute/lute/io/config.py", line 195, in parse_config
    parsed_parameters: TaskParameters = globals()[task_config_name](**lute_config)
  File "pydantic/env_settings.py", line 40, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for TestParameters
compound_var
  field required (type=value_error.missing)
)
WARNING:lute.execution.executor:Task failed with return code: 1
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): psdm.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://psdm.slac.stanford.edu:443 "POST /arps3dfjid/jid/ws/mfxx49820/get_counters HTTP/1.1" 200 28
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): psdm.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://psdm.slac.stanford.edu:443 "POST /arps3dfjid/jid/ws/replace_counters/mfxx49820/bf55ce7b-c4cf-4d0a-b7ba-cb80e75d6d31 HTTP/1.1" 200 93
ERROR:lute.execution.executor:Please run Task before using this method!
ERROR:lute.execution.executor:Please run Task before using this method!
CRITICAL:lute.execution.executor:Unable to store configuration! Downstream Tasks may fail!
```

### `pyalgos_sfx`
Runs `CrystFELIndexer`, `DimpleSolver`, `HKLComparer`, `HKLManipulator`, `PartialatorMerger`, `PeakFinderPyAlgos`, `SmallDataProducer`, `StreamFileConcatenator`.

**Command**
```bash
 > /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py --test --debug -w pyalgos_sfx -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/mfx.yaml --partition=milano --account=lcls:mfxx49820 --ntasks=120 --nodes=2 -e mfxx49820 -r 16
```
**End of Logs**
```bash
		[1, 125, '/sdf/group/lcls/ds/tools/crystfel/0.10.2/bin/compare_hkl', '/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lyso.hkl1 /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lyso.hkl2', '4/mmm_uac', '/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/cell/new.cell', 'Rsplit', 10, '/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lyso_Rsplit_n10.dat', False, False, None, None, None, None, None, 'COMPLETED', 'Rsplit/%: [   3.262   22.72  1713.       3.07     2.887    3.636];/sdf/data/lcls/ds/mfx/mfxx49820/stats/summary/r16/Rsplit/report.html', '/sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lyso_Rsplit_n10.dat', None, 1]
DEBUG:lute.execution.ipc:Stopping socket reader thread.
DEBUG:lute.execution.ipc:Closed reading thread.

--------------------------------------------------
INFO:Launch_Airflow:End of logs for HKLComparer
INFO:Launch_Airflow:Providing logs for DimpleSolver
--------------------------------------------------
Exception reading log file; please check the server logs for more details.
--------------------------------------------------
INFO:Launch_Airflow:End of logs for DimpleSolver
INFO:Launch_Airflow:DAG exited: success
DEBUG:Launch_Airflow:Removing duplicate Kerberos credentials.
```

### `geom_opt_agbh`
Runs `AgBhGeometryOptimizer` and `SmallDataProducer` -> Both completed successfully.
**Command**
```bash
> /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/lute/launch_scripts/launch_airflow.py -w geom_opt_agbh -c /sdf/data/lcls/ds/mfx/mfxx49820/scratch/dorlhiac/lute_output/geom_test.yaml -e mfxx49820 -r 15 --partition=milano --ntasks=20 --account=lcls:data --debug --test
```
**End of Logs**
```bash
hiac/lute_output', None, 4, 5, 1000000.0, -6.0, 6.0, 5, -6.0, 6.0, 5, None, None, 'COMPLETED', 'Detector distance (mm): 102.99016884465927;Detector center (pixels): (825.0090545374029, 836.0067390701785);Detector edge resolution (A): 1.9354159010280991;/sdf/data/lcls/ds/mfx/mfxx49820/stats/summary/Geometry_Fit/r0015/report.html', '', None, 1]
DEBUG:lute.execution.ipc:Stopping socket reader thread.
DEBUG:lute.execution.ipc:Closed reading thread.
TASK_LOG -- INFO:lute.tasks.geometry: New center is: (838.5052480438377, 825.7173567168348)
TASK_LOG -- INFO:lute.tasks.geometry: Detector distance inferred from powder rings: 379.37
TASK_LOG -- INFO:lute.tasks.geometry: New center is: (838.5077149871415, 825.7173963027387)
TASK_LOG -- INFO:lute.tasks.geometry: Detector distance inferred from powder rings: 378.75
TASK_LOG -- INFO:lute.tasks.geometry: New center is: (838.5031492714689, 825.7160800387403)
TASK_LOG -- INFO:lute.tasks.geometry: Detector distance inferred from powder rings: 379.24
TASK_LOG -- INFO:lute.tasks.geometry: New center is: (838.5105475043345, 825.7168857348539)
TASK_LOG -- INFO:lute.tasks.geometry: Detector distance inferred from powder rings: 378.62

--------------------------------------------------
INFO:Launch_Airflow:End of logs for AgBhGeometryOptimizer
INFO:Launch_Airflow:DAG exited: success
DEBUG:Launch_Airflow:Removing duplicate Kerberos credentials.
```


# Screenshots
