### PR TITLE
BUG Fix losing environment when running shell_source

### DIFF
--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -505,6 +505,20 @@ class BaseExecutor(ABC):
                 new_environment[key] = value
             else:
                 new_environment[f"LUTE_TENV_{key}"] = value
+                # Make sure we don't accidentally lose our current environment
+                if key in os.environ and os.getenv(key) == value:
+                    # Add identical items first
+                    new_environment[key] = value
+                elif key == "PYTHONPATH":
+                    # Handle PYTHONPATH specifically if above doesn't catch it
+                    curr: Optional[str] = os.getenv("PYTHONPATH")
+                    if curr is not None:
+                        if curr in value:
+                            new_environment[key] = value
+                        else:
+                            # Not in PYTHONPATH, make sure to add it in
+                            new_environment[key] = f"{value}:{curr}"
+
         # Until we make LUTE installable... Need to make sure this is available
         # for first-party Tasks, regardless of the directory they run in if using
         # a new environment


### PR DESCRIPTION
# Description

This PR addresses losing the environment when running `shell_source`.  Specifically it allows access to `psana` from within parameter models. The bug has always existed, but was never noticeable because the parameter models didn't look for `psana`.

## Checklist
- [x] Fix `shell_source` issue

## PR Type:
- [x] Bug fix

## Address issues:

# Testing

# Screenshots

