### PR TITLE
Minor smd2 patch

### DIFF
--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -77,6 +77,7 @@ def getROIs(run):
     ret_dict = {}
 
     if run > 0:
+        roi_dict = {}
 {% for detector, params in getROIs.items() %}
 {{- step_parameters("roi_dict", detector, params) }}
 {% endfor %}
@@ -180,7 +181,7 @@ def get_azav_pyfai(run):
 {% endif %}
         az_dict['npts'] = {{ params['npts'] }}
         az_dict['npts_az'] = {{ params['npts_az'] }}
-        az_dict['int_units'] = {{ params['2th_deg'] }}
+        az_dict['int_units'] = {{ params['int_units'] | pprint }}
         az_dict['return2d'] = {{ params['return2d'] }}
 
         ret_dict['{{ detector }}'] = az_dict

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -227,7 +227,7 @@ One or more ROIs can be defined on a per detector basis using the parameters def
 ```yaml
   getROIs:
     jungfrau1M:   # Change to detector name
-      - ROI: [[[1, 2], [157, 487], [294, 598]]]
+      - ROI: [[1, 2], [157, 487], [294, 598]]
         #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
         writeArea: True   # Whether to save ROI, if False, save sum but not img.
         thresADU: None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy", "mypy", "meson-python", "pybind11"]
+requires = ["setuptools", "numpy", "mypy", "meson-python", "meson<1.10", "pybind11"]
 build-backend = "mesonpy"
 
 [project]


### PR DESCRIPTION
- Restricts to older meson version for building lute, otherwise dependency incompatible
- Corrected the template for smalldata 2 producer to avoid manually editing smalldata_tools file. Also updated the doc example where ROI should just be a list of lists, rather than list of lists of lists.