### PR TITLE
Added cheetah as a third party task

### DIFF
--- a/config/cheetah.yaml
+++ b/config/cheetah.yaml
@@ -1,0 +1,40 @@
+%YAML 1.3
+---
+title: "Config to run Cheetah task"
+experiment: "xpptut15"
+run: "291"
+date: "2025/09/05"
+lute_version: 0.1      # Do not be change unless need to force older version
+task_timeout: 5
+work_dir: ""
+...
+---
+RunCheetah:                       # All variables are given as strings
+  exp: "{{ experiment }}"         # Experiment name
+  run: "{{ run }}"                # Run number
+  dir: "/some/path"               # Path to raw_directory
+  executable: "/sdf/group/lcls/ds/tools/openmpi-5.0.6/bin/mpirun"              # Path to exectuable
+  n_processes: 1                  # Number of processes to launch
+  om_executable: "/sdf/group/lcls/ds/tools/om/om/om-071725/bin/om_monitor.py"  # om executable
+  om_config: "/sdf/scratch/users/k/kmecseki/cheetah/cheetah_testconfig.yaml"   # OM Config file
+  cheetah_subconfig:
+    om:
+      processing_layer: "CheetahProcessing"
+    data_retrieval_layer:
+      psana_calibration_directory: "/sdf/data/lcls/ds/xpp/xpptut15/calib/"
+    cheetah:
+      processed_directory: "/sdf/data/lcls/ds/xpp/xpptut15/results"
+      processed_filename_prefix: "{{experiment}}-{{run}}"
+      class_sums_filename_prefix: "{{run}}"
+    crystallography:
+      geometry_file: "/sdf/scratch/users/k/kmecseki/cheetah/test.geom"
+      responding_url: null
+    peakfinder8_peak_detection:
+      adc_threshold: 100.0
+      minimum_snr: 5.0
+      min_pixel_count: 1
+      max_pixel_count: 30
+      local_bg_radius: 4
+      bad_pixel_map_filename: null
+      min_res: 80
+      max_res: 800

--- a/config/cheetah.yaml
+++ b/config/cheetah.yaml
@@ -23,19 +23,13 @@ RunCheetah:                       # All variables are given as strings
     data_retrieval_layer:
       psana_calibration_directory: "/sdf/data/lcls/ds/xpp/xpptut15/calib/"
       data_sources:
-        timestamp:
-          type: "TimestampPsana"
-        event_id:
-          type: "EventIdPsana"
         detector_data:
-          type: "AreaDetectorPsana"
           psana_name: "epix10k2M"
           calibration: "true"
         detector_distance:
           type: "EpicsVariablePsana"
           psana_name: "detector_z"
-        beam_energy:
-          type: "BeamEnergyFromEpicsVariablePsana"
+          value: "DetectorDistanceValue"
     cheetah:
       processed_directory: "/sdf/data/lcls/ds/xpp/xpptut15/results"
       processed_filename_prefix: "{{experiment}}-{{run}}"

--- a/config/cheetah.yaml
+++ b/config/cheetah.yaml
@@ -22,6 +22,20 @@ RunCheetah:                       # All variables are given as strings
       processing_layer: "CheetahProcessing"
     data_retrieval_layer:
       psana_calibration_directory: "/sdf/data/lcls/ds/xpp/xpptut15/calib/"
+      data_sources:
+        timestamp:
+          type: "TimestampPsana"
+        event_id:
+          type: "EventIdPsana"
+        detector_data:
+          type: "AreaDetectorPsana"
+          psana_name: "epix10k2M"
+          calibration: "true"
+        detector_distance:
+          type: "EpicsVariablePsana"
+          psana_name: "detector_z"
+        beam_energy:
+          type: "BeamEnergyFromEpicsVariablePsana"
     cheetah:
       processed_directory: "/sdf/data/lcls/ds/xpp/xpptut15/results"
       processed_filename_prefix: "{{experiment}}-{{run}}"

--- a/config/cheetah.yaml
+++ b/config/cheetah.yaml
@@ -5,7 +5,7 @@ experiment: "xpptut15"
 run: "291"
 date: "2025/09/05"
 lute_version: 0.1      # Do not be change unless need to force older version
-task_timeout: 5
+task_timeout: 30
 work_dir: ""
 ...
 ---

--- a/config/templates/cheetah_template.yaml
+++ b/config/templates/cheetah_template.yaml
@@ -7,18 +7,19 @@ data_retrieval_layer:
   psana_calibration_directory: "{{ cheetah_subconfig.data_retrieval_layer.psana_calibration_directory }}"
   data_sources:
     timestamp:
-      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.timestamp.type }}
+      type: TimestampPsana2
     event_id:
-      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.event_id.type }}
+      type: EventIdPsana2
     detector_data:
-      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.type }}
+      type: AreaDetectorPsana2
       psana_name: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.psana_name }}
       calibration: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.calibration }}
     detector_distance:
       type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_distance.type }}
       psana_name: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_distance.psana_name }}
+      value: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_distance.value }}
     beam_energy:
-      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.beam_energy.type }}
+      type: EpicsVariablePsana2
 
 cheetah:
   processed_directory: "{{ cheetah_subconfig.cheetah.processed_directory }}"

--- a/config/templates/cheetah_template.yaml
+++ b/config/templates/cheetah_template.yaml
@@ -7,18 +7,18 @@ data_retrieval_layer:
   psana_calibration_directory: "{{ cheetah_subconfig.data_retrieval_layer.psana_calibration_directory }}"
   data_sources:
     timestamp:
-      type: TimestampPsana
+      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.timestamp.type }}
     event_id:
-      type: EventIdPsana
+      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.event_id.type }}
     detector_data:
-      type: AreaDetectorPsana
-      psana_name: epix10k2M
-      calibration: true
+      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.type }}
+      psana_name: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.psana_name }}
+      calibration: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_data.calibration }}
     detector_distance:
-      type: EpicsVariablePsana
-      psana_name: detector_z
+      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_distance.type }}
+      psana_name: {{ cheetah_subconfig.data_retrieval_layer.data_sources.detector_distance.psana_name }}
     beam_energy:
-      type: BeamEnergyFromEpicsVariablePsana
+      type: {{ cheetah_subconfig.data_retrieval_layer.data_sources.beam_energy.type }}
 
 cheetah:
   processed_directory: "{{ cheetah_subconfig.cheetah.processed_directory }}"

--- a/config/templates/cheetah_template.yaml
+++ b/config/templates/cheetah_template.yaml
@@ -1,0 +1,65 @@
+om:
+  parallelization_layer: MpiParallelization
+  data_retrieval_layer: PsanaDataEventHandler
+  processing_layer: {{ cheetah_subconfig.om.processing_layer }}
+
+data_retrieval_layer:
+  psana_calibration_directory: "{{ cheetah_subconfig.data_retrieval_layer.psana_calibration_directory }}"
+  data_sources:
+    timestamp:
+      type: TimestampPsana
+    event_id:
+      type: EventIdPsana
+    detector_data:
+      type: AreaDetectorPsana
+      psana_name: epix10k2M
+      calibration: true
+    detector_distance:
+      type: EpicsVariablePsana
+      psana_name: detector_z
+    beam_energy:
+      type: BeamEnergyFromEpicsVariablePsana
+
+cheetah:
+  processed_directory: "{{ cheetah_subconfig.cheetah.processed_directory }}"
+  processed_filename_prefix: "{{ exp }}-{{ run }}"
+  processed_filename_extension: "cxi"
+  write_class_sums: true
+  class_sums_update_interval: 5
+  class_sums_sending_interval: 100
+  class_sums_filename_prefix: "{{ run }}"
+  status_file_update_interval: 100
+  hdf5_file_data_type: "float32"
+  hdf5_file_compression: null
+  hdf5_file_max_num_peaks: 2048
+  hdf5_fields:
+    detector_data: "/entry_1/data_1/data"
+    event_id: "/LCLS/fiducial"
+    beam_energy: "/LCLS/photon_energy_eV"
+    detector_distance: "/LCLS/detector_1/EncoderValue"
+    timestamp: "/LCLS/timestamp"
+    peak_list: "/entry_1/result_1"
+
+crystallography:
+  geometry_file: "{{ cheetah_subconfig.crystallography.geometry_file }}"
+  min_num_peaks_for_hit: 10
+  max_num_peaks_for_hit: 5000
+  running_average_window_size: 200
+  geometry_is_optimized: false
+  speed_report_interval: 100
+  responding_url: "ipc://{{ cheetah_subconfig.crystallography.responding_url }}/ipc-socket"
+  external_data_request_list_size: 80
+  data_broadcast_interval: 0
+
+peakfinder8_peak_detection:
+  max_num_peaks: 2048
+  adc_threshold: {{ cheetah_subconfig.peakfinder8_peak_detection.adc_threshold }}
+  minimum_snr: {{ cheetah_subconfig.peakfinder8_peak_detection.minimum_snr }}
+  min_pixel_count: {{ cheetah_subconfig.peakfinder8_peak_detection.min_pixel_count }}
+  max_pixel_count: {{ cheetah_subconfig.peakfinder8_peak_detection.max_pixel_count }}
+  local_bg_radius: {{ cheetah_subconfig.peakfinder8_peak_detection.local_bg_radius }}
+  bad_pixel_map_filename: "{{mask_file}}"
+  bad_pixel_map_hdf5_path: /data/data
+  min_res: {{ cheetah_subconfig.peakfinder8_peak_detection.min_res }}
+  max_res: {{ cheetah_subconfig.peakfinder8_peak_detection.max_res }}
+  

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -74,6 +74,13 @@ def import_function(func_name: str, api_version: int) -> Callable:
 
 
 record_analysis_db: Callable = lazy_import("record_analysis_db", LUTE_DB_SPEC_VERSION)
+update_analysis_db: Callable = lazy_import("update_analysis_db", LUTE_DB_SPEC_VERSION)
+record_parameters_db: Callable = lazy_import(
+    "record_parameters_db", LUTE_DB_SPEC_VERSION
+)
+get_task_parameters_defn_and_params: Callable = lazy_import(
+    "get_task_parameters_defn_and_params", LUTE_DB_CURRENT_SPEC_VERSION
+)
 read_latest_db_entry: Callable = lazy_import(
     "read_latest_db_entry", LUTE_DB_SPEC_VERSION
 )

--- a/lute/io/db.py
+++ b/lute/io/db.py
@@ -74,13 +74,6 @@ def import_function(func_name: str, api_version: int) -> Callable:
 
 
 record_analysis_db: Callable = lazy_import("record_analysis_db", LUTE_DB_SPEC_VERSION)
-update_analysis_db: Callable = lazy_import("update_analysis_db", LUTE_DB_SPEC_VERSION)
-record_parameters_db: Callable = lazy_import(
-    "record_parameters_db", LUTE_DB_SPEC_VERSION
-)
-get_task_parameters_defn_and_params: Callable = lazy_import(
-    "get_task_parameters_defn_and_params", LUTE_DB_CURRENT_SPEC_VERSION
-)
 read_latest_db_entry: Callable = lazy_import(
     "read_latest_db_entry", LUTE_DB_SPEC_VERSION
 )

--- a/lute/io/models/__init__.py
+++ b/lute/io/models/__init__.py
@@ -13,3 +13,4 @@ from .mpi_tests import *
 from .geometry import *
 from .nexus import *
 from .xtc import *
+from .cheetah import *

--- a/lute/io/models/cheetah.py
+++ b/lute/io/models/cheetah.py
@@ -1,0 +1,146 @@
+"""Models for running the Cheetah Task
+
+Classes:
+    RunCheetahParameters(ThirdPartyParameters): Parameters to run Cheetah.
+    More information on Cheetah: https://github.com/omdevteam/om
+"""
+
+__all__ = ["RunCheetahParameters"]
+
+
+from pydantic import BaseModel, Field
+from typing import Any, Dict
+from lute.io.models.base import (
+    ThirdPartyParameters,
+    TemplateConfig,
+    validator,
+    Optional,
+)
+
+
+class RunCheetahParameters(ThirdPartyParameters):
+    """Parameters for running OM Cheetah Task."""
+
+    executable: str = Field(
+        "/sdf/group/lcls/ds/tools/openmpi-5.0.6/bin/mpirun",
+        description="MPI executable.",
+        flag_type="",
+    )
+    n_processes: int = Field(
+        4,
+        description="Number of processes to launch.",
+        flag_type="-",
+        rename_param="n",
+    )
+    om_executable: str = Field(
+        "/sdf/group/lcls/ds/tools/om/om/om-071725/bin/om_monitor.py",
+        description="OM Cheetah binary.",
+        flag_type="",
+    )
+    om_config: str = Field(
+        "/sdf/scratch/users/k/kmecseki/cheetah/test.yaml",
+        description="Config file for OM Cheetah.",
+        flag_type="-",
+        rename_param="c",
+    )
+    lute_template_cfg: TemplateConfig = Field(
+        TemplateConfig(
+            template_name="cheetah_template.yaml",
+            output_path="/sdf/scratch/users/k/kmecseki/cheetah/cheetah_testconfig.yaml",
+        ),
+        description="Template rendering configuration",
+    )
+
+    class CheetahSubconfigParameters(BaseModel):
+        """Parameters for OM Cheetah itself."""
+
+        class Config(BaseModel.Config):
+            extra: str = "allow"
+
+        class OmParameters(BaseModel):
+            """Parameters for OM layers"""
+
+            processing_layer: Optional[str] = Field(
+                "",
+                flag_type="",
+            )
+
+        class DataRetrievalLayerParameters(BaseModel):
+            """Parameters for the data retrieving layer."""
+
+            psana_calibration_directory: Optional[str] = Field(
+                "/sdf/data/lcls/ds/xpp/xpptut15/calib/",
+                flag_type="",
+            )
+
+        class CheetahParameters(BaseModel):
+            """Parameters for Cheetah."""
+
+            processed_directory: Optional[str] = Field(
+                "/sdf/data/lcls/ds/xpp/xpptut15/results",
+                flag_type="",
+            )
+            processed_filename_prefix: Optional[str] = Field(
+                "xpptut15-092",
+                flag_type="",
+            )
+            class_sums_filename_prefix: Optional[str] = Field(
+                "92",
+                flag_type="",
+            )
+
+        class CrystallographyParameters(BaseModel):
+            """Parameters for Crystallography."""
+
+            geometry_file: Optional[str] = Field(
+                "/sdf/scratch/users/k/kmecseki/cheetah/test.geom",
+                flag_type="",
+            )
+            responding_url: Optional[str] = Field(
+                "",
+                flag_type="",
+            )
+
+        class Peakfinder8PeakDetectionParameters(BaseModel):
+            """Parameters for peak finder 8 peak detection."""
+
+            adc_threshold: Optional[float] = Field(
+                100.0,
+                flag_type="",
+            )
+            minimum_snr: Optional[float] = Field(
+                5.0,
+                flag_type="",
+            )
+            min_pixel_count: Optional[int] = Field(
+                1,
+                flag_type="",
+            )
+            max_pixel_count: Optional[int] = Field(
+                30,
+                flag_type="",
+            )
+            local_bg_radius: Optional[int] = Field(
+                4,
+                flag_type="",
+            )
+            bad_pixel_map_filename: Optional[str] = Field(
+                "",
+                flag_type="",
+            )
+            min_res: Optional[int] = Field(
+                80,
+                flag_type="",
+            )
+            max_res: Optional[int] = Field(
+                800,
+                flag_type="",
+            )
+
+    @validator("lute_template_cfg", always=True)
+    def update_output_path(
+        cls, lute_template_cfg: TemplateConfig, values: Dict[str, Any]
+    ) -> TemplateConfig:
+        if lute_template_cfg.output_path == "":
+            lute_template_cfg.output_path = values["om_config"]
+        return lute_template_cfg

--- a/lute/io/models/cheetah.py
+++ b/lute/io/models/cheetah.py
@@ -54,9 +54,6 @@ class RunCheetahParameters(ThirdPartyParameters):
     class CheetahSubconfigParameters(BaseModel):
         """Parameters for OM Cheetah itself."""
 
-        class Config(BaseModel.Config):
-            extra: str = "allow"
-
         class OmParameters(BaseModel):
             """Parameters for OM layers"""
 

--- a/lute/io/models/cheetah.py
+++ b/lute/io/models/cheetah.py
@@ -73,35 +73,18 @@ class RunCheetahParameters(ThirdPartyParameters):
             class DataSourcesParameters(BaseModel):
                 """Parameters for the data retrieval layer data sources subfields."""
 
-                class DataSourceTimestampParameters(BaseModel):
-                    """Data retrieval layer, datasource timestamp parameters."""
-
-                    type: Optional[str] = Field("TimestampPsana", flat_type="")
-
-                class DataSourceEventIdParameters(BaseModel):
-                    """Data retrieval layer, datasource event id parameters."""
-
-                    type: Optional[str] = Field("EventIdPsana", flat_type="")
-
                 class DataSourceDetectorDataParameters(BaseModel):
                     """Data retrieval layer, datasource detector data parameters."""
 
-                    type: Optional[str] = Field("AreaDetectorPsana", flat_type="")
                     psana_name: Optional[str] = Field("epix10k2M", flat_type="")
-                    calibratin: Optional[str] = Field("true", flat_type="")
+                    calibration: Optional[str] = Field("true", flat_type="")
 
                 class DataSourceDetectorDistanceParameters(BaseModel):
                     """Data retrieval layer, datasource detector distance parameters."""
 
                     type: Optional[str] = Field("EpicsVariablePsana", flat_type="")
                     psana_name: Optional[str] = Field("detector_z", flat_type="")
-
-                class DataSourceBeamEnergyParameters(BaseModel):
-                    """Data retrieval layer, datasource beam energy parameters."""
-
-                    type: Optional[str] = Field(
-                        "BeamEnergyFromEpicsVariablePsana", flat_type=""
-                    )
+                    value: Optional[str] = Field("DetectorDistanceValue", flat_type="")
 
         class CheetahParameters(BaseModel):
             """Parameters for Cheetah."""

--- a/lute/io/models/cheetah.py
+++ b/lute/io/models/cheetah.py
@@ -70,6 +70,39 @@ class RunCheetahParameters(ThirdPartyParameters):
                 flag_type="",
             )
 
+            class DataSourcesParameters(BaseModel):
+                """Parameters for the data retrieval layer data sources subfields."""
+
+                class DataSourceTimestampParameters(BaseModel):
+                    """Data retrieval layer, datasource timestamp parameters."""
+
+                    type: Optional[str] = Field("TimestampPsana", flat_type="")
+
+                class DataSourceEventIdParameters(BaseModel):
+                    """Data retrieval layer, datasource event id parameters."""
+
+                    type: Optional[str] = Field("EventIdPsana", flat_type="")
+
+                class DataSourceDetectorDataParameters(BaseModel):
+                    """Data retrieval layer, datasource detector data parameters."""
+
+                    type: Optional[str] = Field("AreaDetectorPsana", flat_type="")
+                    psana_name: Optional[str] = Field("epix10k2M", flat_type="")
+                    calibratin: Optional[str] = Field("true", flat_type="")
+
+                class DataSourceDetectorDistanceParameters(BaseModel):
+                    """Data retrieval layer, datasource detector distance parameters."""
+
+                    type: Optional[str] = Field("EpicsVariablePsana", flat_type="")
+                    psana_name: Optional[str] = Field("detector_z", flat_type="")
+
+                class DataSourceBeamEnergyParameters(BaseModel):
+                    """Data retrieval layer, datasource beam energy parameters."""
+
+                    type: Optional[str] = Field(
+                        "BeamEnergyFromEpicsVariablePsana", flat_type=""
+                    )
+
         class CheetahParameters(BaseModel):
             """Parameters for Cheetah."""
 

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -161,4 +161,4 @@ Xtc1to2Converter: Executor = Executor("ConvertXtc1to2")
 
 CheetahRunner: Executor = Executor("RunCheetah")
 """Run Cheetah task."""
-CheetahRunner.shell_source("/sdf/group/lcls/ds/tools/om/om/om-071725/bin/activate-om")
+CheetahRunner.shell_source("/sdf/group/lcls/ds/tools/om/setup-om.sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -155,3 +155,9 @@ PeakFinderPsocake: Executor = Executor("FindPeaksPsocake")
 
 Xtc1to2Converter: Executor = Executor("ConvertXtc1to2")
 """Converts Xtc1 files to Xtc2 to use in psana2"""
+
+# Cheetah
+#########
+
+CheetahRunner: Executor = Executor("RunCheetah")
+"""Run Cheetah task."""

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -161,3 +161,4 @@ Xtc1to2Converter: Executor = Executor("ConvertXtc1to2")
 
 CheetahRunner: Executor = Executor("RunCheetah")
 """Run Cheetah task."""
+CheetahRunner.shell_source("/sdf/group/lcls/ds/tools/om/om/om-071725/bin/activate-om")


### PR DESCRIPTION
I think this is still just a draft, I could not test it as I think running om will need some special environment (I suppose..)
The config file gets created and gets filled properly with jinja, and it seems like the correct command is sent to slurm. I think we can iterate from here.

INFO:lute.execution.executor:/sdf/group/lcls/ds/tools/openmpi-5.0.6/bin/mpirun -n 1 /sdf/group/lcls/ds/tools/om/om/om-071725/bin/om_monitor.py -c /sdf/scratch/users/k/kmecseki/cheetah/cheetah_testconfig.yaml 

INFO:lute.execution.executor:(Traceback (most recent call last):
  File "/sdf/group/lcls/ds/tools/om/om/om-071725/bin/om_monitor.py", line 5, in <module>
    from om.monitor import main
ModuleNotFoundError: No module named 'om'
)
