### PR TITLE
MNT Change prefect deployment to `dev`

### DIFF
--- a/launch_scripts/launch_prefect.py
+++ b/launch_scripts/launch_prefect.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     auth: HTTPBasicAuth = HTTPBasicAuth(user, pw)
 
     flow_name: str = "lute_dynamic"
-    deployment_name: str = "test-deployment2"
+    deployment_name: str = "dev"
 
     csrf_endpoint: str = f"{PREFECT_API_URL}/csrf-token"
     name_endpoint: str = (

--- a/workflows/prefect/create_deployment.py
+++ b/workflows/prefect/create_deployment.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n",
         "--name",
-        description="Name of the new deployment.",
+        help="Name of the new deployment.",
         type=str,
         default="dev",
     )


### PR DESCRIPTION
# Description

This PR changes the prefect deployment used to the newly created `dev` deployment which runs from the code in the main LUTE repository.

## Checklist
- [x] Switch to `dev` deployment in `launch_prefect.py`
- [x] Fix argument name in the `create_deployment.py` script.

## PR Type:
- [x] Style/Maintenance

## Address issues:

# Testing
Tested by submitting a test run against the new deployment. Did not access data so the experiment and run number did not matter, but used `mfxx49820` and run 16.

## Workflow
Was living at `/sdf/home/d/dorlhiac/Repos/lute/workflows/prefect/dag.yaml` at time of testing.

```yaml
task_name: Tester
slurm_params: "--partition=milano --account=lcls:data --ntasks=1"
next:
- task_name: BinaryTester
  slurm_params: "--partition=milano --account=lcls:data --ntasks=5"
  next: []
- task_name: BinaryErrTester
  slurm_params: "--partition=milano --account=lcls:data --ntasks=5"
  next: []
- task_name: SocketTester
  slurm_params: "--partition=milano --account=lcls:data --ntasks=1"
  next:
    - task_name: WriteTester
      slurm_params: "--partition=milano --account=lcls:data --ntasks=1"
      next:
        - task_name: ReadTester
          slurm_params: "--partition=milano --account=lcls:data --ntasks=1"
          next: []
```

## Config YAML
Used the `test.yaml` available in the `config` folder of this repository. Relevant part partially recreated here:
```yaml
%YAML 1.3
---
title: "LUTE Task Configuration" # Include experiment description if desired
experiment: "{{ $EXPERIMENT }}"
run: "{{ $RUN }}"
date: "2023/10/25"
lute_version: 0.1      # Do not be change unless need to force older version
task_timeout: 600
work_dir: "/sdf/scratch/users/d/dorlhiac"
...
---
Test:
  float_var: 0.01
  str_var: "test"
  compound_var:
    int_var: 10
    dict_var: {"a": "b"}
  throw_error: False # Set True to test Task failure

TestBinary:
  executable: "/sdf/home/d/dorlhiac/test_tasks/test_threads"
  p_arg1: 4 # Number of cores

TestBinaryErr:
  executable: "/sdf/home/d/dorlhiac/test_tasks/test_threads_err"
  p_arg1: 4 # Number of cores

TestSocket:
  array_size: 8000 # Size of arrays to send. 8000 floats ~ 6.4e4
  num_arrays: 10 # Number of arrays to send.

TestMultiNodeCommunication:
  send_obj: "plot" # Either "plot" or "array". Type of object to send
  arr_size: 5      # Size of the array if sending array
...
```

## Submission
```bash
/sdf/home/d/dorlhiac/Repos/lute/launch_scripts/submit_launch_prefect.sh /sdf/home/d/dorlhiac/Repos/lute/launch_scripts/launch_prefect.py -W /sdf/home/d/dorlhiac/Repos/lute/workflows/prefect/dag.yaml -e mfxx49820 -r 16 --debug -c /sdf/home/d/dorlhiac/Repos/lute/config/test.yaml --partition=milano --account=lcls:data
```

## Partial output
```bash
> cat slurm-4679682.out 
Worker 'KubernetesWorker 46301172-c774-4383-9fe7-59e82a4a89a1' submitting flow run 'ed522508-bcc4-430b-aafb-9dca7889f987'
Creating Kubernetes job...
Job 'jasper-armadillo-xt52h': Starting watch for pod start...
Job 'jasper-armadillo-xt52h': Pod has status 'Pending'.
Completed submission of flow run 'ed522508-bcc4-430b-aafb-9dca7889f987'
Job 'jasper-armadillo-xt52h': Pod has status 'Running'.
Opening process...
 > Running git_clone step...
Beginning flow run 'jasper-armadillo' for flow 'lute_dynamic'
Running LUTE Managed Task: Tester
INFO:lute.execution.ipc:Will use TCP (ZMQ).
DEBUG:lute.execution.ipc:Executor bound port 33819
DEBUG:lute.execution.ipc:PipeCommunicator (Executor) - Set _use_pickle=False
INFO:lute.execution.executor:Environment variable RUN not found! Cannot substitute in YAML config!

DEBUG:lute.execution.executor:Cannot set result from TaskParameters. `set_result` not specified!
INFO:lute.execution.executor:Executor: Test started
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): psdm.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://psdm.slac.stanford.edu:443 "POST /arps3dfjid/jid/ws/mfxx49820/get_counters HTTP/11" 200 28
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): psdm.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://psdm.slac.stanford.edu:443 "POST /arps3dfjid/jid/ws/replace_counters/mfxx49820/f24c5aab-b353-4078-9e1b-3d6b7cee1acf HTTP/11" 200 94
INFO:lute.execution.executor:lute_config=AnalysisHeader(title='LUTE Task Configuration', experiment='mfxx49820', run='{{ $RUN }}', date='2023/10/25', lute_version=0.1, task_timeout=600, work_dir='/sdf/scratch/users/d/dorlhiac') float_var=0.01 str_var='test' compound_var=CompoundVar(int_var=10, dict_var={'a': 'b'}) throw_error=False
DEBUG:lute.execution.ipc:PipeCommunicator (Executor) - Set _use_pickle=True
INFO:lute.execution.executor:Test message 0
INFO:lute.execution.executor:Test message 1
INFO:lute.execution.executor:Test message 2
INFO:lute.execution.executor:Test message 3
```
# Screenshots
