### PR TITLE
MNT Add option to specify detector image sum algorithms in smalldata …

### DIFF
--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -119,6 +119,23 @@ SubmitSMD:
   #detnames: []
   #epicsPV: []
   #ttCalib: []
+  # Provide detector image sum algorithms.
+  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+  # calib_dropped_square for every detector. You can add processing algorithms for
+  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+  # will apply to every detector defined in detnames by placing them under "all"
+  #detSumAlgos:
+  #  all:
+  #    - "calib"
+  #    - "calib_dropped"
+  #    - "calib_dropped_square"
+  #    - "calib_thresADU1"
+  #  epix10k2M:
+  #    - "calib_thresADU5"
+  #    - "calib_max"
+  #  Rayonix:
+  #    - "calib_skipFirst_thresADU1"
+  #    - "calib_skipFirst_max"
   #getROIs:
   #  jungfrau1M:   # Change to detector name
   #    ROIs: [[[1, 2], [157, 487], [294, 598]]]

--- a/config/templates/smd_producer_template.py
+++ b/config/templates/smd_producer_template.py
@@ -1002,7 +1002,7 @@ dets_time_start = (start_setup_dets-start_job)/60
 dets_time_end = (end_setup_dets-start_job)/60
 evt_time_start = (start_evt_loop-start_job)/60
 evt_time_end = (end_evt_loop-start_job)/60
-logger.debug(f"##### Timing benchmarks core {ds.rank}: ##### """)
+logger.debug(f"##### Timing benchmarks core {ds.rank}: #####")
 logger.debug(f'Setup dets: \n\tStart: {dets_time_start:.2f} min\n\tEnd: {dets_time_end:.2f} min')
 logger.debug(f'\tDuration:{dets_time_end-dets_time_start:.2f}')
 logger.debug(f'Event loop: \n\tStart: {evt_time_start:.2f} min\n\tEnd: {evt_time_end:.2f} min')
@@ -1018,6 +1018,7 @@ if ds.rank==0:
 #finishing up here....
 logger.debug('rank {0} on {1} is finished'.format(ds.rank, hostname))
 small_data.save()
+small_data.close()
 if os.environ.get('ARP_JOB_ID', None) is not None:
     if ds.size > 1:
         if ds.rank == 0:
@@ -1053,7 +1054,7 @@ if args.postRuntable and ds.rank==0:
     else:
         with open('/cds/home/opr/%s/forElogPost.txt'%user,'r') as reader:
             answer = reader.readline()
-    r = requests.post(ws_url, params={"run_num": args.run}, json=runtable_data, 
+    r = requests.post(ws_url, params={"run_num": args.run}, json=runtable_data,
                       auth=HTTPBasicAuth(args.experiment[:3]+'opr', answer[:-1]))
     print(r)
     if det_presence!={}:

--- a/config/templates/smd_producer_template.py
+++ b/config/templates/smd_producer_template.py
@@ -431,7 +431,24 @@ def define_dets(run):
             if detname in svd:
                 det.addFunc(svdFit(**svd[detname]))
 
+            {%- if detSumAlgos is defined %}
+              {%- for detector, det_algos in detSumAlgos.items() %}
+                {%- if detector == "all" %}
+                  {%- for algo in det_algos %}
+            det.storeSum(sumAlgo='{{ algo }}')
+                  {% endfor %}
+                {% else %}
+            if detname.find("{{ detector }}") >= 0:
+                  {% for algo in det_algos %}
+                det.storeSum(sumAlgo='{{ algo }}')
+                  {% endfor %}
+                {% endif %}
+              {% endfor %}
+            {% else %}
             det.storeSum(sumAlgo='calib')
+            det.storeSum(sumAlgo='calib_dropped')
+            det.storeSum(sumAlgo='calib_dropped_square')
+            {% endif %}
             #det.storeSum(sumAlgo='calib_img')
             dets.append(det)
     return dets

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -40,6 +40,23 @@ SubmitSMD:
   #detnames: []
   #epicsPV: []
   #ttCalib: []
+  # Provide detector image sum algorithms.
+  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+  # calib_dropped_square for every detector. You can add processing algorithms for
+  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+  # will apply to every detector defined in detnames by placing them under "all"
+  #detSumAlgos:
+  #  all:
+  #    - "calib"
+  #    - "calib_dropped"
+  #    - "calib_dropped_square"
+  #    - "calib_thresADU1"
+  #  epix10k2M:
+  #    - "calib_thresADU5"
+  #    - "calib_max"
+  #  Rayonix:
+  #    - "calib_skipFirst_thresADU1"
+  #    - "calib_skipFirst_max"
   #getROIs:
   #  jungfrau1M:   # Change to detector name
   #    ROIs: [[[1, 2], [157, 487], [294, 598]]]

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -106,6 +106,23 @@ SubmitSMD:
   #detnames: []
   #epicsPV: []
   #ttCalib: []
+  # Provide detector image sum algorithms.
+  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+  # calib_dropped_square for every detector. You can add processing algorithms for
+  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+  # will apply to every detector defined in detnames by placing them under "all"
+  #detSumAlgos:
+  #  all:
+  #    - "calib"
+  #    - "calib_dropped"
+  #    - "calib_dropped_square"
+  #    - "calib_thresADU1"
+  #  epix10k2M:
+  #    - "calib_thresADU5"
+  #    - "calib_max"
+  #  Rayonix:
+  #    - "calib_skipFirst_thresADU1"
+  #    - "calib_skipFirst_max"
   #getROIs:
   #  jungfrau1M:   # Change to detector name
   #    ROIs: [[[1, 2], [157, 487], [294, 598]]]

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -106,6 +106,23 @@ SubmitSMD:
   #detnames: []
   #epicsPV: []
   #ttCalib: []
+  # Provide detector image sum algorithms.
+  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+  # calib_dropped_square for every detector. You can add processing algorithms for
+  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+  # will apply to every detector defined in detnames by placing them under "all"
+  #detSumAlgos:
+  #  all:
+  #    - "calib"
+  #    - "calib_dropped"
+  #    - "calib_dropped_square"
+  #    - "calib_thresADU1"
+  #  epix10k2M:
+  #    - "calib_thresADU5"
+  #    - "calib_max"
+  #  Rayonix:
+  #    - "calib_skipFirst_thresADU1"
+  #    - "calib_skipFirst_max"
   #getROIs:
   #  jungfrau1M:   # Change to detector name
   #    ROIs: [[[1, 2], [157, 487], [294, 598]]]

--- a/utilities/src/dbview/dbview.py
+++ b/utilities/src/dbview/dbview.py
@@ -83,7 +83,7 @@ class DBView(App):
         return table
 
     def action_toggle_dark(self) -> None:
-        self.dark = not self.dark
+        self.dark: bool = not self.dark
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR provides support for specifying detector sum algorithms in template substituted smalldata producer files.

In the LUTE configuration file you will now be able to use the following additional section to specify detector image sum algorithms:

```yaml
SubmitSMD:
  # ... other stuff ...
  detnames: ["epix10k2M", "Rayonix", "..."]
  detSumAlgos:
    all:
      - "calib"
      - "calib_dropped"
      - "calib_dropped_square"
      - "calib_thresADU1"
    epix10k2M:
      - "calib_thresADU5"
      - "calib_max"
    Rayonix:
      - "calib_skipFirst_thresADU1"
      - "calib_skipFirst_max"
```
A list of algorithms can be placed under `all` in which case it will be applied to every detector passed in the `detnames` section previously. Otherwise, you can add specific algorithms for different detectors. All algorithms I am currently aware of are included in the above snippet which will also be present with additional commentary in the hutch YAMLs (and `test.yaml`).

In the event the user is opting for template-based substitution to fill in the YAML file, but has **not** provided the `detSumAlgos` section above, then the following code will be added to the producer:

```py
            det.storeSum(sumAlgo='calib')
            det.storeSum(sumAlgo='calib_dropped')
            det.storeSum(sumAlgo='calib_dropped_square')
```
which will use the `calib`, `calib_dropped`, and `calib_dropped_square` algorithm for all detectors specified in `detnames`.

## Checklist
- [x] Update `smd_producer_template.py`
- [ ] Add some example usage in `test.yaml` and hutch-specific YAMLs.

## PR Type:
- [x] Style/Maintenance

## Address issues:
Improves compatibility with the latest smalldata_tools features.

# Testing
## Providing detector specific algorithms
Using the following configuration YAML:
```yaml
%YAML 1.3
---
title: "LUTE Task Configuration" # Include experiment description if desired
experiment: "mfxx49820"
run: "8"
date: "2023/10/25"
lute_version: 0.1      # Do not be change unless need to force older version
task_timeout: 600
work_dir: "/sdf/scratch/users/d/dorlhiac"
...
---
SubmitSMD:
  # Command line arguments
  producer: "/sdf/scratch/users/d/dorlhiac/smalldata_tools/lcls1_producers/smd_producer.py"
  run: 8
  experiment: "mfxx49820"
  directory: "/sdf/home/d/dorlhiac/scratch/lute_tests/test_smd"
  #default: true
  # ...
  # Producer variables. These are substituted into the producer to run specific
  # data reduction algorithms. Uncomment and modify as needed.
  # If you prefer to modify the producer file directly, leave commented.
  # Beginning with `getROIs`, you will need to modify the first entry to be a
  # detector. This detector MUST MATCH one of the detectors in `detnames`.
  # In the future this will be automated. If you have multiple detectors you can
  # add them with their own set of parameters.
  detnames: ["epix100_1", "epix10k2M"]
  #epicsPV: []
  #ttCalib: []
  # Provide detector image sum algorithms.
  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
  # calib_dropped_square for every detector. You can add processing algorithms for
  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
  # will apply to every detector defined in detnames by placing them under "all"
  detSumAlgos:
    all:
      - "calib"
      - "calib_dropped"
      - "calib_dropped_square"
      - "calib_thresADU1"
    epix10k2M:
      - "calib_thresADU5"
      - "calib_max"
  # ...
...
```


We see that after substitution the producer file has the following code (extra white-space is not pretty but code is functional):
```py
            # SVD waveform analysis
            if detname in svd:
                det.addFunc(svdFit(**svd[detname]))
            det.storeSum(sumAlgo='calib')
                  
            det.storeSum(sumAlgo='calib_dropped')
                  
            det.storeSum(sumAlgo='calib_dropped_square')
                  
            det.storeSum(sumAlgo='calib_thresADU1')
                  
                
              
            if detname.find("epix10k2M") >= 0:
                  
                det.storeSum(sumAlgo='calib_thresADU5')
                  
                det.storeSum(sumAlgo='calib_max')
                  
                
              
            
            #det.storeSum(sumAlgo='calib_img')
            dets.append(det)
```

Can launch the managed `Task` using:
```bash
./launch_scripts/submit_slurm.sh -t SmallDataProducer -c /sdf/scratch/users/d/dorlhiac/lute2/config/test.yaml --ntasks=100 --partition=milano --account=lcls:data
```

**We see the output indeed has the detector sum algorithms:**

```bash
> h5ls ../lute_tests/test_smd/mfxx49820_Run0008.h5/Sums
epix10k2M_calib          Dataset {16, 352, 384}
epix10k2M_calib_dropped  Dataset {16, 352, 384}
epix10k2M_calib_dropped_square Dataset {16, 352, 384}
epix10k2M_calib_max      Dataset {16, 352, 384}
epix10k2M_calib_thresADU1 Dataset {16, 352, 384}
epix10k2M_calib_thresADU5 Dataset {16, 352, 384}
```

## Using default algorithms
Using the following YAML configuration we will have template substitution (because of the use of the `detnames` field) but we do not specify any detector image sum algorithms:

```yaml
%YAML 1.3
---
title: "LUTE Task Configuration" # Include experiment description if desired
experiment: "mfxx49820"
run: "8"
date: "2023/10/25"
lute_version: 0.1      # Do not be change unless need to force older version
task_timeout: 600
work_dir: "/sdf/scratch/users/d/dorlhiac"
...
---
SubmitSMD:
  # Command line arguments
  producer: "/sdf/scratch/users/d/dorlhiac/smalldata_tools/lcls1_producers/smd_producer.py"
  run: 8
  experiment: "mfxx49820"
  directory: "/sdf/home/d/dorlhiac/scratch/lute_tests/test_smd"
  #default: true
  # ...
  # Producer variables. These are substituted into the producer to run specific
  # data reduction algorithms. Uncomment and modify as needed.
  # If you prefer to modify the producer file directly, leave commented.
  # Beginning with `getROIs`, you will need to modify the first entry to be a
  # detector. This detector MUST MATCH one of the detectors in `detnames`.
  # In the future this will be automated. If you have multiple detectors you can
  # add them with their own set of parameters.
  detnames: ["epix100_1", "epix10k2M"]
  #epicsPV: []
  #ttCalib: []
  # Provide detector image sum algorithms.
  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
  # calib_dropped_square for every detector. You can add processing algorithms for
  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
  # will apply to every detector defined in detnames by placing them under "all"
  #detSumAlgos:
  #  all:
  #    - "calib"
  # ...
...
```

After substitution we get the default set of algorithms applied to all detectors:
```py
            # SVD waveform analysis
            if detname in svd:
                det.addFunc(svdFit(**svd[detname]))
            det.storeSum(sumAlgo='calib')
            det.storeSum(sumAlgo='calib_dropped')
            det.storeSum(sumAlgo='calib_dropped_square')
            
            #det.storeSum(sumAlgo='calib_img')
            dets.append(det)
    return dets
```

Can launch the managed `Task` using:
```bash
./launch_scripts/submit_slurm.sh -t SmallDataProducer -c /sdf/scratch/users/d/dorlhiac/lute2/config/test.yaml --ntasks=100 --partition=milano --account=lcls:data
```

**We see the output indeed has the detector sum algorithms:**

```bash
> h5ls ../lute_tests/test_smd/mfxx49820_Run0008.h5/Sums
epix10k2M_calib          Dataset {16, 352, 384}
epix10k2M_calib_dropped  Dataset {16, 352, 384}
epix10k2M_calib_dropped_square Dataset {16, 352, 384}
```

# Screenshots
