### PR TITLE
BUG Fix environment update collisions and kerberos issues

### DIFF
--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -114,83 +114,6 @@ def _request_arp_token(exp: str, lifetime: int = 300) -> str:
     return formatted_token
 
 
-def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
-    """Get the current active experiment for a hutch.
-
-    This function is one of two functions to manage the HTTP request independently.
-    This is because it does not require an authorization object, and its result
-    is needed for the generic function `elog_http_request` to work properly.
-
-    Args:
-        hutch (str): The hutch to get the active experiment for.
-
-        endstation (int): The hutch endstation to get the experiment for. This
-            should generally be 0.
-    """
-
-    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
-    endpoint: str = "ws/activeexperiment_for_instrument_station"
-    url: str = f"{base_url}/{endpoint}"
-    params: Dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
-    resp: requests.models.Response = requests.get(url, params)
-    if resp.status_code > 300:
-        raise RuntimeError(
-            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
-        )
-    if resp.json()["success"]:
-        return resp.json()["value"]["name"]
-    else:
-        msg: str = resp.json()["error_msg"]
-        raise RuntimeError(f"Error getting current experiment! Err: {msg}")
-
-
-def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
-    """Produce authentication for the "opr" user associated to an experiment.
-
-    This method uses basic authentication using username and password.
-
-    Args:
-        exp (str): Name of the experiment to produce authentication for.
-
-    Returns:
-        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
-            username and password for the associated operator account.
-    """
-    opr: str = f"{exp[:3]}opr"
-    with open("/sdf/group/lcls/ds/tools/forElogPost.txt", "r") as f:
-        pw: str = f.readline()[:-1]
-    return HTTPBasicAuth(opr, pw)
-
-
-def get_elog_kerberos_auth() -> Dict[str, str]:
-    """Returns Kerberos authorization key.
-
-    This functions returns authorization for the USER account submitting jobs.
-    It assumes that `kinit` has been run.
-
-    Returns:
-        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
-    """
-    from krtc import KerberosTicket  # type: ignore
-
-    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
-
-
-def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
-    """Determine the appropriate auth method depending on experiment state.
-
-    Returns:
-        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
-            is active/live, returns authorization for the hutch operator account
-            or the current user submitting a job.
-    """
-    hutch: str = exp[:3]
-    if exp.lower() == get_elog_active_expmt(hutch=hutch).lower():
-        return get_elog_opr_auth(exp)
-    else:
-        return get_elog_kerberos_auth()
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="trigger_airflow_lute_dag",
@@ -381,18 +304,14 @@ if __name__ == "__main__":
     assert isinstance(arp_job_id, str)
     assert isinstance(jid_authorization, str)
 
-    elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
-    base_url: str
+    elog_auth: Dict[str, str] = {
+        "Authorization": jid_authorization,
+    }
+    base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
     run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
-    if isinstance(elog_auth, dict):
-        base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, headers=elog_auth)
-    else:
-        base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, auth=elog_auth)
+    run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
+    resp = requests.get(run_doc_url, headers=elog_auth)
 
     run_type: str
     is_daq2: Optional[bool] = None

--- a/launch_scripts/launch_airflow.py
+++ b/launch_scripts/launch_airflow.py
@@ -308,7 +308,6 @@ if __name__ == "__main__":
         "Authorization": jid_authorization,
     }
     base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
-    run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
     run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
     resp = requests.get(run_doc_url, headers=elog_auth)

--- a/launch_scripts/launch_prefect.py
+++ b/launch_scripts/launch_prefect.py
@@ -18,7 +18,7 @@ import sys
 import time
 import uuid
 import yaml
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from typing_extensions import TypedDict
 
 import requests
@@ -114,83 +114,6 @@ def _request_arp_token(exp: str, lifetime: int = 300) -> str:
     token: str = resp.json()["value"]
     formatted_token: str = f"Bearer {token}"
     return formatted_token
-
-
-def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
-    """Get the current active experiment for a hutch.
-
-    This function is one of two functions to manage the HTTP request independently.
-    This is because it does not require an authorization object, and its result
-    is needed for the generic function `elog_http_request` to work properly.
-
-    Args:
-        hutch (str): The hutch to get the active experiment for.
-
-        endstation (int): The hutch endstation to get the experiment for. This
-            should generally be 0.
-    """
-
-    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
-    endpoint: str = "ws/activeexperiment_for_instrument_station"
-    url: str = f"{base_url}/{endpoint}"
-    params: Dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
-    resp: requests.models.Response = requests.get(url, params)
-    if resp.status_code > 300:
-        raise RuntimeError(
-            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
-        )
-    if resp.json()["success"]:
-        return resp.json()["value"]["name"]
-    else:
-        msg: str = resp.json()["error_msg"]
-        raise RuntimeError(f"Error getting current experiment! Err: {msg}")
-
-
-def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
-    """Produce authentication for the "opr" user associated to an experiment.
-
-    This method uses basic authentication using username and password.
-
-    Args:
-        exp (str): Name of the experiment to produce authentication for.
-
-    Returns:
-        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
-            username and password for the associated operator account.
-    """
-    opr: str = f"{exp[:3]}opr"
-    with open("/sdf/group/lcls/ds/tools/forElogPost.txt", "r") as f:
-        pw: str = f.readline()[:-1]
-    return HTTPBasicAuth(opr, pw)
-
-
-def get_elog_kerberos_auth() -> Dict[str, str]:
-    """Returns Kerberos authorization key.
-
-    This functions returns authorization for the USER account submitting jobs.
-    It assumes that `kinit` has been run.
-
-    Returns:
-        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
-    """
-    from krtc import KerberosTicket  # type: ignore
-
-    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
-
-
-def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
-    """Determine the appropriate auth method depending on experiment state.
-
-    Returns:
-        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
-            is active/live, returns authorization for the hutch operator account
-            or the current user submitting a job.
-    """
-    hutch: str = exp[:3]
-    if exp.lower() == get_elog_active_expmt(hutch=hutch).lower():
-        return get_elog_opr_auth(exp)
-    else:
-        return get_elog_kerberos_auth()
 
 
 if __name__ == "__main__":
@@ -291,18 +214,14 @@ if __name__ == "__main__":
     assert isinstance(arp_job_id, str)
     assert isinstance(jid_authorization, str)
 
-    elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
-    base_url: str
+    elog_auth: Dict[str, str] = {
+        "Authorization": jid_authorization,
+    }
+    base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
     run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
-    if isinstance(elog_auth, dict):
-        base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, headers=elog_auth)
-    else:
-        base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, auth=elog_auth)
+    run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
+    resp = requests.get(run_doc_url, headers=elog_auth)
 
     run_type: str
     is_daq2: Optional[bool] = None

--- a/launch_scripts/launch_prefect.py
+++ b/launch_scripts/launch_prefect.py
@@ -218,7 +218,6 @@ if __name__ == "__main__":
         "Authorization": jid_authorization,
     }
     base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
-    run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
     run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
     resp = requests.get(run_doc_url, headers=elog_auth)

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -200,6 +200,9 @@ class BaseExecutor(ABC):
         self._task_timeout: Optional[int] = None
         self._task_time0: Optional[float] = None
         self._row_ids: Optional[RowIds] = None
+        self._delayed_update_env_args: Optional[
+            Tuple[Union[Dict[str, str], Callable[[], Dict[str, str]]], str]
+        ] = None
 
     def add_tasklet(
         self,
@@ -432,9 +435,15 @@ class BaseExecutor(ABC):
                 "prepend" is the default option. If PATH is not present in the
                 current environment, the new PATH is used without modification.
         """
+        self._delayed_update_env_args = (env, update_path)
+
+    def _update_environment(
+        self,
+        env: Union[Dict[str, str], Callable[[], Dict[str, str]]],
+        update_path: str = "prepend",
+    ) -> None:
         if callable(env):
             env_update: Dict[str, str] = env()
-            os.environ.update(env_update)
             self._analysis_desc.task_env.update(env_update)
             return
 
@@ -457,7 +466,6 @@ class BaseExecutor(ABC):
                         " Options are: prepend, append, overwrite."
                     )
                 )
-        os.environ.update(env)
         self._analysis_desc.task_env.update(env)
 
     def shell_source(self, env: str) -> None:
@@ -622,13 +630,18 @@ class BaseExecutor(ABC):
         if lute_path is None:
             logger.debug("Absolute path to subprocess_task.py not found.")
             lute_path = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
-            self.update_environment({"LUTE_PATH": lute_path})
+            os.environ.update({"LUTE_PATH": lute_path})
         executable_path: str = f"{lute_path}/subprocess_task.py"
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"
 
+        # Prevent all managed tasks from affecting each others environments
         if self._shell_source_script is not None:
             self._shell_source()
+
+        if self._delayed_update_env_args is not None:
+            self._update_environment(*self._delayed_update_env_args)
+
         cmd: str = self._submit_cmd(executable_path, params)
         proc: subprocess.Popen = self._submit_task(cmd)
         self._task_time0 = time.monotonic()

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -631,6 +631,7 @@ class BaseExecutor(ABC):
             logger.debug("Absolute path to subprocess_task.py not found.")
             lute_path = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
             os.environ.update({"LUTE_PATH": lute_path})
+            self._analysis_desc.task_env.update({"LUTE_PATH": lute_path})
         executable_path: str = f"{lute_path}/subprocess_task.py"
         config_path: str = self._analysis_desc.task_env["LUTE_CONFIGPATH"]
         params: str = f"-c {config_path} -t {self._analysis_desc.task_result.task_name}"

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -221,7 +221,12 @@ class PipeCommunicator(Communicator):
             if self._use_pickle:
                 try:
                     contents = pickle.loads(raw_contents)
-                except (pickle.UnpicklingError, ValueError, EOFError):
+                except (
+                    pickle.UnpicklingError,
+                    ValueError,
+                    EOFError,
+                    ModuleNotFoundError,
+                ):
                     logger.debug("PipeCommunicator (Executor) - Set _use_pickle=False")
                     self._use_pickle = False
                     contents = self._safe_unpickle_decode(raw_contents)
@@ -294,9 +299,10 @@ class PipeCommunicator(Communicator):
                     logger.debug(
                         f"PipeCommunicator has truncated message. Unable to retrieve {missing_bytes} bytes."
                     )
-        except (pickle.UnpicklingError, ValueError, EOFError):
+        except (pickle.UnpicklingError, ValueError, EOFError, ModuleNotFoundError):
             # Pickle may also throw a ValueError, e.g. this bytes: b"Found! \n"
             # Pickle may also throw an EOFError, eg. this bytes: b"F0\n"
+            # Pickle may also throw a ModuleNotFoundError, e.g. this bytes: b"co\nco\n"
             try:
                 contents = maybe_mixed.decode()
             except UnicodeDecodeError as err2:

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -465,11 +465,9 @@ def run_workflow_airflow(
         )
         run_type = "UNKNOWN"
     else:
-        if args.type != "":
-            run_type = args.type
-        else:
-            # If API request succeeds `type` should always be defined
-            run_type = resp.json()["value"]["type"]
+        # If API request succeeds `type` should always be defined
+        run_type = resp.json()["value"]["type"]
+
         # Try checking for "psana1" vs "psana2" by searching for "drp" in detector names
         param_keys: collections.abc.KeysView = resp.json()["value"]["params"].keys()
         for key in param_keys:
@@ -684,11 +682,9 @@ def run_workflow_prefect(
         )
         run_type = "UNKNOWN"
     else:
-        if args.type != "":
-            run_type = args.type
-        else:
-            # If API request succeeds `type` should always be defined
-            run_type = resp.json()["value"]["type"]
+        # If API request succeeds `type` should always be defined
+        run_type = resp.json()["value"]["type"]
+
         # Try checking for "psana1" vs "psana2" by searching for "drp" in detector names
         param_keys: collections.abc.KeysView = resp.json()["value"]["params"].keys()
         for key in param_keys:

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -2,16 +2,18 @@
 
 __author__ = "Gabriel Dorlhiac"
 
-import sys
-import os
-import uuid
-import getpass
-import datetime
-import logging
 import argparse
-import subprocess
+import collections
+import datetime
+import getpass
+import logging
+import os
 import shutil
+import subprocess
+import sys
 import time
+import uuid
+import yaml
 from typing import (
     Any,
     Callable,
@@ -59,6 +61,7 @@ class DagRunConf(TypedDict):
     slurm_params: List[str]
     workflow: Dict[str, Any]
     run_type: Optional[str]
+    is_daq2: Optional[bool]
 
 
 class DagRunData(TypedDict):
@@ -85,6 +88,7 @@ class FlowConf(TypedDict):
     slurm_params: List[str]
     workflow: Dict[str, Any]
     run_type: Optional[str]
+    is_daq2: Optional[bool]
 
 
 class FlowRequestDict(TypedDict):
@@ -316,83 +320,6 @@ def git_fetch_pr_branch(path_to_repo: str, github_id: int) -> None:
     git_checkout_branch(path_to_repo, new_pr_branch_name)
 
 
-def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> str:
-    """Get the current active experiment for a hutch.
-
-    This function is one of two functions to manage the HTTP request independently.
-    This is because it does not require an authorization object, and its result
-    is needed for the generic function `elog_http_request` to work properly.
-
-    Args:
-        hutch (str): The hutch to get the active experiment for.
-
-        endstation (int): The hutch endstation to get the experiment for. This
-            should generally be 0.
-    """
-
-    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
-    endpoint: str = "ws/activeexperiment_for_instrument_station"
-    url: str = f"{base_url}/{endpoint}"
-    params: Dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
-    resp: requests.models.Response = requests.get(url, params)
-    if resp.status_code > 300:
-        raise RuntimeError(
-            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
-        )
-    if resp.json()["success"]:
-        return resp.json()["value"]["name"]
-    else:
-        msg: str = resp.json()["error_msg"]
-        raise RuntimeError(f"Error getting current experiment! Err: {msg}")
-
-
-def get_elog_opr_auth(exp: str) -> HTTPBasicAuth:
-    """Produce authentication for the "opr" user associated to an experiment.
-
-    This method uses basic authentication using username and password.
-
-    Args:
-        exp (str): Name of the experiment to produce authentication for.
-
-    Returns:
-        auth (HTTPBasicAuth): HTTPBasicAuth for an active experiment based on
-            username and password for the associated operator account.
-    """
-    opr: str = f"{exp[:3]}opr"
-    with open("/sdf/group/lcls/ds/tools/forElogPost.txt", "r") as f:
-        pw: str = f.readline()[:-1]
-    return HTTPBasicAuth(opr, pw)
-
-
-def get_elog_kerberos_auth() -> Dict[str, str]:
-    """Returns Kerberos authorization key.
-
-    This functions returns authorization for the USER account submitting jobs.
-    It assumes that `kinit` has been run.
-
-    Returns:
-        auth (Dict[str, str]): Dictionary containing Kerberos authorization key.
-    """
-    from krtc import KerberosTicket  # type: ignore
-
-    return KerberosTicket("HTTP@pswww.slac.stanford.edu").getAuthHeaders()
-
-
-def get_elog_auth(exp: str) -> Union[HTTPBasicAuth, Dict[str, str]]:
-    """Determine the appropriate auth method depending on experiment state.
-
-    Returns:
-        auth (HTTPBasicAuth | Dict[str, str]): Depending on whether an experiment
-            is active/live, returns authorization for the hutch operator account
-            or the current user submitting a job.
-    """
-    hutch: str = exp[:3]
-    if exp.lower() == get_elog_active_expmt(hutch=hutch).lower():
-        return get_elog_opr_auth(exp)
-    else:
-        return get_elog_kerberos_auth()
-
-
 def run_workflow_airflow(
     lute_location: str,
     config_file: str,
@@ -519,19 +446,41 @@ def run_workflow_airflow(
     assert isinstance(arp_job_id, str)
     assert isinstance(jid_authorization, str)
 
-    run_type: str
-    elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
-    base_url: str
+    elog_auth: Dict[str, str] = {
+        "Authorization": jid_authorization,
+    }
+    base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
     run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
-    if isinstance(elog_auth, dict):
-        base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, headers=elog_auth)
+    run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
+    resp = requests.get(run_doc_url, headers=elog_auth)
+
+    run_type: str
+    is_daq2: Optional[bool] = None
+    if resp.status_code != 200:
+        logger.warning(
+            "Unable to retrieve run document! No `run_type` information will be used! "
+            "No information about psana1/psana2 can be retrieved. "
+            "Workflow may be able to continue but this could point to issues with "
+            "API access that lead to problems downstream."
+        )
+        run_type = "UNKNOWN"
     else:
-        base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, auth=elog_auth)
+        if args.type != "":
+            run_type = args.type
+        else:
+            # If API request succeeds `type` should always be defined
+            run_type = resp.json()["value"]["type"]
+        # Try checking for "psana1" vs "psana2" by searching for "drp" in detector names
+        param_keys: collections.abc.KeysView = resp.json()["value"]["params"].keys()
+        for key in param_keys:
+            if "/drp/" in key:
+                # Detectors in LCLS2 DAQ are sent to eLog as "DAQ Detectors/drp/<name>"
+                # In LCLS1 they are sent as "DAQ Detector/<name>"
+                is_daq2 = True
+                break
+        else:
+            is_daq2 = False
 
     if resp.status_code != 200:
         logger.warning(
@@ -560,6 +509,7 @@ def run_workflow_airflow(
             "slurm_params": extra_args,
             "workflow": wf_defn,  # Only used for custom defined workflows.
             "run_type": run_type,
+            "is_daq2": is_daq2,
         },
     }
 
@@ -716,30 +666,40 @@ def run_workflow_prefect(
     assert isinstance(arp_job_id, str)
     assert isinstance(jid_authorization, str)
 
-    run_type: str
-    elog_auth: Union[HTTPBasicAuth, Dict[str, str]] = get_elog_auth(experiment)
-    base_url: str
+    elog_auth: Dict[str, str] = {
+        "Authorization": jid_authorization,
+    }
+    base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
     run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
-    if isinstance(elog_auth, dict):
-        base_url = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, headers=elog_auth)
-    else:
-        base_url = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
-        run_doc_url = f"{base_url}/{run_doc_endpoint}"
-        resp = requests.get(run_doc_url, auth=elog_auth)
+    run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
+    resp = requests.get(run_doc_url, headers=elog_auth)
 
+    run_type: str
+    is_daq2: Optional[bool] = None
     if resp.status_code != 200:
         logger.warning(
             "Unable to retrieve run document! No `run_type` information will be used! "
+            "No information about psana1/psana2 can be retrieved. "
             "Workflow may be able to continue but this could point to issues with "
             "API access that lead to problems downstream."
         )
         run_type = "UNKNOWN"
     else:
-        # If API request succeeds `type` should always be defined
-        run_type = resp.json()["value"]["type"]
+        if args.type != "":
+            run_type = args.type
+        else:
+            # If API request succeeds `type` should always be defined
+            run_type = resp.json()["value"]["type"]
+        # Try checking for "psana1" vs "psana2" by searching for "drp" in detector names
+        param_keys: collections.abc.KeysView = resp.json()["value"]["params"].keys()
+        for key in param_keys:
+            if "/drp/" in key:
+                # Detectors in LCLS2 DAQ are sent to eLog as "DAQ Detectors/drp/<name>"
+                # In LCLS1 they are sent as "DAQ Detector/<name>"
+                is_daq2 = True
+        else:
+            is_daq2 = False
 
     params: LuteParams = {
         "config_file": config_file,
@@ -760,6 +720,7 @@ def run_workflow_prefect(
         "slurm_params": extra_args,
         "workflow": wf_defn,
         "run_type": run_type,
+        "is_daq2": is_daq2,
     }
 
     # Get CSRF

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -450,7 +450,6 @@ def run_workflow_airflow(
         "Authorization": jid_authorization,
     }
     base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
-    run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
     run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
     resp = requests.get(run_doc_url, headers=elog_auth)
@@ -670,7 +669,6 @@ def run_workflow_prefect(
         "Authorization": jid_authorization,
     }
     base_url: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
-    run_doc_url: str
     run_doc_endpoint: str = f"{experiment}/ws/runs/{run_num}"
     run_doc_url: str = f"{base_url}/{run_doc_endpoint}"
     resp = requests.get(run_doc_url, headers=elog_auth)


### PR DESCRIPTION
# Description

This PR addresses collisions that occur when running `update_environment` and `shell_source` with various **managed** `Task`s since they all live in the same module. It delays the operations until `execute_task` is called to prevent this problem.

## Checklist
- [x] Fix environment update collisions.
- [x] Change endpoint to use different authentication method, avoiding Kerberos problems.
  - [x] Update `launch_airflow.py`
  - [x] Update `launch_prefect.py`
  - [x] Update `run_functional.py`

## PR Type:
- [x] Bug fix

## Address issues:
- There was an error with the environment update methods which could collide depending on which methods were used for various **managed** `Task`s. The new changes delay all environment changes until the execution phase avoiding issues caused by the the objects being defined in a single module (`managed_tasks.py`). They are also done in the correct order. This means that the regardless of the order in which `shell_source` and `update_environment` are called, the requested changes will all be applied.
- The recent new additions to make run type and DAQ1 vs DAQ2 information available for logic at the workflow layer required Kerberos authentication when not running against an active experiment. This caused issues when submitting from the eLog in the event that no ticket was available. The new change switches the authentication method to avoid this problem allowing the code to run against all experiments.

# Testing
## From eLog for non-active experiment
Tested from the eLog against `mfx100852324` run `298`. See screenshots.

## Functional test suite
Also tested the functional test suite. Note that in this case the eLog APIs will fail (since `xpptut15` is being used which is a special public experiment without the same API availability), but this information is not used by the dynamic DAGs anyway. This is non-fatal. For newer tests that use specific real experiments we would expect the endpoint changes to work.

```bash
> ./submit_run_functional.sh --run_dir /sdf/scratch/users/d/dorlhiac/work/lute_tests --git_pr_id 86
Sourced latest psconda.sh
python -B /sdf/scratch/users/d/dorlhiac/work/lute_env/tests/run_functional.py --run_dir /sdf/scratch/users/d/dorlhiac/work/lute_tests --git_pr_id 86
Running python -B /sdf/scratch/users/d/dorlhiac/work/lute_env/tests/run_functional.py --run_dir /sdf/scratch/users/d/dorlhiac/work/lute_tests --git_pr_id 86 with --partition=milano --account=lcls:data --ntasks=1
Submitted batch job 12548220
> tail -f slurm-12548220.out 
DEBUG:Launch_Func_Tests:Cloning LUTE to /sdf/scratch/users/d/dorlhiac/work/lute_tests
INFO:Launch_Func_Tests:Cloning into '/sdf/scratch/users/d/dorlhiac/work/lute_tests/lute'...

INFO:Launch_Func_Tests:Switching to PR branch ID 86
INFO:Launch_Func_Tests:From https://github.com/slac-lcls/lute
 * [new ref]         refs/pull/86/head -> PR_BRANCH

INFO:Launch_Func_Tests:Saved working directory and index state WIP on dev: 9537a15 Merge pull request #85 from gadorlhiac/BUG/source_same_env

INFO:Launch_Func_Tests:Switched to branch 'PR_BRANCH'

INFO:Launch_Func_Tests:Will write output to /sdf/scratch/users/d/dorlhiac/work/lute_tests/lute_output
INFO:Launch_Func_Tests:Will attempt running 2 tests
INFO:Launch_Func_Tests:Running test: test2
INFO:Launch_Func_Tests:experiment: "xpptut15"

INFO:Launch_Func_Tests:run: 650

DEBUG:Launch_Func_Tests:Running as user.
DEBUG:Launch_Func_Tests:Sent new workflow definition.
# ...
INFO:Launch_Func_Tests:user_workflow.SmallDataProducer state: running
# ...
INFO:lute.execution.executor:Exiting after Task completion.

--------------------------------------------------
INFO:Launch_Func_Tests:End of logs for user_workflow.SmallDataProducer
INFO:Launch_Func_Tests:delete_workflow state: success
INFO:Launch_Func_Tests:No logs for delete_workflow.
INFO:Launch_Func_Tests:End of logs for delete_workflow
INFO:Launch_Func_Tests:DAG exited: success
INFO:Launch_Func_Tests:Test workflow test2 completed successfully.
INFO:Launch_Func_Tests:Running test: test1
INFO:Launch_Func_Tests:experiment: "xpptut15"

INFO:Launch_Func_Tests:run: 670

DEBUG:Launch_Func_Tests:Running as user.
DEBUG:Launch_Func_Tests:Sent new workflow definition.
DEBUG:Launch_Func_Tests:Re-parsed DAG for setup with new workflow.
WARNING:Launch_Func_Tests:Unable to retrieve run document! No `run_type` information will be used! No information about psana1/psana2 can be retrieved. Workflow may be able to continue but this could point to issues with API access that lead to problems downstream.
WARNING:Launch_Func_Tests:Unable to retrieve run document! No `run_type` information will be used! Workflow may be able to continue but this could point to issues with API access that lead to problems downstream.
INFO:Launch_Func_Tests:Contains Managed Tasks (alphabetical, not execution order):
# ...
DEBUG:lute.execution.ipc:Closed reading thread.
INFO:lute.execution.executor:Exiting after Task completion.

--------------------------------------------------
INFO:Launch_Func_Tests:End of logs for user_workflow.ReadTester
INFO:Launch_Func_Tests:delete_workflow state: failed
INFO:Launch_Func_Tests:No logs for delete_workflow.
INFO:Launch_Func_Tests:End of logs for delete_workflow
INFO:Launch_Func_Tests:DAG exited: failed
INFO:Launch_Func_Tests:Test workflow test1 was unsuccessful but this is marked as intentional.
INFO:Launch_Func_Tests:Ran 2 tests. 2 were successful.
DEBUG:Launch_Func_Tests:Removing duplicate Kerberos credentials.
INFO:Launch_Func_Tests:Cleaning up /sdf/scratch/users/d/dorlhiac/work/lute_tests/lute
INFO:Launch_Func_Tests:Cleaning up /sdf/scratch/users/d/dorlhiac/work/lute_tests/lute_output
```

# Screenshots
## Workflow definition
<img width="1872" height="61" alt="image" src="https://github.com/user-attachments/assets/be868fc4-3aed-4f56-b652-d099a2922b64" />

## Workflow Running from Control Tab
<img width="1198" height="45" alt="image" src="https://github.com/user-attachments/assets/2ac35dd1-838a-4431-8f9f-d67663633651" />

## Old error you would get due to kerberos
<img width="935" height="31" alt="image" src="https://github.com/user-attachments/assets/07105747-8b09-4524-8072-d125d2e5f309" />

<img width="704" height="291" alt="image" src="https://github.com/user-attachments/assets/4bad382d-3957-4820-88cd-6817905ca235" />


