### PR TITLE
ENH Support passing run types to Airflow and Prefect workflows

### DIFF
--- a/docs/development/creating_workflows_airflow.md
+++ b/docs/development/creating_workflows_airflow.md
@@ -194,8 +194,9 @@ dag: DAG = DAG(
     start_date=datetime(1970, 1, 1),
     schedule_interval=None,
     description=description,
-    is_paused_on_creation=False,
+    is_paused_upon_creation=False,
 )
+
 
 @task.branch(task_id="BranchTester")
 def test_branch_func(**context) -> str:
@@ -204,6 +205,7 @@ def test_branch_func(**context) -> str:
         if "run_type" in conf and conf["run_type"] == "TEST_ERROR":
             return "BinaryErrTester"
     return "BinaryTester"
+
 
 branch_tester = test_branch_func()
 tester: JIDSlurmOperator = JIDSlurmOperator(max_cores=2, task_id="Tester", dag=dag)
@@ -214,16 +216,20 @@ binary_err_tester: JIDSlurmOperator = JIDSlurmOperator(
     max_cores=5, task_id="BinaryErrTester", dag=dag
 )
 socket_tester: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=2, task_id="SocketTester", dag=dag
+    max_cores=2, task_id="SocketTester", dag=dag, trigger_rule="none_failed"
 )
 write_tester: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=2, task_id="WriteTester", dag=dag
+    max_cores=2, task_id="WriteTester", dag=dag, trigger_rule="none_failed"
 )
 read_tester: JIDSlurmOperator = JIDSlurmOperator(
-    max_cores=2, task_id="ReadTester", dag=dag
+    max_cores=2, task_id="ReadTester", dag=dag, trigger_rule="none_failed"
 )
 
 # If we get binary_err_tester rest of workflow won't run
 tester >> branch_tester >> [binary_tester, binary_err_tester] >> socket_tester >> write_tester >> read_tester
-
 ```
+
+The key features to note in this workflow are:
+
+- The `test_branch_func` branching task returns a `str` which matches the `task_id` of the next task to run. In this case it is either `BinaryTester` or `BinaryErrTester` (these correspond to the operator objects `binary_tester` and `binary_err_tester` respectively).
+- The `trigger_rule` was changed on all of the tasks downstream of the branching operation to be `none_failed`. By default the trigger rule is `all_succeed`, which means that all of the tasks that are upstream need to run, and be successful. In this case, since we are branching, one of the two tasks will be skipped. By specifying a trigger rule of `none_failed`, we say that downstream tasks can run as long as everything upstream was successful, or it was skipped.

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import argparse
 import time
-from typing import Dict, Union, List, Optional, Any, cast, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -48,6 +48,7 @@ class DagRunConf(TypedDict):
     lute_params: Dict[str, Union[str, bool]]
     slurm_params: List[str]
     workflow: Dict[str, Any]
+    run_type: Optional[str]
 
 
 class DagRunData(TypedDict):
@@ -111,6 +112,83 @@ def _request_arp_token(exp: str, lifetime: int = 300) -> str:
     return formatted_token
 
 
+def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
+    """Get the current active experiment for a hutch.
+
+    This function is one of two functions to manage the HTTP request independently.
+    This is because it does not require an authorization object, and its result
+    is needed for the generic function `elog_http_request` to work properly.
+
+    Args:
+        hutch (str): The hutch to get the active experiment for.
+
+        endstation (int): The hutch endstation to get the experiment for. This
+            should generally be 0.
+    """
+
+    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
+    endpoint: str = "ws/activeexperiment_for_instrument_station"
+    url: str = f"{base_url}/{endpoint}"
+    params: Dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
+    resp: requests.models.Response = requests.get(url, params)
+    if resp.status_code > 300:
+        raise RuntimeError(
+            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
+        )
+    if resp.json()["success"]:
+        return resp.json()["value"]["name"]
+    else:
+        msg: str = resp.json()["error_msg"]
+        raise RuntimeError(f"Error getting current experiment! Err: {msg}")
+
+
+def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
+    """Produce authentication for the "opr" user associated to an experiment.
+
+    This method uses basic authentication using username and password.
+
+    Args:
+        exp (str): Name of the experiment to produce authentication for.
+
+    Returns:
+        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
+            username and password for the associated operator account.
+    """
+    opr: str = f"{exp[:3]}opr"
+    with open("/sdf/group/lcls/ds/tools/forElogPost.txt", "r") as f:
+        pw: str = f.readline()[:-1]
+    return HTTPBasicAuth(opr, pw)
+
+
+def get_elog_kerberos_auth() -> Dict[str, str]:
+    """Returns Kerberos authorization key.
+
+    This functions returns authorization for the USER account submitting jobs.
+    It assumes that `kinit` has been run.
+
+    Returns:
+        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
+    """
+    from krtc import KerberosTicket  # type: ignore
+
+    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
+
+
+def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
+    """Determine the appropriate auth method depending on experiment state.
+
+    Returns:
+        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
+            is active/live, returns authorization for the hutch operator account
+            or the current user submitting a job.
+    """
+    hutch: str = exp[:3]
+    if exp.lower() == get_elog_active_expmt(hutch=hutch).lower():
+        return get_elog_opr_auth(exp)
+    else:
+        return get_elog_kerberos_auth()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="trigger_airflow_lute_dag",
@@ -124,6 +202,16 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--debug", help="Run in debug mode.", action="store_true")
     parser.add_argument(
         "--test", help="Use test Airflow instance.", action="store_true"
+    )
+    parser.add_argument(
+        "--type",
+        help=(
+            "Provide a run type to describe this workflow submission. "
+            "Some workflows may use a run type/tag to determine branching e.g. "
+            "This overrides the eLog type provided by the DAQ (if present)."
+        ),
+        type=str,
+        default="",
     )
     parser.add_argument(
         "-w", "--workflow", type=str, help="Workflow to run.", default="test"
@@ -220,10 +308,10 @@ if __name__ == "__main__":
 
     pw: str = _retrieve_pw(instance_str, is_admin=args.admin)
     user_name: str = "btx" if args.admin else "lcls_user"
-    auth: HTTPBasicAuth = HTTPBasicAuth(user_name, pw)
+    airflow_auth: HTTPBasicAuth = HTTPBasicAuth(user_name, pw)
     resp: requests.models.Response = requests.get(
         f"{airflow_instance}/{airflow_api_endpoints['health']}",
-        auth=auth,
+        auth=airflow_auth,
     )
     resp.raise_for_status()
 
@@ -251,7 +339,7 @@ if __name__ == "__main__":
         resp = requests.patch(
             f"{airflow_instance}/{airflow_api_endpoints['update_defn']}",
             json=new_workflow,
-            auth=auth,
+            auth=airflow_auth,
         )
         try:
             resp.raise_for_status()
@@ -261,7 +349,7 @@ if __name__ == "__main__":
                 resp = requests.post(
                     f"{airflow_instance}/{airflow_api_endpoints['create_defn']}",
                     json=new_workflow,
-                    auth=auth,
+                    auth=airflow_auth,
                 )
                 resp.raise_for_status()
             else:
@@ -269,45 +357,79 @@ if __name__ == "__main__":
         logger.debug("Sent new workflow definition.")
         resp = requests.get(
             f"{airflow_instance}/{airflow_api_endpoints['mod_dag']}",
-            auth=auth,
+            auth=airflow_auth,
         )
         resp.raise_for_status()
         file_token: str = resp.json()["file_token"]
         f_endpoint: str = airflow_api_endpoints["parse_file"].format(
             file_token=file_token
         )
-        resp = requests.put(f"{airflow_instance}/{f_endpoint}", auth=auth)
+        resp = requests.put(f"{airflow_instance}/{f_endpoint}", auth=airflow_auth)
         resp.raise_for_status()
         logger.debug("Re-parsed DAG for setup with new workflow.")
 
     # Experiment, run #, and ARP env variables come from ARP submission only
     # We override above or exit if we cannot, so we cast here
-    assert isinstance(os.getenv("EXPERIMENT"), str)
-    assert isinstance(os.getenv("RUN_NUM"), str)
-    assert isinstance(os.getenv("ARP_JOB_ID"), str)
-    assert isinstance(os.getenv("Authorization"), str)
+    experiment: Optional[str] = os.getenv("EXPERIMENT")
+    run_num: Optional[str] = os.getenv("RUN_NUM")
+    arp_job_id: Optional[str] = os.getenv("ARP_JOB_ID")
+    jid_authorization: Optional[str] = os.getenv("Authorization")
+    assert isinstance(experiment, str)
+    assert isinstance(run_num, str)
+    assert isinstance(arp_job_id, str)
+    assert isinstance(jid_authorization, str)
+
+    run_type: str
+    if args.type != "":
+        run_type = args.type
+    else:
+        elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
+        base_url: str
+        run_doc_url: str
+        run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
+        if isinstance(elog_auth, dict):
+            base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
+            run_doc_url = f"{base_url}/{run_doc_endpoint}"
+            resp = requests.get(run_doc_url, headers=elog_auth)
+        else:
+            base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
+            run_doc_url = f"{base_url}/{run_doc_endpoint}"
+            resp = requests.get(run_doc_url, auth=elog_auth)
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Unable to retrieve run document! No `run_type` information will be used! "
+                "Workflow may be able to continue but this could point to issues with "
+                "API access that lead to problems downstream."
+            )
+            run_type = "UNKNOWN"
+        else:
+            # If API request succeeds `type` should always be defined
+            run_type = resp.json()["value"]["type"]
+
     dag_run_data: DagRunData = {
         "dag_run_id": str(uuid.uuid4()),
         "conf": {
-            "experiment": cast(str, os.getenv("EXPERIMENT")),
-            "run_id": f"{cast(str, os.getenv('RUN_NUM'))}_{datetime.datetime.utcnow().isoformat()}",
+            "experiment": experiment,
+            "run_id": f"{run_num}_{datetime.datetime.utcnow().isoformat()}",
             "JID_UPDATE_COUNTERS": os.getenv("JID_UPDATE_COUNTERS"),
-            "ARP_ROOT_JOB_ID": cast(str, os.getenv("ARP_JOB_ID")),
+            "ARP_ROOT_JOB_ID": arp_job_id,
             "ARP_LOCATION": os.getenv("ARP_LOCATION", "S3DF"),
-            "Authorization": cast(str, os.getenv("Authorization")),
+            "Authorization": jid_authorization,
             "user": getpass.getuser(),
             "lute_location": os.path.abspath(f"{os.path.dirname(__file__)}/.."),
             "kerb_file": cache_file,
             "lute_params": params,
             "slurm_params": extra_args,
             "workflow": wf_defn,  # Only used for custom defined workflows.
+            "run_type": run_type,
         },
     }
 
     resp = requests.post(
         f"{airflow_instance}/{airflow_api_endpoints['run_dag']}",
         json=dag_run_data,
-        auth=auth,
+        auth=airflow_auth,
     )
     resp.raise_for_status()
     dag_run_id: str = dag_run_data["dag_run_id"]
@@ -320,7 +442,7 @@ if __name__ == "__main__":
     if not use_custom_defn:
         resp = requests.get(
             f"{airflow_instance}/{airflow_api_endpoints['get_tasks']}",
-            auth=auth,
+            auth=airflow_auth,
         )
         resp.raise_for_status()
         task_ids = [task["task_id"] for task in resp.json()["tasks"]]
@@ -351,12 +473,12 @@ if __name__ == "__main__":
     while True:
         time.sleep(1)
         # DAG Status
-        resp = requests.get(url, auth=auth)
+        resp = requests.get(url, auth=airflow_auth)
         resp.raise_for_status()
         dag_state = resp.json()["state"]
         # Check Task instances
         task_url: str = f"{url}/taskInstances"
-        resp = requests.get(task_url, auth=auth)
+        resp = requests.get(task_url, auth=airflow_auth)
         resp.raise_for_status()
         instance_information: List[Dict[str, Any]] = resp.json()["task_instances"]
         for inst in instance_information:
@@ -384,7 +506,7 @@ if __name__ == "__main__":
                         xcom_key=xcom_key,
                     )
                     try:
-                        resp = requests.get(xcom_url, auth=auth)
+                        resp = requests.get(xcom_url, auth=airflow_auth)
                         resp.raise_for_status()
                         logs: str = resp.json()["value"]  # Only want to print once.
                         logger.info(f"Providing logs for {task_id}")

--- a/launch_scripts/launch_prefect.py
+++ b/launch_scripts/launch_prefect.py
@@ -17,7 +17,7 @@ import sys
 import time
 import uuid
 import yaml
-from typing import Any, cast, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 from typing_extensions import TypedDict
 
 import requests
@@ -54,6 +54,7 @@ class FlowConf(TypedDict):
     lute_params: LuteParams
     slurm_params: List[str]
     workflow: Dict[str, Any]
+    run_type: Optional[str]
 
 
 class FlowRequestDict(TypedDict):
@@ -111,6 +112,83 @@ def _request_arp_token(exp: str, lifetime: int = 300) -> str:
     token: str = resp.json()["value"]
     formatted_token: str = f"Bearer {token}"
     return formatted_token
+
+
+def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
+    """Get the current active experiment for a hutch.
+
+    This function is one of two functions to manage the HTTP request independently.
+    This is because it does not require an authorization object, and its result
+    is needed for the generic function `elog_http_request` to work properly.
+
+    Args:
+        hutch (str): The hutch to get the active experiment for.
+
+        endstation (int): The hutch endstation to get the experiment for. This
+            should generally be 0.
+    """
+
+    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
+    endpoint: str = "ws/activeexperiment_for_instrument_station"
+    url: str = f"{base_url}/{endpoint}"
+    params: Dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
+    resp: requests.models.Response = requests.get(url, params)
+    if resp.status_code > 300:
+        raise RuntimeError(
+            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
+        )
+    if resp.json()["success"]:
+        return resp.json()["value"]["name"]
+    else:
+        msg: str = resp.json()["error_msg"]
+        raise RuntimeError(f"Error getting current experiment! Err: {msg}")
+
+
+def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
+    """Produce authentication for the "opr" user associated to an experiment.
+
+    This method uses basic authentication using username and password.
+
+    Args:
+        exp (str): Name of the experiment to produce authentication for.
+
+    Returns:
+        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
+            username and password for the associated operator account.
+    """
+    opr: str = f"{exp[:3]}opr"
+    with open("/sdf/group/lcls/ds/tools/forElogPost.txt", "r") as f:
+        pw: str = f.readline()[:-1]
+    return HTTPBasicAuth(opr, pw)
+
+
+def get_elog_kerberos_auth() -> Dict[str, str]:
+    """Returns Kerberos authorization key.
+
+    This functions returns authorization for the USER account submitting jobs.
+    It assumes that `kinit` has been run.
+
+    Returns:
+        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
+    """
+    from krtc import KerberosTicket  # type: ignore
+
+    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
+
+
+def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
+    """Determine the appropriate auth method depending on experiment state.
+
+    Returns:
+        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
+            is active/live, returns authorization for the hutch operator account
+            or the current user submitting a job.
+    """
+    hutch: str = exp[:3]
+    if exp.lower() == get_elog_active_expmt(hutch=hutch).lower():
+        return get_elog_opr_auth(exp)
+    else:
+        return get_elog_kerberos_auth()
 
 
 if __name__ == "__main__":
@@ -202,33 +280,64 @@ if __name__ == "__main__":
 
     # Experiment, run #, and ARP env variables come from ARP submission only
     # We override above or exit if we cannot, so we cast here
-    assert isinstance(os.getenv("EXPERIMENT"), str)
-    assert isinstance(os.getenv("RUN_NUM"), str)
-    assert isinstance(os.getenv("ARP_JOB_ID"), str)
-    assert isinstance(os.getenv("Authorization"), str)
+    experiment: Optional[str] = os.getenv("EXPERIMENT")
+    run_num: Optional[str] = os.getenv("RUN_NUM")
+    arp_job_id: Optional[str] = os.getenv("ARP_JOB_ID")
+    jid_authorization: Optional[str] = os.getenv("Authorization")
+    assert isinstance(experiment, str)
+    assert isinstance(run_num, str)
+    assert isinstance(arp_job_id, str)
+    assert isinstance(jid_authorization, str)
+
+    run_type: str
+    if args.type != "":
+        run_type = args.type
+    else:
+        elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
+        base_url: str
+        run_doc_url: str
+        run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
+        if isinstance(elog_auth, dict):
+            base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
+            run_doc_url = f"{base_url}/{run_doc_endpoint}"
+            resp = requests.get(run_doc_url, headers=elog_auth)
+        else:
+            base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
+            run_doc_url = f"{base_url}/{run_doc_endpoint}"
+            resp = requests.get(run_doc_url, auth=elog_auth)
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Unable to retrieve run document! No `run_type` information will be used! "
+                "Workflow may be able to continue but this could point to issues with "
+                "API access that lead to problems downstream."
+            )
+            run_type = "UNKNOWN"
+        else:
+            # If API request succeeds `type` should always be defined
+            run_type = resp.json()["value"]["type"]
 
     params: LuteParams = {"config_file": args.config, "debug": args.debug}
 
     conf: FlowConf = {
-        "experiment": cast(str, os.getenv("EXPERIMENT")),
-        "run_id": f"{cast(str, os.getenv('RUN_NUM'))}_{datetime.datetime.utcnow().isoformat()}",
+        "experiment": experiment,
+        "run_id": f"{run_num}_{datetime.datetime.utcnow().isoformat()}",
         "JID_UPDATE_COUNTERS": os.getenv("JID_UPDATE_COUNTERS"),
-        "ARP_ROOT_JOB_ID": cast(str, os.getenv("ARP_JOB_ID")),
+        "ARP_ROOT_JOB_ID": arp_job_id,
         "ARP_LOCATION": os.getenv("ARP_LOCATION", "S3DF"),
-        "Authorization": cast(str, os.getenv("Authorization")),
+        "Authorization": jid_authorization,
         "user": getpass.getuser(),
         "lute_location": os.path.abspath(f"{os.path.dirname(__file__)}/.."),
         "kerb_file": cache_file,
         "lute_params": params,
         "slurm_params": extra_args,
         "workflow": wf_defn,
+        "run_type": run_type,
     }
 
     # Get CSRF
     ##############################################
-    resp: requests.models.Response = requests.get(
-        csrf_endpoint, auth=auth, params={"client": user}
-    )
+    resp = requests.get(csrf_endpoint, auth=auth, params={"client": user})
 
     token: str = resp.json()["token"]
     client: str = resp.json()["client"]

--- a/workflows/airflow/test_type_branch.py
+++ b/workflows/airflow/test_type_branch.py
@@ -1,0 +1,59 @@
+"""DAG for testing branching based on provision of a `run_type.`
+
+If a specific `run_type` is passed along in the dag run conf, it will change
+the branch it takes.
+
+This tests functionality that allows workflows to branch based on run_types
+that can be provided when asking the DAQ to record a run.
+"""
+
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+from airflow import DAG
+from airflow.decorators import task
+
+from lute.operators.jidoperators import JIDSlurmOperator
+
+dag_id: str = f"lute_{os.path.splitext(os.path.basename(__file__))[0]}"
+description: str = "DAG to test branching based on run_type."
+
+dag: DAG = DAG(
+    dag_id=dag_id,
+    start_date=datetime(1970, 1, 1),
+    schedule_interval=None,
+    description=description,
+    is_paused_upon_creation=False,
+)
+
+
+@task.branch(task_id="BranchTester")
+def test_branch_func(**context) -> str:
+    if "dag_run" in context:
+        conf: Dict[str, Any] = context["dag_run"].conf
+        if "run_type" in conf and conf["run_type"] == "TEST_ERROR":
+            return "BinaryErrTester"
+    return "BinaryTester"
+
+
+branch_tester = test_branch_func()
+tester: JIDSlurmOperator = JIDSlurmOperator(max_cores=2, task_id="Tester", dag=dag)
+binary_tester: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=5, task_id="BinaryTester", dag=dag
+)
+binary_err_tester: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=5, task_id="BinaryErrTester", dag=dag
+)
+socket_tester: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="SocketTester", dag=dag, trigger_rule="none_failed"
+)
+write_tester: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="WriteTester", dag=dag, trigger_rule="none_failed"
+)
+read_tester: JIDSlurmOperator = JIDSlurmOperator(
+    max_cores=2, task_id="ReadTester", dag=dag, trigger_rule="none_failed"
+)
+
+# If we get binary_err_tester rest of workflow won't run
+tester >> branch_tester >> [binary_tester, binary_err_tester] >> socket_tester >> write_tester >> read_tester

--- a/workflows/prefect/flow_dataclasses.py
+++ b/workflows/prefect/flow_dataclasses.py
@@ -20,6 +20,7 @@ class FlowConf(TypedDict):
     lute_params: LuteParams
     slurm_params: List[str]
     workflow: Dict[str, Any]
+    run_type: Optional[str]
 
 
 class FlowRequestDict(TypedDict):


### PR DESCRIPTION
# Description

This PR adds support for passing the run `type` to workflows run by Airflow and Prefect.

The run `type` is similar to `tag`s which may be attached to runs in the eLog; however, it has a major advantage over the latter in that they can be specified at the **start** of the run. Support for providing run types via runs started from the DAQ was added in this commit https://github.com/slac-lcls/lcls2/commit/df6f8c14d7bfd422c945b2a7bf96e81e1e070df7 .

Because run types are attached at the start of the run, they are ideal candidates for use in creating branching operations in analysis workflows. A single workflow can be constructed that triggers on the beginning of every run, and then chooses the appropriate branch to take based on the run type, e.g. run geometry calibration, or just normal small data analysis. https://github.com/pcdshub/mfx/pull/215 in the MFX hutch-python repository is providing a `GEOM` type that will make use of this feature to run exactly this type of branched workflow for geometry calibration.

This PR provides a test Airflow workflow (`test_type_branch`) which demonstrates the functionality.

## Checklist
- [x] Modify `launch_airflow.py` to support passing `run_type` via the conf object to an Airflow workflow.
  - Retrieves the run type via kerberos/basic authentication for the current analysis run using the eLog API.
- [x] Modify `launch_prefect.py` to support passing `run_type` via the conf object to a Prefect workflow.
  - Retrieves the run type via kerberos/basic authentication for the current analysis run using the eLog API.
- [x] Create a `test_type_branch` Airflow workflow to test branching based on type.
- [x] Minor documentation updates

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- This will make workflow deployment simpler, since a single workflow can be used to encompass a variety of use cases that may arise during the normal course of an experiment.

# Testing
Testing done in runs 15 and 16 of `mfxdaq23`.

## Command to run
Tested using a `START OF RUN` trigger using the ARP:
```bash
/sdf/scratch/users/d/dorlhiac/work/lute/launch_scripts/submit_launch_airflow.sh /sdf/scratch/users/d/dorlhiac/work/lute/launch_scripts/launch_airflow.py -c /sdf/scratch/users/d/dorlhiac/work/lute/config/test.yaml -w test_type_branch --test --partition=milano --ntasks=6 --account=lcls:data --nodes=1
```

## YAML

```yaml
%YAML 1.3
---
title: "LUTE Task Configuration" # Include experiment description if desired
experiment: "{{ $EXPERIMENT }}"
run: "{{ $RUN_NUM }}"
date: "2023/10/25"
lute_version: 0.1 
task_timeout: 600
work_dir: "/sdf/scratch/users/d/dorlhiac"
...
---
Test:
  float_var: 0.01
  str_var: "test"
  compound_var:
    int_var: 10
    dict_var: {"a": "b"}
  throw_error: False # Set True to test Task failure

TestBinary:
  executable: "/sdf/home/d/dorlhiac/test_tasks/test_threads"
  p_arg1: 4 # Number of cores

TestBinaryErr:
  executable: "/sdf/home/d/dorlhiac/test_tasks/test_threads_err"
  p_arg1: 4 # Number of cores

TestSocket:
  array_size: 8000 # Size of arrays to send. 8000 floats ~ 6.4e4
  num_arrays: 10 # Number of arrays to send.

TestMultiNodeCommunication:
  send_obj: "plot" # Either "plot" or "array". Type of object to send
  arr_size: 5      # Size of the array if sending array
...
```

# Screenshots

In run 15, the `run_type` was specified as `TEST_ERROR`. This leads to the failure branch taken:

<img width="1363" height="385" alt="Image" src="https://github.com/user-attachments/assets/1217c3ba-70a3-43c1-8fe3-1cbb0b3364c4" />

In run 16, the `run_type` was specified as `TEST`. The successful branch was taken as a result. In this workflow implementation, anything except `TEST_ERROR` for the `run_type` would lead to the successful branch:

<img width="1363" height="385" alt="Image" src="https://github.com/user-attachments/assets/f59568e1-ce4d-4f90-9037-61b7473f8ec6" />


Reporting from the eLog Workflow > Control page.
<img width="1360" height="178" alt="Image" src="https://github.com/user-attachments/assets/d100a8c9-ffb6-42ea-b218-22598e796dea" />

