### PR TITLE
ENH SMD to NeXus Tasks and Workflow

### DIFF
--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -2,7 +2,7 @@
 ---
 title: "LUTE Task Configuration" # Include experiment description if desired
 experiment: "{{ $EXPERIMENT }}"
-#run: "{{ $RUN }}"
+#run: "{{ $RUN_NUM }}"
 date: "2023/10/25"
 lute_version: 0.1      # Do not be change unless need to force older version
 task_timeout: 6000
@@ -85,6 +85,13 @@ DimpleSolve:
 # Smalldata
 ###########
 
+ConvertSMDToNexus:
+  convertor_script: "LUTE_LOCATION/third_party_scripts/smd2nx.py"
+  #input: ""
+  geom: "/path/to/geom.expt"
+  #output: ""
+  #flip: true
+
 # Producer will be auto-determined. Set only if you have a separate install
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
@@ -95,13 +102,14 @@ SubmitSMD:
   #experiment: ""
   #stn: 0
   #directory: ""
+  #config: "mfx_cctbx"
   #gather_interval: 25
   #norecorder: False
   #url: "https://pswww.slac.stanford.edu"
   #epicsAll: False
   #full: False
   #fullSum: False
-  default: true
+  #default: true
   #image: False
   #tiff: False
   #centerpix: False

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -2,7 +2,7 @@
 ---
 title: "LUTE Task Configuration" # Include experiment description if desired
 #experiment: ""
-#run: "{{ $RUN }}"
+#run: "{{ $RUN_NUM }}"
 date: "2023/10/25"
 lute_version: 0.1      # Do not be change unless need to force older version
 task_timeout: 600
@@ -82,13 +82,14 @@ SubmitSMD:
   #experiment: ""
   #stn: 0
   #directory: ""
+  #config: "xcs"
   #gather_interval: 25
   #norecorder: False
   #url: "https://pswww.slac.stanford.edu"
   #epicsAll: False
   #full: False
   #fullSum: False
-  default: true
+  #default: true
   #image: False
   #tiff: False
   #centerpix: False

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -2,7 +2,7 @@
 ---
 title: "LUTE Task Configuration" # Include experiment description if desired
 #experiment: ""
-#run: "{{ $RUN }}"
+#run: "{{ $RUN_NUM }}"
 date: "2023/10/25"
 lute_version: 0.1      # Do not be change unless need to force older version
 task_timeout: 600
@@ -82,13 +82,14 @@ SubmitSMD:
   #experiment: ""
   #stn: 0
   #directory: ""
+  #config: "xpp"
   #gather_interval: 25
   #norecorder: False
   #url: "https://pswww.slac.stanford.edu"
   #epicsAll: False
   #full: False
   #fullSum: False
-  default: true
+  #default: true
   #image: False
   #tiff: False
   #centerpix: False

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -11,3 +11,4 @@ from .smd import *
 from .tests import *
 from .mpi_tests import *
 from .geometry import *
+from .nexus import *

--- a/lute/io/models/nexus.py
+++ b/lute/io/models/nexus.py
@@ -1,0 +1,72 @@
+"""Models for NeXuS related Tasks.
+
+Classes:
+    ConvertSMDToNexusParameters(ThirdPartyParameters): Parameters to convert
+        smalldata_tools HDF5 file to CCTBX compatible NeXuS file.
+"""
+
+__all__ = ["ConvertSMDToNexusParameters"]
+__author__ = "Fred Poitevin and Gabriel Dorlhiac"
+
+from typing import Any, Dict, Union
+
+from pydantic import Field, validator
+
+from lute.io.models.base import ThirdPartyParameters
+
+
+class ConvertSMDToNexusParameters(ThirdPartyParameters):
+    """Parameters for running a conversion of smalldata HDF5 to NEXUS HDF5."""
+
+    class Config(ThirdPartyParameters.Config):
+        """Identical to super-class Config but includes a result."""
+
+        set_result: bool = True
+        """Whether the Executor should mark a specified parameter as a result."""
+
+        result_from_params: str = ""
+        """Defines a result from the parameters. Use a validator to do so."""
+
+    executable: str = Field("python", description="Python executable.", flag_type="")
+    convertor_script: str = Field(
+        description="smd to nexus conversion script from Derek Mendez.", flag_type=""
+    )
+    input: str = Field(
+        "",
+        description="Path to input smd .h5 file.",
+        flag_type="--",
+        rename_param="psanah5",
+    )
+    geom: str = Field(description="Detector geometry file (.expt).", flag_type="--")
+    output: str = Field(
+        "",
+        description="Path to output Nexus (.h5) file.",
+        flag_type="--",
+        rename_param="nexus",
+        is_result=True,
+    )
+    flip: bool = Field(False, description="Flag to flip.", flag_type="--")
+
+    @validator("input", always=True)
+    def validate_input_path(cls, input: str, values: Dict[str, Any]) -> str:
+        if input == "":
+            exp: str = values["lute_config"].experiment
+            hutch: str = exp[:3]
+            run: Union[str, int] = values["lute_config"].run
+            base_path: str = f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/cctbx"
+            path: str
+            path = f"{base_path}/{exp}_Run{int(run):04d}.h5"
+            return path
+        return input
+
+    @validator("output", always=True)
+    def validate_output_path(cls, output: str, values: Dict[str, Any]) -> str:
+        if output == "":
+            exp: str = values["lute_config"].experiment
+            hutch: str = exp[:3]
+            run: Union[str, int] = values["lute_config"].run
+            base_path: str = f"/sdf/data/lcls/ds/{hutch}/{exp}/hdf5/cctbx"
+            path: str
+            path = f"{base_path}/{exp}_Run{int(run):04d}_nexus.h5"
+            return path
+        return output

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -356,6 +356,11 @@ class SubmitSMDParameters(ThirdPartyParameters):
         flag_type="--",
     )
     stn: NonNegativeInt = Field(0, description="Hutch endstation.", flag_type="--")
+    config: Optional[str] = Field(
+        None,
+        description="Alternative config file to use for producer configuration",
+        flag_type="--",
+    )
     nevents: int = Field(
         int(1e9), description="Number of events to process.", flag_type="--"
     )
@@ -462,9 +467,14 @@ class SubmitSMDParameters(ThirdPartyParameters):
             if hutch.lower() in ("cxi", "mec", "xcs", "xpp"):
                 lute_template_cfg.output_path = values["producer"]
             else:
-                cfg: str = str(
-                    Path(values["producer"]).parent / f"prod_config_{hutch}.py"
-                )
+                cfg: str
+                if values["config"] is not None:
+                    prod_cfg: str = f"prod_config_{values['config']}"
+                    cfg = str(Path(values["producer"]).parent / prod_cfg)
+                else:
+                    cfg = str(
+                        Path(values["producer"]).parent / f"prod_config_{hutch}.py"
+                    )
                 lute_template_cfg.output_path = cfg
                 lute_template_cfg.template_name = "smd_prod_config_template.py"
         return lute_template_cfg

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -82,6 +82,11 @@ CCTBXIndexer: Executor = Executor("IndexCCTBXXFEL")
 """Runs crystallographic indexing using cctbx.xfel."""
 CCTBXIndexer.shell_source("/sdf/group/lcls/ds/tools/cctbx/setup.sh")
 
+SMDToNexusConvertor: Executor = Executor("ConvertSMDToNexus")
+"""Convert smalldata HDF5 to NEXUS HDF5 for use by CCTBX."""
+SMDToNexusConvertor.shell_source(
+    "/sdf/data/lcls/ds/prj/prjlumine22/results/lcls-mlcv/cctbx-builds/cctbx-psana2/build/conda_setpaths.sh"
+)
 CrystFELIndexer: Executor = Executor("IndexCrystFEL")
 """Runs crystallographic indexing using CrystFEL."""
 CrystFELIndexer.update_environment(

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -85,7 +85,7 @@ CCTBXIndexer.shell_source("/sdf/group/lcls/ds/tools/cctbx/setup.sh")
 SMDToNexusConvertor: Executor = Executor("ConvertSMDToNexus")
 """Convert smalldata HDF5 to NEXUS HDF5 for use by CCTBX."""
 SMDToNexusConvertor.shell_source(
-    "/sdf/data/lcls/ds/prj/prjlumine22/results/lcls-mlcv/cctbx-builds/cctbx-psana2/build/conda_setpaths.sh"
+    "/sdf/group/lcls/ds/tools/cctbx-psana2/build/conda_setpaths.sh"
 )
 CrystFELIndexer: Executor = Executor("IndexCrystFEL")
 """Runs crystallographic indexing using CrystFEL."""

--- a/third_party_scripts/smd2nx.py
+++ b/third_party_scripts/smd2nx.py
@@ -1,0 +1,97 @@
+from argparse import ArgumentParser
+
+ap = ArgumentParser()
+ap.add_argument("--nexus", type=str, required=True)
+ap.add_argument("--geom", type=str, required=True)
+ap.add_argument("--psanah5", type=str, required=True)
+ap.add_argument("--flip", action="store_true")
+args = ap.parse_args()
+
+
+import dxtbx
+import h5py
+from dxtbx.model import ExperimentList
+from dxtbx.format.nxmx_writer import NXmxWriter
+from dxtbx.format.nxmx_writer import phil_scope
+from libtbx.phil import parse
+from dxtbx.model import Beam
+from copy import deepcopy
+
+
+params = phil_scope.extract()
+params.nexus_details.source_name = "SLAC LCLS"
+params.nexus_details.instrument_name = "SLAC LCLS BEAMLINE MFX"
+params.nexus_details.instrument_short_name = "MFX"
+params.nexus_details.source_short_name = "LCLS"
+params.output_file = args.nexus
+writer = NXmxWriter(params)
+writer.construct_entry()
+
+E = ExperimentList.from_file(args.geom, False)[0]
+D = E.detector
+if args.flip:
+    import numpy as np
+    from dxtbx.model import Detector, Panel
+
+    new_D = Detector()
+    for i_p, p in enumerate(D):
+        pd = p.to_dict()
+        ox, oy, oz = p.get_origin()
+        fast = np.array(p.get_slow_axis()) * -1
+        slow = np.array(p.get_fast_axis()) * 1
+        orig = -oy, ox, oz
+        pd["origin"] = orig
+        pd["slow_axis"] = tuple(slow)
+        pd["fast_axis"] = tuple(fast)
+        new_p = Panel.from_dict(pd)
+        new_D.add_panel(new_p)
+    D = new_D
+
+writer.detector = D
+writer.construct_detector(detector=D)
+h = h5py.File(args.psanah5, "r")
+print("loading beams")
+from scipy import constants
+
+en_convert = 1e10 * constants.c * constants.h / constants.electron_volt
+waves = en_convert / h["ebeamh/ebeamPhotonEnergy"][()]
+B = E.beam
+
+if args.flip:
+    B.set_unit_s0((0, 0, -1))
+
+beams = []
+for i, w in enumerate(waves):
+    b = deepcopy(B)
+    b.set_wavelength(w)
+    beams.append(b)
+    print(i)
+
+writer.beams = beams
+writer.add_beams(beams)
+
+entry = writer.handle["entry"]
+data_group = entry.create_group("data")
+data_group.attrs["NX_class"] = "NXdata"
+imgs_path = "jungfrau/full_area"
+vlay = h5py.VirtualLayout(shape=h[imgs_path].shape, dtype=h[imgs_path].dtype)
+vs = h5py.VirtualSource(h.filename, imgs_path, h[imgs_path].shape)
+vlay[:] = vs
+data_group.create_virtual_dataset("data", vlay)
+
+h = writer.handle
+del h["entry/instrument/detector/sensor_material"]
+dt = h5py.special_dtype(vlen=str)
+h.create_dataset("entry/instrument/detector/sensor_material", data="Si", dtype=dt)
+
+del h["entry/instrument/detector/sensor_thickness"]
+thick_dset = h.create_dataset(
+    "entry/instrument/detector/sensor_thickness", data=0.00032
+)
+thick_dset.attrs["units"] = "m"
+
+h.close()
+
+# write semaphore file for Wilko
+with open(f"{args.nexus}.todo", "w") as f:
+    f.write("")

--- a/workflows/airflow/smd_to_nersc.py
+++ b/workflows/airflow/smd_to_nersc.py
@@ -1,0 +1,41 @@
+"""Run smalldata_tools and converts to NeXus format.
+
+Runs smalldata_tools and then converts to NeXus format.
+
+Note:
+    The task_id MUST match the managed task name when defining DAGs - it is used
+    by the operator to properly launch it.
+
+    dag_id names must be unique, and they are not namespaced via folder
+    hierarchy. I.e. all DAGs on an Airflow instance must have unique ids. The
+    Airflow instance used by LUTE is currently shared by other software - DAG
+    IDs should always be prefixed with `lute_`. LUTE scripts should append this
+    internally, so a DAG "lute_test" can be triggered by asking for "test"
+"""
+
+from datetime import datetime
+import os
+from airflow import DAG
+from lute.operators.jidoperators import JIDSlurmOperator
+
+dag_id: str = f"lute_{os.path.splitext(os.path.basename(__file__))[0]}"
+description: str = "Produces Nexus hdf5 file from SmallData hdf5 files."
+
+dag: DAG = DAG(
+    dag_id=dag_id,
+    start_date=datetime(2024, 9, 3),
+    schedule_interval=None,
+    description=description,
+    is_paused_upon_creation=False,
+)
+
+smd2_producer: JIDSlurmOperator = JIDSlurmOperator(
+    task_id="SmallDataProducer2", dag=dag
+)
+
+smd2nx: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="SMDToNexusConvertor", dag=dag
+)
+
+# Run summaries
+smd2_producer >> smd2nx


### PR DESCRIPTION
# Description

This PR adds support for conversion of jungfrau images to NeXus HDF5 format. A third party script is included to not lose track of it. This code is used for production of NeXus files for CCTBX processing at NERSC.

## Checklist
- [x] `ConvertSMDToNexusParameters` (and, by proxy, `ConvertSMDToNexus` Task)
- [x] `SMDToNexusConvertor` Managed Task
- [x] Change to `SubmitSMDParameters` to support `--config` option.
- [x] `smd_to_nersc` Airflow workflow
- [x] For time being leave the third party conversion script that the Task runs in the repository to not lose track.
- [x] Update hutch default config YAMLs.

## PR Type:
- [x] New feature/Enhancement


## Address issues:

# Testing
This code and workflow was tested for a good portion of `mfx100852324`. The eLog has results of the testing.

## YAML Used
```yaml
%YAML 1.3
---
title: "LUTE Task Configuration" # Include experiment description if desired
experiment: "{{ $EXPERIMENT }}"
run: "{{ $RUN_NUM }}"
date: "2023/10/25"
lute_version: 0.1      # Do not be change unless need to force older version
task_timeout: 6000
work_dir: "/sdf/data/lcls/ds/mfx/mfx100852324/results/lute_output"
...
---
###########
# Smalldata
###########

ConvertSMDToNexus:
  convertor_script: "/sdf/data/lcls/ds/mfx/mfx100852324/results/smd2nx.py"
  #input: ""
  #geom: "/sdf/data/lcls/ds/mfx/mfx100852324/results/imported.expt"
  geom: "/sdf/data/lcls/ds/mfx/mfx100852324/results/flip_test_imported.expt"
  #output: ""
  #flip: true
# Producer will be auto-determined. Set only if you have a separate install
# Set `directory` if you want to write to a different folder
# For out of memory issues try setting gather_interval
SubmitSMD:
  # Command line arguments
  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
  #run: 99
  #experiment: ""
  #stn: 0
  #directory: "/sdf/data/lcls/ds/mfx/mfx100861624/hdf5/cctbx" 
  directory: "/sdf/data/lcls/ds/mfx/mfx100852324/hdf5/cctbx"
  config: "mfx_cctbx"
  gather_interval: 1
  #norecorder: False
  #url: "https://pswww.slac.stanford.edu"
  #epicsAll: False
  #full: False
  #fullSum: False
  #default: true
  #image: False
  #tiff: False
  #centerpix: False
  #postRuntable: False
  #wait: False
# ... rest is commented out ....
...
```

# Screenshots
