### PR TITLE
UTL/BUG Use temporary batch script and `srun` for SLURM submission. Minor IPC bug fix

### DIFF
--- a/config/templates/smd.patch
+++ b/config/templates/smd.patch
@@ -1,0 +1,26 @@
+diff --git a/lcls1_producers/smd_producer.py b/lcls1_producers/smd_producer.py
+index 4c2fe87..af212d8 100755
+--- a/lcls1_producers/smd_producer.py
++++ b/lcls1_producers/smd_producer.py
+@@ -654,7 +654,7 @@ for evt_num, evt in enumerate(ds.events()):
+ 
+     #the ARP will pass run & exp via the enviroment, if I see that info, the post updates
+     if ( (evt_num<100 and evt_num%10==0) or (evt_num<1000 and evt_num%100==0) or (evt_num%1000==0)):
+-        if os.environ.get('ARP_JOB_ID', None) is not None:
++        if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+             if ds.size == 1:
+                 requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Current Event</b>", "value": evt_num+1}])
+             elif ds.rank == 0:
+diff --git a/lcls2_producers/smd_producer.py b/lcls2_producers/smd_producer.py
+index 9f52b00..2b50c9b 100755
+--- a/lcls2_producers/smd_producer.py
++++ b/lcls2_producers/smd_producer.py
+@@ -1058,6 +1058,6 @@ logger.debug("rank {0} on {1} is finished".format(rank, hostname))
+ #        cmd = ['timestamp_sort_h5', h5_f_name, h5_f_name]
+ 
+ if ds.unique_user_rank():
+-    if os.environ.get("ARP_JOB_ID", None) is not None:
++    if os.environ.get("ARP_JOB_ID", None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+         requests.post(
+             os.environ["JID_UPDATE_COUNTERS"],
+             json=[

--- a/config/templates/smd.patch
+++ b/config/templates/smd.patch
@@ -1,5 +1,5 @@
 diff --git a/lcls1_producers/smd_producer.py b/lcls1_producers/smd_producer.py
-index 4c2fe87..af212d8 100755
+index 4c2fe87..dcdf7d4 100755
 --- a/lcls1_producers/smd_producer.py
 +++ b/lcls1_producers/smd_producer.py
 @@ -654,7 +654,7 @@ for evt_num, evt in enumerate(ds.events()):
@@ -11,6 +11,15 @@ index 4c2fe87..af212d8 100755
              if ds.size == 1:
                  requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Current Event</b>", "value": evt_num+1}])
              elif ds.rank == 0:
+@@ -703,7 +703,7 @@ if ds.rank==0:
+ 
+ #finishing up here....
+ logger.debug('rank {0} on {1} is finished'.format(ds.rank, hostname))
+-if os.environ.get('ARP_JOB_ID', None) is not None:
++if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+     if ds.size > 1:
+         if ds.rank == 0:
+             requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Last Event</b>", "value": "~ %d cores * %d evts"%(ds.size,evt_num)},{"key": "<b>Duration</b>", "value": "%f min"%(prod_time)}])
 diff --git a/lcls2_producers/smd_producer.py b/lcls2_producers/smd_producer.py
 index 9f52b00..2b50c9b 100755
 --- a/lcls2_producers/smd_producer.py

--- a/docs/development/creating_workflows_airflow.md
+++ b/docs/development/creating_workflows_airflow.md
@@ -7,7 +7,7 @@ In addition to the core LUTE package, a number of components are generally invol
 For building and running workflows using SLURM and Airflow, the following components are necessary, and will be described in more detail below:
 - Airflow launch script: `launch_airflow.py`
   - This has a wrapper batch submission script: `submit_launch_airflow.sh` . When running using the ARP (from the eLog), you **MUST** use this wrapper script instead of the Python script directly.
-- SLURM submission script: `submit_slurm.sh`
+- SLURM submission script: `submit_slurm`
 - Airflow operators:
   - `JIDSlurmOperator`
 
@@ -57,7 +57,7 @@ launch_airflow.py [-a | --admin] -c <path_to_config_yaml> [-d | --debug] [--test
     - `-e` is used to pass the experiment name. Needed if not using the ARP, i.e. running from the command-line.
     - `-r` is used to pass a run number. Needed if not using the ARP, i.e. running from the command-line.
 
-- `SLURM_ARGS` are SLURM arguments to be passed to the `submit_slurm.sh` script which are used for each individual **managed** `Task`. These arguments to do NOT affect the submission parameters for the job running `launch_airflow.py` (if using `submit_launch_airflow.sh` below).
+- `SLURM_ARGS` are SLURM arguments to be passed to the `submit_slurm` script which are used for each individual **managed** `Task`. These arguments to do NOT affect the submission parameters for the job running `launch_airflow.py` (if using `submit_launch_airflow.sh` below).
 
 
 #### Lifetime
@@ -75,10 +75,10 @@ Usage:
 submit_launch_airflow.sh /path/to/launch_airflow.py [-a | --admin] -c <path_to_config_yaml> [-d | --debug] [--test] [--type <TYPE>] -w <workflow_name> [-W <patch_to_dag] [-e <exp>] [-r <run>] [SLURM_ARGS]
 ```
 
-### `submit_slurm.sh`
+### `submit_slurm`
 Launches a job on the S3DF batch nodes using the SLURM job scheduler. This script launches a single **managed** `Task` at a time. The usage is as follows:
 ```bash
-submit_slurm.sh -c <path_to_config_yaml> -t <MANAGED_task_name> [--debug] [SLURM_ARGS ...]
+submit_slurm -c <path_to_config_yaml> -t <MANAGED_task_name> [--debug] [SLURM_ARGS ...]
 ```
 As a reminder the **managed** `Task` refers to the `Executor`-`Task` combination. The script does not parse any SLURM specific parameters, and instead passes them transparently to SLURM. At least the following two SLURM arguments must be provided:
 ```bash
@@ -87,7 +87,7 @@ As a reminder the **managed** `Task` refers to the `Executor`-`Task` combination
 ```
 Generally, resource requests will also be included, such as the number of cores to use. A complete call may look like the following:
 ```bash
-submit_slurm.sh -c /sdf/data/lcls/ds/hutch/experiment/scratch/config.yaml -t Tester --partition=milano --account=lcls:experiment --ntasks=100 [...]
+submit_slurm -c /sdf/data/lcls/ds/hutch/experiment/scratch/config.yaml -t Tester --partition=milano --account=lcls:experiment --ntasks=100 [...]
 ```
 
 When running a workflow using the `launch_airflow.py` script, each step of the workflow will be submitted using this script.
@@ -95,7 +95,7 @@ When running a workflow using the `launch_airflow.py` script, each step of the w
 ## Operators
 `Operator`s are the objects submitted as individual steps of a DAG by Airflow. They are conceptually linked to the idea of a task in that each task of a workflow is generally an operator. Care should be taken, not to confuse them with LUTE `Task`s or **managed** `Task`s though. There is, however, usually a one-to-one correspondance between a `Task` and an `Operator`.
 
-Airflow runs on a K8S cluster which has no access to the experiment data. When we ask Airflow to run a DAG, it will launch an `Operator` for each step of the DAG. However, the `Operator` itself cannot perform productive analysis without access to the data. The solution employed by `LUTE` is to have a limited set of `Operator`s which do not perform analysis, but instead request that a `LUTE` **managed** `Task`s be submitted on the batch nodes where it can access the data. There may be small differences between how the various provided `Operator`s do this, but in general they will all make a request to the **job interface daemon** (JID) that a new SLURM job be scheduled using the `submit_slurm.sh` script described above.
+Airflow runs on a K8S cluster which has no access to the experiment data. When we ask Airflow to run a DAG, it will launch an `Operator` for each step of the DAG. However, the `Operator` itself cannot perform productive analysis without access to the data. The solution employed by `LUTE` is to have a limited set of `Operator`s which do not perform analysis, but instead request that a `LUTE` **managed** `Task`s be submitted on the batch nodes where it can access the data. There may be small differences between how the various provided `Operator`s do this, but in general they will all make a request to the **job interface daemon** (JID) that a new SLURM job be scheduled using the `submit_slurm` script described above.
 
 Therefore, running a typical Airflow DAG involves the following steps:
 
@@ -211,7 +211,7 @@ task1 >> task3
 
 As each DAG is defined in pure Python, standard control structures (loops, if statements, etc.) can be used to create more complex workflow arrangements.
 
-**Note:** Your DAG will not be available to the production Airflow instance until your PR including the file you have defined is merged! Once merged the file will be synced with the Airflow instance and can be run using the scripts described earlier in this document. For testing it is generally preferred that you run each step of your DAG individually using the `submit_slurm.sh` script and the independent **managed** `Task` names. If, however, you want to test the behaviour of Airflow itself (in a modified form) you can either use the "dynamic" run-time DAGs described on the [dynamic workflows page](dynamic_workflows.md), or work against the test Airflow instance described below.
+**Note:** Your DAG will not be available to the production Airflow instance until your PR including the file you have defined is merged! Once merged the file will be synced with the Airflow instance and can be run using the scripts described earlier in this document. For testing it is generally preferred that you run each step of your DAG individually using the `submit_slurm` script and the independent **managed** `Task` names. If, however, you want to test the behaviour of Airflow itself (in a modified form) you can either use the "dynamic" run-time DAGs described on the [dynamic workflows page](dynamic_workflows.md), or work against the test Airflow instance described below.
 
 ### `psdag` repository and the production vs test Airflow instances
 

--- a/docs/development/creating_workflows_maestro.md
+++ b/docs/development/creating_workflows_maestro.md
@@ -59,7 +59,7 @@ Refer to https://github.com/slac-lcls/lute for more information.
 - `--num_server_threads` is an optional flag which will override the default number of threads setup by the built-in HTTP server.
 - `--unbuffered` is an optional flag which will display logs immediately as the are written. By default, logs are collected and displayed at the end of each step of the workflow. This unbuffered option will print them immediately. This is probably not useful if you have multiple things running in parallel as part of your workflow, but if all the steps are running serially it could be useful for more immediate feedback.
 
-- `SLURM_ARGS` are SLURM arguments to be passed to the `submit_slurm.sh` script which are used for each individual **managed** `Task`. These arguments to do NOT affect the submission parameters for the job running `launch_airflow.py` (if using `submit_launch_airflow.sh` below).
+- `SLURM_ARGS` are SLURM arguments to be passed to the `submit_slurm` script which are used for each individual **managed** `Task`. These arguments to do NOT affect the submission parameters for the job running `launch_airflow.py` (if using `submit_launch_airflow.sh` below).
 
 
 #### Lifetime

--- a/docs/development/maestro.md
+++ b/docs/development/maestro.md
@@ -120,7 +120,7 @@ There are currently two `Launcher` implementations. They are selected via the `L
 ```
 
 - The `PythonLauncher` runs the job steps directly calling the `python` interpreter - this is a blocking call.
-- The `SlurmLauncher` submits the `submit_slurm.sh` batch script to launch the `JobStep` as a batch job.
+- The `SlurmLauncher` submits the `submit_slurm` batch script to launch the `JobStep` as a batch job.
 
 ### `Handler` implementations
 

--- a/docs/usage/running_lute.md
+++ b/docs/usage/running_lute.md
@@ -3,7 +3,7 @@
 After a YAML file has been filled in you can run a `Task` (really, a **managed** `Task`). There are multiple ways to submit a `Task`, but there are 3 that are most likely:
 
 1. Run a single **managed** `Task` interactively by running `python ...`
-2. Run a single **managed** `Task` as a batch job (e.g. on S3DF) via a SLURM submission `submit_slurm.sh ...`
+2. Run a single **managed** `Task` as a batch job (e.g. on S3DF) via a SLURM submission `submit_slurm ...`
 3. Run a DAG (workflow with multiple **managed** `Task`s).
 
 These will be covered in turn below; however, in general all methods will require two parameters: the path to a configuration YAML file, and the name of the **managed** `Task` or workflow you want to run. When submitting via SLURM or submitting an entire workflow there are additional parameters to control these processes.
@@ -40,10 +40,10 @@ If you are submitting a **managed** `Task` that uses MPI you may encounter an is
 For additional debugging variables see the advanced usage section below.
 
 ### Submitting a single managed `Task` as a batch job
-On S3DF you can also submit individual **managed** `Task`s to run as batch jobs. To do so use `launch_scripts/submit_slurm.sh`. If you sourced the "activation" script described in the installation documentation, it is added to path as `submit_slurm.sh`
+On S3DF you can also submit individual **managed** `Task`s to run as batch jobs. To do so use `launch_scripts/submit_slurm.py`. If you sourced the "activation" script described in the installation documentation, it is added to path as `submit_slurm`
 
 ```bash
-> submit_slurm.sh -t <ManagedTaskName> -c </path/to/config/yaml> [--debug] [--psana2] $SLURM_ARGS
+> submit_slurm -t <ManagedTaskName> -c </path/to/config/yaml> [--debug] [--psana2] $SLURM_ARGS
 ```
 
 As before command-line arguments in square brackets `[]` are optional, while those in `<>` must be provided
@@ -69,7 +69,7 @@ In general, it is best to prefer the long-form of the SLURM-argument (`--arg=<..
 If you are not providing a specific experiment and run in your configuration YAML, you can additionally pass these values as arguments on the command-line:
 
 ```bash
-> submit_slurm.sh -t <ManagedTaskName> -c </path/to/config/yaml> [-e EXPERIMENT] [-r RUN] [--debug] $SLURM_ARGS
+> submit_slurm -t <ManagedTaskName> -c </path/to/config/yaml> [-e EXPERIMENT] [-r RUN] [--debug] $SLURM_ARGS
 ```
 
 ### Workflow (DAG) submission
@@ -117,7 +117,7 @@ The Airflow launch process actually involves two steps. There is a wrapper prior
 1. `launch_scripts/submit_launch_airflow.sh` is run.
 2. This script runs the `launch_scripts/launch_airflow.py` script which was provided as the first argument. This is the **true** launch script
 3. `launch_airflow.py` communicates with the Airflow API, requesting that a specific DAG be launched. It then continues to run, and gathers the individual logs and the exit status of each step of the DAG.
-4. Airflow will then enter a loop of communication where it asks the JID to submit each step of the requested DAG as batch job using `launch_scripts/submit_slurm.sh`.
+4. Airflow will then enter a loop of communication where it asks the JID to submit each step of the requested DAG as batch job using `launch_scripts/submit_slurm.py`.
 
 There are some specific reasons for this complexity:
 

--- a/launch_scripts/launch_slurm_v1.py
+++ b/launch_scripts/launch_slurm_v1.py
@@ -233,7 +233,7 @@ def launch_lute_task(
         slurm_params=slurm_params,
         kerb_file=kerb_file,
     )
-    executable: str = f"{lute_location}/launch_scripts/submit_slurm.sh"
+    executable: str = f"{lute_location}/launch_scripts/submit_slurm"
     launch_cmd: List[str] = [executable]
     launch_cmd.extend(parameter_str.split())
 

--- a/launch_scripts/meson.build
+++ b/launch_scripts/meson.build
@@ -2,7 +2,7 @@ bash_scripts = [
     'submit_launch_airflow.sh',
     'submit_launch_prefect.sh',
     'submit_launch_slurm.sh',
-    'submit_slurm.sh',
+    # 'submit_slurm.sh',
 ]
 
 install_data(
@@ -15,6 +15,7 @@ py_sources = [
     'launch_airflow.py',
     'launch_prefect.py',
     'launch_slurm_v1.py',
+    'submit_slurm.py',
 ]
 
 py3.install_sources(

--- a/launch_scripts/submit_slurm.py
+++ b/launch_scripts/submit_slurm.py
@@ -181,7 +181,7 @@ def prepare_environment_variables(
     else:
         os.environ["LUTE_USE_TCP"] = "1"
 
-    script_dir: str = os.path.dirname(os.path.realpath(__file__))
+    script_dir: str = os.path.dirname(os.path.realpath(sys.argv[0]))
     lute_location: str = os.path.abspath(f"{script_dir}/..")
 
     bin_subdir: str = script_dir.split("/")[-1]

--- a/launch_scripts/submit_slurm.py
+++ b/launch_scripts/submit_slurm.py
@@ -1,0 +1,315 @@
+"""Script to submit a single **managed** Task via SLURM."""
+
+__author__ = "Gabriel Dorlhiac"
+
+import argparse
+import datetime
+import os
+import re
+import secrets
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Setup the submit_slurm command-line argument parser.
+
+    Returns:
+        parser (argparse.ArgumentParser): The command-line parser.
+    """
+    parser: argparse.ArgumentParser = argparse.ArgumentParser()
+
+    # Immediately pop the group - takes out the help argument. We add to the group later
+    optional_args: argparse._ArgumentGroup = parser._action_groups.pop()
+
+    # Required arguments
+    required_args: argparse._ArgumentGroup = parser.add_argument_group(
+        "required arguments"
+    )
+
+    required_args.add_argument(
+        "-c", "--config", type=str, help="Absolute path to config YAML file."
+    )
+    required_args.add_argument(
+        "-t", "--taskname", help="Name of the LUTE **managed** Task to run."
+    )
+
+    # Arguments required for when running from command-line
+    non_arp_required_args: argparse._ArgumentGroup = parser.add_argument_group(
+        "required arguments when running without the ARP"
+    )
+    non_arp_required_args.add_argument(
+        "-e",
+        "--experiment",
+        type=str,
+        help="Provide an experiment if not running with ARP.",
+        required=False,
+    )
+    non_arp_required_args.add_argument(
+        "-r",
+        "--run",
+        type=str,
+        help="Provide a run number if not running with ARP.",
+        required=False,
+    )
+
+    # Optional Arguments
+    optional_args.add_argument(
+        "-d", "--debug", help="Run in debug mode.", action="store_true"
+    )
+
+    optional_args.add_argument(
+        "-K", "--KERB", help="Kerberos cache file variable. Should NOT be set manually!"
+    )
+
+    parser.add_argument(
+        "--psana2", help="Use the psana2 base environment.", action="store_true"
+    )
+    parser.add_argument(
+        "--psana1",
+        help=(
+            "Use the psana1 base environment. NOTE: We allow both --psana1 and --psana2 "
+            "to be passed. This is because the LUTE infrastructure now defaults to "
+            "psana2 in the event that it cannot auto-determine the type of experiment. "
+            "When both --psana2 and --psana1 are passed, **psana1 TAKES PRECEDENCE**. "
+            "This allows forcing the use of the psana1 environment without changing "
+            "default behaviour elsewhere in the infrastructure. "
+        ),
+        action="store_true",
+    )
+
+    parser._action_groups.append(optional_args)
+    return parser
+
+
+def parse_arguments(
+    parser: argparse.ArgumentParser,
+) -> Tuple[argparse.Namespace, List[str]]:
+    """Check the command-line parsing.
+
+    To avoid any issues with other parsing, it enforces that SLURM arguments are
+    of the format: --long_arg=value. The one exception to this rule is if the
+    --exclusive flag is passed, which does not take an argument value.
+
+    Args:
+        parser (argparse.ArgumentParser): The command-line parser.
+
+    Returns:
+        lute_args (argparse.Namespace): The main LUTE argument namespace.
+
+        slurm_args (List[str]): A list of additional arguments. Assumed to be
+            for SLURM.
+    """
+    args: argparse.Namespace
+    extra_args: List[str]
+    args, extra_args = parser.parse_known_args()
+
+    # Double check that SLURM args were passed as --long_form=value
+    # Not sure if numbers allowed. Nearly certain that no... but leave it in case...
+    # Make an exception for --exclusive
+    valid_slurm_form: re.Pattern = re.compile(r"^--[A-Za-z0-9][A-Za-z0-9_-]*=.+")
+
+    invalid_args: List[str] = [
+        arg
+        for arg in extra_args
+        if not valid_slurm_form.match(arg) and arg != "--exclusive"
+    ]
+    if invalid_args:
+        parser.error(
+            "SLURM arguments should be passed in the form: `--long_form=value`.\n"
+            "E.g. --nodes=2 instead of -N 2."
+        )
+
+    return args, extra_args
+
+
+def prepare_environment_variables(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> str:
+    """Setup the LUTE environment variables.
+
+    Args:
+        parser (argparse.ArgumentParser): The command-line parser. This is used
+            only to throw errors as needed.
+
+        args (argparse.Namespace): Validated LUTE command-line arguments.
+
+    Returns:
+        bin_subdir (str): The sub-directory for LUTE executables.
+    """
+    experiment: Optional[str] = os.getenv("EXPERIMENT")
+    run_num: Optional[str] = os.getenv("RUN_NUM")
+
+    if experiment is None:
+        experiment = args.experiment
+        if experiment is None:
+            parser.error(
+                "The `EXPERIMENT` environment variable was not defined, so you "
+                "have likely submitted this from the command-line. Please pass "
+                "-e <EXPERIMENT> to provide an experiment!"
+            )
+
+    if run_num is None:
+        run_num = args.run
+        if run_num is None:
+            parser.error(
+                "The `RUN_NUM` environment variable was not defined, so you "
+                "have likely submitted this from the command-line. Please pass "
+                "-r <RUN_NUM> to provide a run number!"
+            )
+
+    # NOTE: When submitted from the ARP, the RUN_NUM env var is actually: RUN_DATETIME
+    # So we clip off the date time portion
+    run_num = run_num.split("_")[0]
+
+    # Re-export all required environment variables
+    os.environ["RUN"] = run_num
+    os.environ["RUN_NUM"] = run_num  # Both forms of RUN are used by different things...
+    os.environ["EXPERIMENT"] = experiment
+
+    if args.KERB:
+        os.environ["KRB5CCNAME"] = args.KERB
+
+    # Check TCP vs Unix socket. Default is TCP if unset
+    if (env_tcp := os.getenv("LUTE_USE_TCP")) is not None and env_tcp == "0":
+        print("Using Unix sockets")
+        # Emulating bash $RANDOM - could make this better now... but should be fine
+        os.environ["LUTE_SOCKET"] = f"/tmp/lute_{secrets.randbelow(32768)}.sock"
+        if "LUTE_USE_TCP" in os.environ:
+            os.environ.pop("LUTE_USE_TCP")
+    else:
+        os.environ["LUTE_USE_TCP"] = "1"
+
+    script_dir: str = os.path.dirname(os.path.realpath(__file__))
+    lute_location: str = os.path.abspath(f"{script_dir}/..")
+
+    bin_subdir: str = script_dir.split("/")[-1]
+
+    os.environ["LUTE_PATH"] = lute_location
+
+    return bin_subdir
+
+
+def fill_in_batch_script(
+    args: argparse.Namespace, slurm_args: List[str], bin_subdir: str
+) -> str:
+    """Prepare a temporary batch script.
+
+    Args:
+        args (argparse.Namespace): Validated LUTE command-line arguments.
+
+        slurm_args (List[str]): Validated SLURM command-line arguments.
+
+        bin_subdir (str): The sub-directory for LUTE executables.
+
+    Returns:
+        batch_script (str): A completed batch script which can be run with
+            sbatch once written to a file.
+    """
+    experiment: Optional[str] = os.getenv("EXPERIMENT")
+    run_num: Optional[str] = os.getenv("RUN_NUM")
+
+    if experiment is None or run_num is None:
+        raise RuntimeError("Experiment and/or run number are not defined!")
+
+    batch_script: str = "#!/bin/bash\n"
+
+    # Setup log file name - task_exp_run_time_job, the %J will be filled in by SLURM
+    # This will be used for both stdout and stderr log files
+    curr_time: str = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%d_%H-%M-%S"
+    )
+    log_file: str = (
+        f"{args.taskname}_{experiment}_r{int(run_num):04d}_{curr_time}_%J.out"
+    )
+
+    for slurm_arg in slurm_args:
+        batch_script += f"#SBATCH {slurm_arg}\n"
+
+    batch_script += f"#SBATCH --output={log_file}\n"
+    batch_script += f"#SBATCH --error={log_file}\n"
+
+    if args.psana1:
+        print("Using a Psana1 base environment")
+        batch_script += (
+            "source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh\n"
+        )
+    elif args.psana2:
+        print("Using a Psana2 base environment")
+        batch_script += (
+            "source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh\n"
+        )
+    else:
+        print("Using a Psana1 base environment")
+        batch_script += (
+            "source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh\n"
+        )
+
+    lute_location: Optional[str] = os.getenv("LUTE_PATH")
+    if lute_location is None:
+        raise RuntimeError("LUTE path env var is empty! Check the launch scripts!")
+
+    full_bindir: str = f"{lute_location}/{bin_subdir}"
+    lute_executable: str
+    if "launch_scripts" in bin_subdir:
+        lute_executable = f"{lute_location}/run_task.py"
+    else:
+        lute_executable = f"{full_bindir}/run_task"
+
+        py_ver: str = f"{sys.version_info.major}.{sys.version_info.minor}"
+        # Need to redo the LUTE_PATH env var here... not great...
+        # Note that in this case, the LUTE_PATH included the /install/ dir
+        os.environ["LUTE_PATH"] = f"{lute_location}/lib/python{py_ver}/site-packages"
+
+        batch_script += f"source {full_bindir}/activate_installation\n\n"
+
+    cmd: str
+    if args.debug:
+        cmd = f"python -B {lute_executable} -c {args.config} -t {args.taskname}"
+    else:
+        cmd = f"python -OB {lute_executable} -c {args.config} -t {args.taskname}"
+
+    batch_script += f"srun --cpus-per-task=1 {cmd}\n"
+
+    return batch_script
+
+
+def main() -> None:
+    """Parse LUTE and SLURM command-line arguments and submit a batch job."""
+    parser: argparse.ArgumentParser = get_parser()
+
+    args, slurm_args = parse_arguments(parser)
+
+    bin_subdir: str = prepare_environment_variables(parser=parser, args=args)
+
+    batch_script: str = fill_in_batch_script(
+        args=args, slurm_args=slurm_args, bin_subdir=bin_subdir
+    )
+
+    # Write temporary file
+    temp_filename: str = f"submit_{args.taskname}_{secrets.token_hex(4)}.sh"
+    with open(temp_filename, "w") as f:
+        f.write(batch_script)
+
+    print(f"Submitting task {args.taskname}")
+    if args.debug:
+        print(f"Running {args.taskname} with SLURM arguments: {slurm_args}")
+        print(f"Full script:\n{batch_script}")
+
+    try:
+        result: subprocess.CompletedProcess = subprocess.run(
+            ["sbatch", temp_filename], check=True
+        )
+        print(result.stdout)
+        print(result.stderr)
+    except subprocess.CalledProcessError as e:
+        print(f"Error submitting job: {e}")
+        sys.exit(1)
+    finally:
+        if os.path.exists(temp_filename):
+            os.remove(temp_filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/launch_scripts/submit_slurm.py
+++ b/launch_scripts/submit_slurm.py
@@ -270,7 +270,7 @@ def fill_in_batch_script(
     else:
         cmd = f"python -OB {lute_executable} -c {args.config} -t {args.taskname}"
 
-    batch_script += f"srun --cpus-per-task=1 {cmd}\n"
+    batch_script += f"{cmd}\n"
 
     return batch_script
 

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -769,6 +769,12 @@ class BaseExecutor(ABC):
         else:
             status_str = "COMPLETED"
 
+        hostfile: Optional[str] = os.getenv("LUTE_MPI_HOSTFILE_PATH")
+        if hostfile is not None:
+            if os.path.exists(hostfile):
+                logger.debug(f"Removing hostfile: {hostfile}.")
+                os.remove(hostfile)
+
         if self._lute_manager_url is not None:
             json_data = {
                 "managed_task": self._m_task_name,

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -772,7 +772,7 @@ class BaseExecutor(ABC):
         hostfile: Optional[str] = os.getenv("LUTE_MPI_HOSTFILE_PATH")
         if hostfile is not None:
             if os.path.exists(hostfile):
-                logger.debug(f"Removing hostfile: {hostfile}.")
+                logger.debug(f"Removing (temporary) MPI hostfile: {hostfile}.")
                 os.remove(hostfile)
 
         if self._lute_manager_url is not None:

--- a/lute/execution/ipc.py
+++ b/lute/execution/ipc.py
@@ -214,9 +214,16 @@ class PipeCommunicator(Communicator):
             proc.stdout.read() if proc.stdout is not None else None
         )
         if raw_signal is not None:
-            signal = raw_signal.decode()
+            try:
+                signal = raw_signal.decode()
+            except UnicodeDecodeError:
+                logger.debug(
+                    "PipeCommunicator (Executor) - Stderr signal contains non-UTF-8 bytes. "
+                    "Decoding with errors='replace'."
+                )
+                signal = raw_signal.decode(errors="replace")
         else:
-            signal = raw_signal
+            signal = None
         if raw_contents:
             if self._use_pickle:
                 try:

--- a/lute/execution/launch.py
+++ b/lute/execution/launch.py
@@ -155,7 +155,7 @@ def setup_launch_env(args: argparse.Namespace) -> EnvLaunchInfo:
     Returns:
         env_cmd_vars (EnvLaunchInfo): A dictionary of variables which will
             be passed either via environment or command-line to the job submission
-            scripts (submit_slurm.sh) during workflow execution.
+            scripts (submit_slurm) during workflow execution.
     """
     cache_file: Optional[str] = os.getenv("KRB5CCNAME")
 

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -4,6 +4,8 @@ Executor-managed Tasks with specific environment specifications are defined
 here.
 """
 
+import os
+
 from lute.execution.executor import Executor, MPIExecutor
 from lute.tasks.util.environment import setup_smd2_env
 from lute.tasks.tasklets import (
@@ -55,7 +57,7 @@ SmallDataProducer2.shell_source(
 )
 SmallDataProducer2.add_tasklet(
     clone_smalldata,
-    ["{{ producer }}"],
+    ["{{ producer }}", f"{os.getenv('LUTE_PATH')}/config/templates/smd.patch"],
     when="before",
     set_result=False,
     set_summary=False,

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -44,7 +44,7 @@ SmallDataProducer: Executor = Executor("SubmitSMD")
 """Runs the production of a LCLS1 smalldata HDF5 file."""
 SmallDataProducer.add_tasklet(
     clone_smalldata,
-    ["{{ producer }}"],
+    ["{{ producer }}", f"{os.getenv('LUTE_PATH')}/config/templates/smd.patch"],
     when="before",
     set_result=False,
     set_summary=False,

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -532,6 +532,8 @@ class ThirdPartyTask(Task):
             "MPIEXEC_HOSTFILE": hostfile_path,  # Not sure if this exists/is needed?
             # Can turn this on for debugging - display MPI's discovered resources
             # "PRTE_MCA_rmaps_base_display_allocation": "1",
+            # Can turn this on for debugging - report how ranks are bound
+            # "OMPI_MCA_hwloc_base_report_bindings": "1",
             "PRTE_MCA_plm_rsh_pass_path": "1",
         }
 

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -501,51 +501,38 @@ class ThirdPartyTask(Task):
         self._report_to_executor(msg)
 
     def _non_slurm_mpi_mods(self, task_env: Dict[str, str]) -> Dict[str, str]:
+        """Configure MPI to use a hostfile for resource determination.
+
+        In the event the ThirdPartyTask is calling `mpirun` or similar, the automated
+        resource determination can fail inside the SLURM job depending on the
+        environment and/or MPI version. By using a hostfile, the resources can
+        always be determined. The execution layer sets this up before hand
+        and defines the `LUTE_MPI_HOSTFILE_PATH` environment variable.
+
+        Args:
+            task_env (Dict[str, str]): The new Task environment. It should already
+                be processed (e.g. LUTE_TENV_ removal). It will be checked for the
+                `LUTE_MPI_HOSTFILE_PATH` environment variable.
+
+        Returns:
+            mpi_updates (Dict[str, str]): A set of new environment variables which
+                should be added to the Task environment dictionary for MPI
+                configuration.
+        """
         hostfile_path: Optional[str] = task_env.get("LUTE_MPI_HOSTFILE_PATH")
         if hostfile_path is None:
             return {}
 
-        critical_vars: Set[str] = {
-            "PATH",
-            "PYTHONPATH",
-            "CONDA_PREFIX",
-            "LD_LIBRARY_PATH",
-            "LUTE_CONFIG",
-            "LUTE_CONFIGPATH",
-            "EXPERIMENT",
-            "RUN_NUM",
-            "SLURM_JOB_ID",
-            "SLURM_NPROCS",
-            "SLURM_NTASKS",
-            "SLURM_JOB_NODELIST",
-        }
-
-        export_parts: List[str] = []
-        for key, val in task_env.items():
-            # if "CONDA" in key or "LUTE" in key or key in critical_vars or "PS_" in key:
-            #    # Add to the export string (verified semicolon format)
-            #    export_parts.append(f"{key}={val}")
-            if key in critical_vars or "SLURM_" not in key:
-                export_parts.append(f"{key}={val}")
-
-        # export_str = ";".join(export_parts)
-
         mca_config: Dict[str, str] = {
-            # Use hostfile and EXPLICITLY EXCLUDE the native Slurm component
-            # "PRTE_MCA_ras": "hostfile,^slurm",
-            # "PRTE_MCA_ras": "^slurm",
             "PRTE_MCA_ras_slurm_priority": "0",
-            # Enable overlapping steps for srun calls within the job
             "PRTE_MCA_plm": "slurm",
             "PRTE_MCA_plm_slurm_args": "--overlap --export=ALL",
             "PRTE_MCA_prte_default_hostfile": hostfile_path,
             "OMPI_MCA_orte_default_hostfile": hostfile_path,
-            "MPIEXEC_HOSTFILE": hostfile_path,
+            "MPIEXEC_HOSTFILE": hostfile_path,  # Not sure if this exists/is needed?
+            # Can turn this on for debugging - display MPI's discovered resources
             # "PRTE_MCA_rmaps_base_display_allocation": "1",
-            # "PRTE_MCA_prte_base_export_env_vars": export_str,
             "PRTE_MCA_plm_rsh_pass_path": "1",
-            # "PRTE_MCA_plm_rsh_no_tree_spawn": "1",
-            # "OMPI_MCA_plm_rsh_no_tree_spawn": "1",
         }
 
         return mca_config
@@ -558,6 +545,9 @@ class ThirdPartyTask(Task):
                 # Set if using a custom environment
                 new_key: str = key[10:]
                 new_env[new_key] = value
+            # SLURM vars and the hostfile are needed for MPI
+            elif "SLURM_" in key:
+                new_env[key] = value
             elif key == "LUTE_MPI_HOSTFILE_PATH":
                 mpi_hostfile = value
         if not new_env:

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -523,6 +523,8 @@ class ThirdPartyTask(Task):
         if hostfile_path is None:
             return {}
 
+        # You may find some info here: https://docs.open-mpi.org/en/v5.0.7/mca.html
+        # BUT - things change between versions. Tread carefully...
         mca_config: Dict[str, str] = {
             "PRTE_MCA_ras_slurm_priority": "0",
             "PRTE_MCA_plm": "slurm",

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -482,6 +482,7 @@ class ThirdPartyTask(Task):
             self._report_to_executor(msg)
         LUTE_DEBUG_EXIT("LUTE_DEBUG_BEFORE_TPP_EXEC")
         task_env: Dict[str, str] = self._setup_env()
+        task_env.update(self._non_slurm_mpi_mods(task_env=task_env))
         sys.stdout.flush()
         sys.stderr.flush()
         os.execvpe(file=self._cmd, args=self._args_list, env=task_env)
@@ -499,14 +500,71 @@ class ThirdPartyTask(Task):
         msg: Message = Message(signal=signal)
         self._report_to_executor(msg)
 
+    def _non_slurm_mpi_mods(self, task_env: Dict[str, str]) -> Dict[str, str]:
+        hostfile_path: Optional[str] = task_env.get("LUTE_MPI_HOSTFILE_PATH")
+        if hostfile_path is None:
+            return {}
+
+        critical_vars: Set[str] = {
+            "PATH",
+            "PYTHONPATH",
+            "CONDA_PREFIX",
+            "LD_LIBRARY_PATH",
+            "LUTE_CONFIG",
+            "LUTE_CONFIGPATH",
+            "EXPERIMENT",
+            "RUN_NUM",
+            "SLURM_JOB_ID",
+            "SLURM_NPROCS",
+            "SLURM_NTASKS",
+            "SLURM_JOB_NODELIST",
+        }
+
+        export_parts: List[str] = []
+        for key, val in task_env.items():
+            # if "CONDA" in key or "LUTE" in key or key in critical_vars or "PS_" in key:
+            #    # Add to the export string (verified semicolon format)
+            #    export_parts.append(f"{key}={val}")
+            if key in critical_vars or "SLURM_" not in key:
+                export_parts.append(f"{key}={val}")
+
+        # export_str = ";".join(export_parts)
+
+        mca_config: Dict[str, str] = {
+            # Use hostfile and EXPLICITLY EXCLUDE the native Slurm component
+            # "PRTE_MCA_ras": "hostfile,^slurm",
+            # "PRTE_MCA_ras": "^slurm",
+            "PRTE_MCA_ras_slurm_priority": "0",
+            # Enable overlapping steps for srun calls within the job
+            "PRTE_MCA_plm": "slurm",
+            "PRTE_MCA_plm_slurm_args": "--overlap --export=ALL",
+            "PRTE_MCA_prte_default_hostfile": hostfile_path,
+            "OMPI_MCA_orte_default_hostfile": hostfile_path,
+            "MPIEXEC_HOSTFILE": hostfile_path,
+            # "PRTE_MCA_rmaps_base_display_allocation": "1",
+            # "PRTE_MCA_prte_base_export_env_vars": export_str,
+            "PRTE_MCA_plm_rsh_pass_path": "1",
+            # "PRTE_MCA_plm_rsh_no_tree_spawn": "1",
+            # "OMPI_MCA_plm_rsh_no_tree_spawn": "1",
+        }
+
+        return mca_config
+
     def _setup_env(self) -> Dict[str, str]:
         new_env: Dict[str, str] = {}
+        mpi_hostfile: str = ""
         for key, value in os.environ.items():
             if "LUTE_TENV_" in key:
                 # Set if using a custom environment
                 new_key: str = key[10:]
                 new_env[new_key] = value
+            elif key == "LUTE_MPI_HOSTFILE_PATH":
+                mpi_hostfile = value
         if not new_env:
             # No shell script sourced - will use the base environment
-            return os.environ.copy()
+            new_env = os.environ.copy()
+
+        if mpi_hostfile:
+            new_env["LUTE_MPI_HOSTFILE_PATH"] = mpi_hostfile
+
         return new_env

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -542,9 +542,11 @@ class ThirdPartyTask(Task):
     def _setup_env(self) -> Dict[str, str]:
         new_env: Dict[str, str] = {}
         mpi_hostfile: str = ""
+        found_tenv: bool = False
         for key, value in os.environ.items():
             if "LUTE_TENV_" in key:
                 # Set if using a custom environment
+                found_tenv = True
                 new_key: str = key[10:]
                 new_env[new_key] = value
             # SLURM vars and the hostfile are needed for MPI
@@ -552,8 +554,9 @@ class ThirdPartyTask(Task):
                 new_env[key] = value
             elif key == "LUTE_MPI_HOSTFILE_PATH":
                 mpi_hostfile = value
-        if not new_env:
+        if not found_tenv:
             # No shell script sourced - will use the base environment
+            # The SLURM_ keys will be in this copy.
             new_env = os.environ.copy()
 
         if mpi_hostfile:

--- a/lute/tasks/tasklets.py
+++ b/lute/tasks/tasklets.py
@@ -113,7 +113,9 @@ def modify_permissions(path: str, permissions: int) -> None:
             os.chmod(os.path.join(root, f), permissions)
 
 
-def git_clone(repo: str, location: str, permissions: int) -> None:
+def git_clone(
+    repo: str, location: str, permissions: int, patch: Optional[str] = None
+) -> None:
     """Clone a git repository.
 
     Will not overwrite a directory of there is already a folder at the specified
@@ -126,6 +128,8 @@ def git_clone(repo: str, location: str, permissions: int) -> None:
         location (str): Path to the location to clone to.
 
         permissions (str): Permissions to set on the repository.
+
+        patch (Optional[str]): The path to a patch to apply (if desired).
     """
     repo_only: str = repo.split("/")[1]
     if os.path.exists(f"{location}/{repo_only}"):
@@ -143,20 +147,44 @@ def git_clone(repo: str, location: str, permissions: int) -> None:
     out, _ = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
     ).communicate()
+
+    # Apply patch if requested
+    if patch is not None:
+        if not os.path.exists(patch):
+            logger.warning(f"Patch requested, but path does not exist: {patch}")
+        else:
+            cwd: str = os.getcwd()
+            os.chdir(f"{location}/{repo_only}")
+            patch_cmd: List[str] = [
+                "git",
+                "apply",
+                patch,
+            ]
+            subprocess.Popen(
+                patch_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            ).communicate()
+            logger.debug(f"Applied patch ({patch}) to {location}/{repo_only}.")
+            os.chdir(cwd)
+
     modify_permissions(f"{location}/{repo_only}", permissions)
 
 
-def clone_smalldata(producer_location: str) -> None:
+def clone_smalldata(producer_location: str, patch: Optional[str] = None) -> None:
     """Clone smalldata_tools based on producer location.
 
     Args:
         producer_location (str): Full path to the producer to be used.
+
+        patch (Optional[str]): The path to a patch to apply (if desired).
     """
     from pathlib import Path
 
     repo: str = "slac-lcls/smalldata_tools"
     location: str = str(Path(producer_location).parent.parent.parent)
-    git_clone(repo, location, 0o777)
+    git_clone(repo, location, 0o777, patch)
 
 
 def grep(match_str: str, in_file: str) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ subprocess_task = "subprocess_task:main"
 launch_airflow = "launch_scripts.launch_airflow:main"
 launch_prefect = "launch_scripts.launch_prefect:main"
 launch_slurm = "launch_scripts.launch_maestro:main"
+submit_slurm = "launch_scripts.submit_slurm:main"
 ## *** NOTE: The following are in different packages in installed directories vs repo
 ## I.e. utilties -> lute_utilities
 setup_lute = "lute_utilities.setup.setup_lute:main"
@@ -60,7 +61,7 @@ script-files = [
     "launch_scripts/submit_launch_airflow.sh",
     "launch_scripts/submit_launch_prefect.sh",
     "launch_scripts/submit_launch_slurm.sh",
-    "launch_scripts/submit_slurm.sh",
+    # "launch_scripts/submit_slurm.sh",
 ]
 
 [tool.black]

--- a/run_task.py
+++ b/run_task.py
@@ -17,32 +17,14 @@ else:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+def setup_mpi_hostfile() -> None:
+    """Prepare a hostfile for MPI if running in a SLURM job.
 
-def main() -> None:
-    parser: argparse.ArgumentParser = argparse.ArgumentParser(
-        prog="run_managed_task",
-        description="Run a LUTE managed task.",
-        epilog="Refer to https://github.com/slac-lcls/lute for more information.",
-    )
-    parser.add_argument(
-        "-c", "--config", type=str, help="Path to config file with Task parameters."
-    )
-    parser.add_argument(
-        "-t",
-        "--taskname",
-        type=str,
-        help="Name of the Managed Task to run.",
-        default="test",
-    )
-
-    args: argparse.Namespace = parser.parse_args()
-    config: str = args.config
-    task_name: str = args.taskname
-
-    # Environment variables need to be set before importing Executors
-    os.environ["LUTE_CONFIGPATH"] = config
-
-    # Setup SLURM env host file to facilitate MPI stuff
+    This function creates a hostfile and sets an environment variable to the path
+    where it was created. The hostfile can be used by Tasks that use MPI to determine
+    available resources in a SLURM allocation. Depending on environment configuration
+    and/or MPI version, the automated MPI mechanism may not work.
+    """
     nodelist: str = os.getenv("SLURM_JOB_NODELIST", "")
     if nodelist:
         result: subprocess.CompletedProcess = subprocess.run(
@@ -70,6 +52,8 @@ def main() -> None:
         hostfile_path: str = os.path.abspath(f"lute_hostfile_{job_id}.hosts")
         executor_host: str = socket.gethostname()
         with open(hostfile_path, "w") as f:
+            node: str
+            tpn: int
             for node, tpn in zip(nodes, tpn_list):
                 n_slots: int
                 if node == executor_host:
@@ -78,7 +62,36 @@ def main() -> None:
                     n_slots = tpn
                 f.write(f"{node} slots={n_slots}\n")
 
+        # Task layer will look for this environment variable
         os.environ["LUTE_MPI_HOSTFILE_PATH"] = hostfile_path
+
+
+def main() -> None:
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        prog="run_managed_task",
+        description="Run a LUTE managed task.",
+        epilog="Refer to https://github.com/slac-lcls/lute for more information.",
+    )
+    parser.add_argument(
+        "-c", "--config", type=str, help="Path to config file with Task parameters."
+    )
+    parser.add_argument(
+        "-t",
+        "--taskname",
+        type=str,
+        help="Name of the Managed Task to run.",
+        default="test",
+    )
+
+    args: argparse.Namespace = parser.parse_args()
+    config: str = args.config
+    task_name: str = args.taskname
+
+    # Environment variables need to be set before importing Executors
+    os.environ["LUTE_CONFIGPATH"] = config
+
+    # Prepare hostfile in case using MPI
+    setup_mpi_hostfile()
 
     if hasattr(managed_tasks, task_name):
         managed_task: Executor = getattr(managed_tasks, task_name)

--- a/run_task.py
+++ b/run_task.py
@@ -17,6 +17,7 @@ else:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+
 def setup_mpi_hostfile() -> None:
     """Prepare a hostfile for MPI if running in a SLURM job.
 
@@ -51,16 +52,35 @@ def setup_mpi_hostfile() -> None:
         assert isinstance(job_id, str)
         hostfile_path: str = os.path.abspath(f"lute_hostfile_{job_id}.hosts")
         executor_host: str = socket.gethostname()
+
+        # Setup MPI core affinity. The Task tries to do this as well, but MPI
+        # ignores (sometimes). The `Executor` will pin later (in `execute_task`)
+        # since the core counts may be used by various calculations.
+        mpi_cpuset: str = ""
+        try:
+            available_cores: List[int] = sorted(list(os.sched_getaffinity(0)))
+            if len(available_cores) > 1:
+                mpi_cpuset = ",".join(map(str, available_cores[1:]))
+                logger.debug(f"MPI cpuset for {executor_host}: {mpi_cpuset}")
+            else:
+                logger.warning(
+                    f"Only one core available on {executor_host} - the Executor "
+                    "and Task will share it."
+                )
+        except Exception as e:
+            logger.warning(f"Could not determine CPU affinity: {e}")
+
         with open(hostfile_path, "w") as f:
             node: str
             tpn: int
             for node, tpn in zip(nodes, tpn_list):
-                n_slots: int
-                if node == executor_host:
+                if node == executor_host and mpi_cpuset:
+                    # Explicitly assign the reserved core list to this node
                     n_slots = tpn - 1
+                    f.write(f"{node} slots={n_slots} cpuset={mpi_cpuset}\n")
                 else:
                     n_slots = tpn
-                f.write(f"{node} slots={n_slots}\n")
+                    f.write(f"{node} slots={n_slots}\n")
 
         # Task layer will look for this environment variable
         os.environ["LUTE_MPI_HOSTFILE_PATH"] = hostfile_path

--- a/run_task.py
+++ b/run_task.py
@@ -1,8 +1,11 @@
-import sys
 import argparse
 import logging
 import os
-from typing import List
+import re
+import socket
+import subprocess
+import sys
+from typing import List, Optional
 
 from lute.execution.executor import BaseExecutor, Executor
 from lute import managed_tasks
@@ -13,6 +16,7 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 logger: logging.Logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
@@ -37,6 +41,44 @@ def main() -> None:
 
     # Environment variables need to be set before importing Executors
     os.environ["LUTE_CONFIGPATH"] = config
+
+    # Setup SLURM env host file to facilitate MPI stuff
+    nodelist: str = os.getenv("SLURM_JOB_NODELIST", "")
+    if nodelist:
+        result: subprocess.CompletedProcess = subprocess.run(
+            ["scontrol", "show", "hostnames", nodelist],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        nodes: List[str] = result.stdout.splitlines()
+        tpn_str: str = os.getenv("SLURM_TASKS_PER_NODE", "")
+        tpn_list: List[int] = []
+        for part in tpn_str.split(","):
+            m: Optional[re.Match] = re.match(r"(\d+)\(x(\d+)\)", part)
+            if m:
+                tasks: int = int(m.group(1))
+                count: int = int(m.group(2))
+                tpn_list.extend([tasks] * count)
+            else:
+                try:
+                    tpn_list.append(int(part))
+                except ValueError:
+                    pass
+        job_id: Optional[str] = os.getenv("SLURM_JOB_ID")
+        assert isinstance(job_id, str)
+        hostfile_path: str = os.path.abspath(f"lute_hostfile_{job_id}.hosts")
+        executor_host: str = socket.gethostname()
+        with open(hostfile_path, "w") as f:
+            for node, tpn in zip(nodes, tpn_list):
+                n_slots: int
+                if node == executor_host:
+                    n_slots = tpn - 1
+                else:
+                    n_slots = tpn
+                f.write(f"{node} slots={n_slots}\n")
+
+        os.environ["LUTE_MPI_HOSTFILE_PATH"] = hostfile_path
 
     if hasattr(managed_tasks, task_name):
         managed_task: Executor = getattr(managed_tasks, task_name)
@@ -64,6 +106,7 @@ def main() -> None:
 
     managed_task._m_task_name = task_name
     managed_task.execute_task()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -18,4 +18,5 @@
 | smd_xpp_default | SmallDataProducer     | xpptut15     | 650 | xpplv9818 run 127. This is to test default production only.           |
 | smd_mfx_default | SmallDataProducer     | mfxx49820    | 15  | Default small data production                                         |
 | smd2_mfx_prod   | SmallDataProducer2    | mfx101344525 | 70  | LCLS2 non-default SMD (MFX).                                          |
+| smd2_multi_node | SmallDataProducer2    | mfx101262725 | 96  | LCLS2 non-default SMD (MFX) submitted across multiple nodes.          |
 |                 |                       |              |     |                                                                       |

--- a/tests/functional/smd2_multi_node/README.md
+++ b/tests/functional/smd2_multi_node/README.md
@@ -1,0 +1,3 @@
+# SMD2 Multi-node Production
+Test for `smalldata_tools` using `SmallDataProducer2` across multiple nodes.
+

--- a/tests/functional/smd2_multi_node/config.yaml
+++ b/tests/functional/smd2_multi_node/config.yaml
@@ -1,0 +1,89 @@
+%YAML 1.3
+---
+title: "Multi-node T-Jump Analysis Configuration"
+experiment: "mfx101262725"
+run: 96
+date: "2026/02/03"
+lute_version: 0.1
+task_timeout: 6000
+work_dir: "/tmp"
+...
+---
+###########
+# Smalldata
+###########
+# Producer will be auto-determined. Set only if you have a separate install
+# Set `directory` if you want to write to a different folder
+# For out of memory issues try setting gather_interval
+SubmitSMD:
+  # Command line arguments
+  producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  #run: 99
+  #experiment: ""
+  #stn: 0
+  directory: "{{ work_dir }}"
+  #config: "mfx_cctbx"
+  gather_interval: 5
+  nevents: 5000
+  #norecorder: False
+  #url: "https://pswww.slac.stanford.edu"
+  #epicsAll: False
+  #full: False
+  #fullSum: False
+  #default: true
+  #image: False
+  #tiff: False
+  #centerpix: False
+  #postRuntable: False
+  #wait: False
+  #xtcav: False
+  #noarch: False
+  # **************************************************************************/
+  # * Below this point you will be configuring the prod_config_mfx file ******/
+  # * This will overwrite any manual changes you make to that file      ******/
+  # * Comment all the rest of these parameters out to manually edit     ******/
+  # **************************************************************************/
+  # Producer variables. These are substituted into the producer to run specific
+  # data reduction algorithms. Uncomment and modify as needed.
+  # If you prefer to modify the producer file directly, leave commented.
+  # Beginning with `getROIs`, you will need to modify the first entry to be a
+  # detector. This detector MUST MATCH one of the detectors in `detnames`.
+  # In the future this will be automated. If you have multiple detectors you can
+  # add them with their own set of parameters.
+  detnames: ["jungfrau","epix100_0", "qadc"]
+  #epicsPV: []
+  epicsArchFilePV:
+    - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
+    - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
+    - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
+    - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
+    - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
+    - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
+    - ["MFX:LAS:MMN:11.RBV",'lens_h']
+    - ["MFX:LAS:MMN:12.RBV",'lens_v']
+  getAzIntParams:
+    jungfrau:
+      eBeam: 12.965
+      center: [-1107, 918]
+      dis_to_sam: 155.5
+      phiBins: 11
+      qbin: 0.02
+      tx: 0
+      ty: 0
+
+AnalyzeSmallDataXSS:
+  # smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection
+  xss_detname: "jungfrau"  # Name of detector with scattering signal
+  ipm_var: "MfxDg2BmMon/totalIntensityJoules"       # ipm PV to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lens_v"
+    - "lens_h"
+    - "lens_g"
+  # Thresholds used for data filtering
+  thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+...

--- a/tests/functional/smd2_multi_node/dag.yaml
+++ b/tests/functional/smd2_multi_node/dag.yaml
@@ -1,0 +1,8 @@
+!LUTE_DAG
+task_name: SmallDataProducer2
+slurm_params: '--account=lcls:data --partition=milano --ntasks-per-node=50 --nodes=4 --exclusive'
+next:
+- !ALWAYS
+  task_name: SmallDataXSSAnalyzer
+  slurm_params: '--account=lcls:data --partition=milano'
+  next: []

--- a/tests/functional/smd2_multi_node/dag.yaml
+++ b/tests/functional/smd2_multi_node/dag.yaml
@@ -2,7 +2,6 @@
 task_name: SmallDataProducer2
 slurm_params: '--account=lcls:data --partition=milano --ntasks-per-node=50 --nodes=4 --exclusive'
 next:
-- !ALWAYS
-  task_name: SmallDataXSSAnalyzer
+- task_name: SmallDataXSSAnalyzer
   slurm_params: '--account=lcls:data --partition=milano'
   next: []

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -24,7 +24,6 @@ from typing import (
     overload,
 )
 
-import yaml
 import json
 import requests
 import socket
@@ -805,6 +804,17 @@ if __name__ == "__main__":
         ),
         action="store_true",
     )
+    # Whether to allow output location to exist or not
+    # To avoid accidental overwrites, by default we exit if the output location
+    # already existed prior to running tests
+    parser.add_argument(
+        "--exist_ok",
+        help=(
+            "If passed, tests will continue even if the determined output directory "
+            "already existed. It is possible things may be overwritten in this case."
+        ),
+        action="store_true",
+    )
 
     args: argparse.Namespace
     extra_args: List[str]
@@ -837,13 +847,22 @@ if __name__ == "__main__":
             logger.info("Running LUTE from dev branch.")
         lute_location = f"{run_dir}/lute"
     else:
-        run_dir =  os.path.abspath(f"{os.path.dirname(__file__)}/../..")
+        run_dir = os.path.abspath(f"{os.path.dirname(__file__)}/../..")
         lute_location = os.path.abspath(f"{os.path.dirname(__file__)}/..")
 
     output_location: str = f"{run_dir}/lute_output"
     logger.info(f"Will write output to {output_location}")
-    os.makedirs(output_location, mode=0o777)
-    os.chmod(output_location, mode=0o777)
+    if not os.path.exists(output_location):
+        os.makedirs(output_location, mode=0o777)
+        os.chmod(output_location, mode=0o777)
+    else:
+        if not args.exist_ok:
+            logger.error(
+                f"Output location ({output_location}) already exists! Exiting now. "
+                "If you intended this, you can resubmit with the `--exist_ok` flag."
+            )
+            sys.exit(-1)
+        logger.warning(f"Output location ({output_location}) already exists.")
 
     func_tests_dir: str
     if args.tests_dir is not None:

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -837,8 +837,8 @@ if __name__ == "__main__":
             logger.info("Running LUTE from dev branch.")
         lute_location = f"{run_dir}/lute"
     else:
-        run_dir =  f"{os.path.dirname(__file__)}/../.."
-        lute_location = f"{os.path.dirname(__file__)}/.."
+        run_dir =  os.path.abspath(f"{os.path.dirname(__file__)}/../..")
+        lute_location = os.path.abspath(f"{os.path.dirname(__file__)}/..")
 
     output_location: str = f"{run_dir}/lute_output"
     logger.info(f"Will write output to {output_location}")

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+from lute.execution.ipc import Message, PipeCommunicator, Party
+
+
+def test_pipe_communicator_non_utf():
+    """Verify that PipeCommunicator handles non-UTF-8 bytes on stderr gracefully."""
+    comm: PipeCommunicator = PipeCommunicator(party=Party.EXECUTOR, use_pickle=False)
+
+    # Mock subprocess.Popen
+    mock_proc: MagicMock = MagicMock()
+
+    # Simulate junk on stderr that is not valid UTF-8 - we saw 0x94 before
+    bad_bytes: bytes = b"Some signal \x94 and more text"
+    mock_proc.stderr.read.return_value = bad_bytes
+    mock_proc.stdout.read.return_value = b"Normal stdout content"
+
+    msg: Message = comm.read(mock_proc)
+
+    # Non LUTE_SIGNAL should be moved into msg.contents
+    assert msg.signal is None
+    # \ufffd is the replacement character used for invalid UTF-8
+    assert "Some signal \ufffd and more text" in msg.contents
+    assert "Normal stdout content" in msg.contents
+
+
+def test_pipe_communicator_no_signals():
+    """Verify standard read without signals."""
+    comm: PipeCommunicator = PipeCommunicator(party=Party.EXECUTOR, use_pickle=False)
+    mock_proc: MagicMock = MagicMock()
+    mock_proc.stderr.read.return_value = b""
+    mock_proc.stdout.read.return_value = b"Hello World"
+
+    msg: Message = comm.read(mock_proc)
+    assert msg.signal == "" or msg.signal is None
+    assert msg.contents == "Hello World"

--- a/workflows/airflow/operators/jidoperators.py
+++ b/workflows/airflow/operators/jidoperators.py
@@ -288,7 +288,7 @@ class JIDSlurmOperator(BaseOperator):
         jid_job_definition: Dict[str, str] = {
             "_id": str(uuid.uuid4()),
             "name": self.lute_task_id,
-            "executable": f"{self.lute_location}/{executable_subdir}/submit_slurm.sh",
+            "executable": f"{self.lute_location}/{executable_subdir}/submit_slurm",
             "trigger": "MANUAL",
             "location": dagrun_config.get("ARP_LOCATION", "S3DF"),
             "parameters": parameter_str,

--- a/workflows/maestro/src/lwm/launcher.cc
+++ b/workflows/maestro/src/lwm/launcher.cc
@@ -341,7 +341,7 @@ namespace LWM {
     //if (job.parameters.executable_subdir == "launch_")
     std::string executable =
       job.parameters.lute_location + "/" + job.parameters.executable_subdir
-      + "/submit_slurm.sh";
+      + "/submit_slurm";
 
     std::string config_file = job.parameters.config_file;
     std::string param_str =

--- a/workflows/prefect/tasks/jidtasks.py
+++ b/workflows/prefect/tasks/jidtasks.py
@@ -192,7 +192,7 @@ def create_control_doc(
     jid_job_definition: Dict[str, str] = {
         "_id": str(uuid.uuid4()),
         "name": lute_task_id,
-        "executable": f"{lute_location}/{executable_subdir}/submit_slurm.sh",
+        "executable": f"{lute_location}/{executable_subdir}/submit_slurm",
         "trigger": "MANUAL",
         "location": conf.get("ARP_LOCATION", "S3DF"),
         "parameters": parameter_str,


### PR DESCRIPTION
# Description

This PR switches the `submit_slurm.sh` script to a `submit_slurm.py` script. This new script will generate a temporary batch script which does submission using `srun`. An MPI hostfile is also created which explicitly lists resources (including cpuset) in case a `Task` will use MPI.

This PR also address a minor IPC pipe issue.

A "patch" functionality for clone tasklets allows application of small edits to cloned repositories. Tests now pass as expected.
 
## Checklist
- [x] `submit_slurm.py` submission script which uses `srun`. Update `maestro` for the change.
- [x] Fix IPC issue
- [x] Add functional test on multiple nodes (`smd2_multi_node`). Add some `UnicodeDecodeError` unit tests (`test_ipc.py`).
- [x] Add "patch" functionality for clone tasklets.

## PR Type:
- [x] Utility
- [x] Bug fix

## Address issues:
- NA

# Testing
## Functional
**With the "patch" functionality, functional smalldata_tools components tests should pass now.** The XSS analysis in one workflow fails. But this will be worked on separately.

```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/scratch --no_delete --partition=milano --account=lcls:data
Sourced latest psconda.sh
# .... #
Submitted batch job 20199727
> tail -f slurm-20199727.out 
# ...
INFO:Launch_Func_Tests:Running test: basic_tests
INFO:Launch_Func_Tests:experiment: "xpptut15"

INFO:Launch_Func_Tests:run: 670

Unable to retrieve run document! No `run_type` information will be used! No information about psana1/psana2 can be retrieved.
[2026-02-04 10:33:21.378] [LWM:Manager] [info] Running workflows with SlurmLauncher.
# ...
[2026-02-04 10:36:19.188] [LWM:Manager] [error] Exiting after workflow failed! [5/6 succeeded]
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
INFO:Launch_Func_Tests:Test workflow basic_tests was unsuccessful but this is marked as intentional.
INFO:Launch_Func_Tests:Running test: smd_xpp_default
INFO:Launch_Func_Tests:experiment: "xpptut15"

INFO:Launch_Func_Tests:run: 650

Unable to retrieve run document! No `run_type` information will be used! No information about psana1/psana2 can be retrieved.
[2026-02-04 10:36:19.667] [LWM:Manager] [info] Running workflows with SlurmLauncher.
# ...
INFO:lute.execution.executor:Exiting after Task completion.

Time SmallDataProducer spent: 
- Pending: 52 s
- Running: 141 s
[2026-02-04 10:39:34.114] [HTTP:Server] [info] Shutting down server...
[2026-02-04 10:39:34.114] [HTTP:Server] [info] All server threads exited.
[2026-02-04 10:39:34.114] [LWM:Manager] [info] Exiting after workflow completed successfully.
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow smd_xpp_default completed successfully.
INFO:Launch_Func_Tests:Running test: smd2_mfx_prod
INFO:Launch_Func_Tests:experiment: "mfx101344525"

INFO:Launch_Func_Tests:run: 90

[2026-02-04 10:39:34.601] [LWM:Manager] [info] Running workflows with SlurmLauncher.
[2026-02-04 10:39:34.602] [HTTP:Server] [info] Starting server on 0.0.0.0:41239 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 10:39:34.602] [LWM:Manager] [info] Beginning workflow.
# ....
# ... and so on ....
# Final result:

[2026-02-04 10:49:47.491] [HTTP:Server] [info] Shutting down server...
[2026-02-04 10:49:47.491] [HTTP:Server] [info] All server threads exited.
[2026-02-04 10:49:47.491] [LWM:Manager] [error] Exiting after workflow failed! [1/2 succeeded]
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
ERROR:Launch_Func_Tests:Test workflow smd2_multi_node was unsuccessfull!
INFO:Launch_Func_Tests:Ran 5 tests. 4 were successful.
```


## Unit tests
```bash
> pytest tests/unit/
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/scratch/users/d/dorlhiac/work/lute_srun2
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 27 items                                                                                                                                                                                              

tests/unit/test_db_common.py .....                                                                                                                                                                        [ 18%]
tests/unit/test_db_v1.py .                                                                                                                                                                                [ 22%]
tests/unit/test_db_v2.py .                                                                                                                                                                                [ 25%]
tests/unit/test_executor.py ......                                                                                                                                                                        [ 48%]
tests/unit/test_ipc.py ..                                                                                                                                                                                 [ 55%]
tests/unit/test_launch_utils.py ....                                                                                                                                                                      [ 70%]
tests/unit/test_parsing.py .....                                                                                                                                                                          [ 88%]
tests/unit/test_task.py ...                                                                                                                                                                               [100%]

============================================================================================== 27 passed in 2.67s ===============================================================================================
> test_http
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
> test_server 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-02-04 09:52:02.796] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 09:52:02.796] [HTTP:Server] [info] Shutting down server...
[2026-02-04 09:52:02.796] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-02-04 09:52:02.796] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 09:52:02.897] [HTTP:Server] [info] Shutting down server...
[2026-02-04 09:52:02.897] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-02-04 09:52:02.897] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 09:52:02.998] [HTTP:Server] [info] Shutting down server...
[2026-02-04 09:52:02.998] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (202 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (202 ms total)
[  PASSED  ] 3 tests.
```

# Screenshots
NA
