### PR TITLE
BUG Fix `Task` timeout for third-party `Task`s

### DIFF
--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -899,6 +899,9 @@ class Executor(BaseExecutor):
                     executor._run_tasklets(when="before")
                 # Need to continue since Task._signal_start raises SIGSTOP
                 executor._continue(proc)
+                executor._task_timeout = (
+                    executor._analysis_desc.task_parameters.lute_config.task_timeout
+                )
                 if hasattr(
                     executor._analysis_desc.task_parameters.Config, "set_result"
                 ):
@@ -909,9 +912,6 @@ class Executor(BaseExecutor):
                 f"Executor: {executor._analysis_desc.task_result.task_name} started"
             )
             executor._analysis_desc.task_result.task_status = TaskStatus.RUNNING
-            executor._task_timeout = (
-                self._analysis_desc.task_parameters.lute_config.task_timeout
-            )
             elog_data: Dict[str, str] = {
                 f"{executor._analysis_desc.task_result.task_name} status": "RUNNING",
             }

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -194,6 +194,8 @@ class BaseExecutor(ABC):
         )
         self._tasklets: TaskletDict = {"before": None, "after": None}
         self._shell_source_script: Optional[str] = None
+        self._task_timeout: Optional[int] = None
+        self._task_time0: Optional[float] = None
 
     def add_tasklet(
         self,
@@ -593,9 +595,14 @@ class BaseExecutor(ABC):
             self._shell_source()
         cmd: str = self._submit_cmd(executable_path, params)
         proc: subprocess.Popen = self._submit_task(cmd)
+        self._task_time0 = time.monotonic()
 
         while self._task_is_running(proc):
             self._task_loop(proc)
+            if self._task_timeout is not None:
+                run_time: float = time.monotonic() - self._task_time0
+                if run_time > self._task_timeout:
+                    self._sigalrm_task(proc)
             time.sleep(self._analysis_desc.poll_interval)
 
         if proc.stdout is not None:
@@ -670,6 +677,11 @@ class BaseExecutor(ABC):
         """Stop the Task subprocess."""
         os.kill(proc.pid, signal.SIGTSTP)
         self._analysis_desc.task_result.task_status = TaskStatus.STOPPED
+
+    def _sigalrm_task(self, proc: subprocess.Popen) -> None:
+        """Timeout the Task subprocess with SIGALRM."""
+        os.kill(proc.pid, signal.SIGALRM)
+        self._analysis_desc.task_result.task_status = TaskStatus.TIMEDOUT
 
     def _continue(self, proc: subprocess.Popen) -> None:
         """Resume a stopped Task subprocess."""
@@ -897,6 +909,9 @@ class Executor(BaseExecutor):
                 f"Executor: {executor._analysis_desc.task_result.task_name} started"
             )
             executor._analysis_desc.task_result.task_status = TaskStatus.RUNNING
+            executor._task_timeout = (
+                self._analysis_desc.task_parameters.lute_config.task_timeout
+            )
             elog_data: Dict[str, str] = {
                 f"{executor._analysis_desc.task_result.task_name} status": "RUNNING",
             }

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -651,6 +651,7 @@ class BaseExecutor(ABC):
         if self._analysis_desc.task_result.task_status in (
             TaskStatus.FAILED,
             TaskStatus.TIMEDOUT,
+            TaskStatus.CANCELLED,
         ):
             logger.info("Exiting after Task failure. Result recorded.")
             logging.shutdown()
@@ -892,13 +893,11 @@ class Executor(BaseExecutor):
                 # Run "before" tasklets
                 if executor._tasklets["before"] is not None:
                     executor._run_tasklets(when="before")
-                else:
-                    # Hack: Seemingly SIGCONT doesn't always resume execution
-                    # Seemingly occurs more when there are no tasklets, waiting
-                    # before SIGCONT helps
-                    time.sleep(2)
                 # Need to continue since Task._signal_start raises SIGSTOP
-                executor._continue(proc)
+                status: int
+                _, status = os.waitpid(proc.pid, os.WUNTRACED)
+                if os.WIFSTOPPED(status):
+                    executor._continue(proc)
                 executor._task_timeout = (
                     executor._analysis_desc.task_parameters.lute_config.task_timeout
                 )

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -694,19 +694,6 @@ class BaseExecutor(ABC):
     def _continue(self, proc: subprocess.Popen) -> None:
         """Resume a stopped Task subprocess."""
         os.kill(proc.pid, signal.SIGCONT)
-        # status: str = psutil.Process(proc.pid).status()
-        # max_tries: int = 10
-        # while status != "running":
-        #    max_tries -= 1
-        #    os.kill(proc.pid, signal.SIGCONT)
-        #    status = psutil.Process(proc.pid).status()
-        #    if max_tries == 0:
-        #        logger.error(
-        #            "Cannot resume process from stopped/sleeping state! Exiting!"
-        #        )
-        #        os.kill(proc.pid, signal.SIGKILL)
-        #        self._analysis_desc.task_result.task_status = TaskStatus.FAILED
-        #        return None
         self._analysis_desc.task_result.task_status = TaskStatus.RUNNING
 
     def _set_result_from_parameters(self) -> None:
@@ -905,6 +892,11 @@ class Executor(BaseExecutor):
                 # Run "before" tasklets
                 if executor._tasklets["before"] is not None:
                     executor._run_tasklets(when="before")
+                else:
+                    # Hack: Seemingly SIGCONT doesn't always resume execution
+                    # Seemingly occurs more when there are no tasklets, waiting
+                    # before SIGCONT helps
+                    time.sleep(2)
                 # Need to continue since Task._signal_start raises SIGSTOP
                 executor._continue(proc)
                 executor._task_timeout = (

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -602,6 +602,7 @@ class BaseExecutor(ABC):
             if self._task_timeout is not None:
                 run_time: float = time.monotonic() - self._task_time0
                 if run_time > self._task_timeout:
+                    logger.error("Task timed out!")
                     self._sigalrm_task(proc)
             time.sleep(self._analysis_desc.poll_interval)
 
@@ -617,9 +618,10 @@ class BaseExecutor(ABC):
             proc.stderr.close()
         proc.wait()
         if ret := proc.returncode:
-            logger.warning(f"Task failed with return code: {ret}")
-            self._analysis_desc.task_result.task_status = TaskStatus.FAILED
-            self.Hooks.task_failed(self, msg=Message())
+            if self._analysis_desc.task_result.task_status != TaskStatus.TIMEDOUT:
+                logger.warning(f"Task failed with return code: {ret}")
+                self._analysis_desc.task_result.task_status = TaskStatus.FAILED
+                self.Hooks.task_failed(self, msg=Message())
         elif self._analysis_desc.task_result.task_status == TaskStatus.RUNNING:
             # Ret code is 0, no exception was thrown, task forgot to set status
             self._analysis_desc.task_result.task_status = TaskStatus.COMPLETED
@@ -645,10 +647,16 @@ class BaseExecutor(ABC):
 
         for comm in self._communicators:
             comm.clear_communicator()
-
-        if self._analysis_desc.task_result.task_status == TaskStatus.FAILED:
+        time.sleep(1)
+        if self._analysis_desc.task_result.task_status in (
+            TaskStatus.FAILED,
+            TaskStatus.TIMEDOUT,
+        ):
             logger.info("Exiting after Task failure. Result recorded.")
+            logging.shutdown()
             sys.exit(-1)
+        logger.info("Exiting after Task completion.")
+        logging.shutdown()
 
     def _store_configuration(self) -> None:
         """Store configuration and results in the LUTE database."""

--- a/utilities/setup_lute
+++ b/utilities/setup_lute
@@ -19,6 +19,7 @@ from krtc import KerberosTicket
 logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger(__name__)
 
+
 def _run_subprocess_log(cmd: List[str]) -> None:
     """Run a subprocess with logging."""
     global logger
@@ -33,6 +34,7 @@ def _run_subprocess_log(cmd: List[str]) -> None:
     if err:
         logger.info(err)
 
+
 def touch(full_path: str) -> None:
     """Touch a file.
 
@@ -42,14 +44,21 @@ def touch(full_path: str) -> None:
     cmd: List[str] = ["touch", full_path]
     _run_subprocess_log(cmd)
 
+
 def database_setup(full_path: str) -> None:
     """Touch a file.
 
     Args:
         full_path (str): The full path to the file to touch.
     """
+    if os.path.exists(full_path):
+        logger.error(
+            f"LUTE database already exists at: {full_path}. Will not overwrite, exiting."
+        )
+        sys.exit(-1)
     touch(full_path)
     os.chmod(full_path, 0o664)
+
 
 def git_clone(repo: str, location: str, tag: str) -> None:
     """Clone a git repository.
@@ -84,6 +93,7 @@ def git_clone(repo: str, location: str, tag: str) -> None:
     _run_subprocess_log(cmd)
     os.chdir(cwd)
 
+
 def inplace_sed(in_file: str, pattern: str) -> None:
     """Perform an in-place operation on a file using sed.
 
@@ -94,6 +104,7 @@ def inplace_sed(in_file: str, pattern: str) -> None:
     """
     cmd: List[str] = ["sed", "-i", pattern, in_file]
     _run_subprocess_log(cmd)
+
 
 def modify_permissions(lute_path: str):
     """Recursively set permissions for a LUTE installation."""
@@ -176,6 +187,11 @@ if __name__ == "__main__":
         os.makedirs(lute_output_dir, mode=0o777)
         os.chmod(lute_output_dir, 0o777)
     config_path: str = f"{lute_output_dir}/{hutch}_lute.yaml"
+    if os.path.exists(config_path):
+        logger.error(
+            f"Configuration YAML already exists at: {config_path}. Will not overwrite, exiting."
+        )
+        sys.exit(-1)
     if not os.path.exists(std_hutch_config):
         shutil.copy(f"{lute_path}/config/test.yaml", config_path)
     else:
@@ -185,7 +201,7 @@ if __name__ == "__main__":
     sed_pattern: str = f"s|work_dir:\(.*\)|work_dir: \\\"{lute_output_dir}\\\"|g"
     inplace_sed(config_path, sed_pattern)
 
-    database_setup(f"{lute_output_dir}/lute.db") # Setup permissions on database
+    database_setup(f"{lute_output_dir}/lute.db")  # Setup permissions on database
     param_string: str = f"{launch_executable} -c {config_path} -w {args.workflow}"
 
     if args.debug:
@@ -261,7 +277,7 @@ if __name__ == "__main__":
         }
     else:
         main_workflow = {
-            "name": "lute_smd_summaries",
+            "name": f"lute_{args.workflow}",
             "executable": arp_executable,
             "trigger": "END_OF_RUN",
             "location": "S3DF",


### PR DESCRIPTION
# Description

This PR addresses third-party `Task`s not being timed out. The issue is that the mechanism uses timers and signals (and handlers), which are not going to be preserved across an `exec`. As a fix provide an `Executor`-side check.

## Checklist
- [x] `Executor`-side timeout mechanism
- [x] Attempt at fix for potential hang (think this may be a race condition)
- [x] Minor checks added to setup script to not overwrite existing database/yaml

## PR Type:
- [x] Bug fix

## Address issues:

# Testing

# Screenshots

