### PR TITLE
UTL Update `build.sh` for fast incremental builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,133 @@
 #!/usr/bin/env bash
-mkdir -p install
+set -e
 
+## This build script will create an isolated build environment, and cache it for reuse
+## By caching, we can use `meson` (fast) to actually build C++ code.
+## `pip` gets used only at the very end to install the entry-points.
+
+# Bunch of functions to pretty print...
+center_text() {
+    local TEXT="$1"
+    local WIDTH="$2"
+    local LEN=${#TEXT}
+    if (( LEN >= WIDTH )); then
+        echo "===== ${TEXT} ====="
+    else
+        # Calculate spaces on each side
+        local PAD_SIZE=$(( (WIDTH - LEN) / 2 + 5))
+        NEW_LINE=$(printf "%*s%s%*s\n" "${PAD_SIZE}" "" "${TEXT}" "$((WIDTH - LEN - PAD_SIZE))" " ")
+        echo "===== ${NEW_LINE} ====="
+    fi
+}
+
+## Create a banner that looks like:
+## ===============================
+## =====         Line 1      =====
+## =====         Line 2      =====
+## =====         Line 3      =====
+## ===============================
+## For the LINES that are provided
+print_banner() {
+    local LINES=("$@")
+    local MAXLEN=0
+    local NEWLINES=()
+    for LINE in "${LINES[@]}"; do
+        NEWLINES+=("$LINE")
+        (( ${#LINE} > MAXLEN )) && MAXLEN=${#LINE}
+    done
+
+    local BORDERLEN=$((MAXLEN+12))
+    if (( BORDERLEN < 80)); then
+        BORDERLEN=80
+        MAXLEN=$((BORDERLEN - 12))
+    fi
+    # Print top border
+    printf '%*s\n' "${BORDERLEN}" '' | tr ' ' '='
+
+    # Print centered lines
+    for LINE in "${NEWLINES[@]}"; do
+        center_text "${LINE}" "${MAXLEN}"
+    done
+
+    printf '%*s\n' "${BORDERLEN}" '' | tr ' ' '='
+}
+
+
+# Determine build directories, install directory, and where to put the build env
+BASE_DIR="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )"
+BUILD_DIR="${BASE_DIR}/_build"
+INSTALL_DIR="${BASE_DIR}/install"
+
+# Virtual environment needs to be outside the source tree
+# Otherwise you get some path errors with meson
+# At least I couldn't figure out any other way to do it...
+BUILD_ENV="${HOME}/.cache/lute_build_env_$(echo ${BASE_DIR} | md5sum | cut -d' ' -f1)"
+
+mkdir -p "${INSTALL_DIR}"
+mkdir -p "${BUILD_DIR}"
+mkdir -p "${HOME}/.cache"
+
+# On S3DF get a standard Python3 - otherwise you're on your own
 if [[ $HOSTNAME =~ "sdf" ]]; then
+    LINES=("Sourcing the Psana1 environment (for Python3)")
+    print_banner "${LINES[@]}"
     source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 fi
 
-BASE_DIR="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )"
-INSTALL_DIR="${BASE_DIR}/install"
+# Create a build environment if it doesn't yet exist
+if [ ! -d "${BUILD_ENV}" ]; then
+    LINES=("Creating isolated build environment in ${BUILD_ENV}...")
+    print_banner "${LINES[@]}"
+    python3 -m venv "${BUILD_ENV}"
+    # Source before installing dependencies
+    source "${BUILD_ENV}/bin/activate"
+    pip install --upgrade pip
+    # Install the relevant build dependencies and nothing else
+    pip install "meson>=1.10.1" "meson-python" "ninja" "numpy" "pybind11" "setuptools"
+else
+    # If it already exists (you've run build.sh before) just activate it
+    LINES=("Activating build environment at ${BUILD_ENV}")
+    print_banner "${LINES[@]}"
+    source "${BUILD_ENV}/bin/activate"
+fi
 
-echo "Will build an installation of LUTE at ${INSTALL_DIR}"
-pip install . --prefix="${INSTALL_DIR}" --no-dependencies
+LINES=(
+    "Will build and installation of LUTE at ${INSTALL_DIR}"
+    "(Build cache available at: ${BUILD_DIR})"
+    "(Build environment available at: ${BUILD_ENV})"
+)
+
+print_banner "${LINES[@]}"
+
+# Run meson configure/setup if it hasn't be done yet.
+if [ ! -d "${BUILD_DIR}" ]; then
+    LINES=("Running meson setup for build configuration")
+    print_banner "${LINES[@]}"
+    meson setup "${BUILD_DIR}" --prefix="${INSTALL_DIR}" -Dbuildtype=release
+else
+    LINES=("Running meson setup configuration")
+    print_banner "${LINES[@]}"
+    # Reconfigure in case prefix or options changed, but keep cache
+    meson setup "${BUILD_DIR}" --reconfigure --prefix="${INSTALL_DIR}"
+fi
+
+# Build... This is mostly for `maestro` and C/C++ extensions
+LINES=("Compiling...")
+print_banner "${LINES[@]}"
+meson compile -C "${BUILD_DIR}"
+
+LINES=("Installing files in ${INSTALL_DIR}...")
+print_banner "${LINES[@]}"
+meson install -C "${BUILD_DIR}"
+
+# Run `pip` at the end - this gets the entrypoints defined in `pyproject.toml`
+# It can be pointed at the build directory to prevent `pip` from trying to rebuild
+# the rest of the stuff from scratch.
+
+LINES=("Creating Python entry points")
+print_banner "${LINES[@]}"
+pip install . \
+    --prefix="${INSTALL_DIR}" \
+    --no-dependencies \
+    --no-build-isolation \
+    --config-settings=build-dir="${BUILD_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -74,6 +74,9 @@ if [[ $HOSTNAME =~ "sdf" ]]; then
     source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 fi
 
+# Save host/conda env Python for later
+HOST_PYTHON=$(which python3)
+
 # Create a build environment if it doesn't yet exist
 if [ ! -d "${BUILD_ENV}" ]; then
     LINES=("Creating isolated build environment in ${BUILD_ENV}...")
@@ -124,9 +127,16 @@ meson install -C "${BUILD_DIR}"
 # It can be pointed at the build directory to prevent `pip` from trying to rebuild
 # the rest of the stuff from scratch.
 
+# We will also use the underlying Python (e.g. from psconda.sh)
+# This way, the build env can be kept small, and it can be deleted as well.
+# Otherwise, the Python scripts would end up pointing to the Python from that env.
 LINES=("Creating Python entry points")
 print_banner "${LINES[@]}"
-pip install . \
+
+BUILD_VENV_SITE_PACKAGES=(${BUILD_ENV}/lib/python*/site-packages)
+PYTHONPATH="${BUILD_VENV_SITE_PACKAGES}:${PYTHONPATH}" \
+PATH="${BUILD_ENV}/bin:${PATH}" \
+${HOST_PYTHON} -m pip install . \
     --prefix="${INSTALL_DIR}" \
     --no-dependencies \
     --no-build-isolation \

--- a/build.sh
+++ b/build.sh
@@ -2,21 +2,89 @@
 set -e
 
 ## This build script will create an isolated build environment, and cache it for reuse
-## By caching, we can use `meson` (fast) to actually build C++ code.
-## `pip` gets used only at the very end to install the entry-points.
+## By caching, we can use meson (fast) to actually build C++ code.
+## pip gets used only at the very end to install the entry-points.
+
+usage()
+{
+    cat << EOF
+$(basename "$0"):
+    Build an installation of LUTE.
+
+    This build script will create an isolated build environment. It is cached in
+    your home directory under ~/.cache/lute_build_env_XXXX where the final portion
+    is created from a hash of base installation directory.
+
+    Subsequent runs of the build will not need to re-create the build environment,
+    speeding up the process significantly. You can of course delete the build environment
+    from the specified folder at any time, and it will be recreated next time the script
+    is run. You can pass a parameter to this script to do cleanup as well.
+
+    Options:
+        -c|--clean
+          Clean up the build environment
+        -h|--help
+          Display this message.
+
+    Options that apply on subsequent runs of the build script:
+        -e|--entry_points
+          Re-run the pip install command. This is only needed if pyproject.toml is
+          modified.
+        -r|--reconfigure
+          Re-run the meson setup. This is only required if meson.build files have been
+          modified, or meson options/the install prefix have changed since the last
+          time it was run.
+EOF
+}
+
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]
+do
+    flag="$1"
+
+    case $flag in
+    -c|--clean)
+        NEED_CLEANUP=1
+        shift
+        ;;
+    -e|--entry_points)
+        NEED_ENTRYPOINTS=1
+        shift
+        ;;
+    -r|--reconfigure)
+        NEED_RECONFIG=1
+        shift
+        ;;
+    -h|--help)
+        usage
+        exit
+        ;;
+    *)
+        POS+=("$1")
+        shift
+        ;;
+    esac
+done
+set -- "${POS[@]}"
 
 # Bunch of functions to pretty print...
 center_text() {
     local TEXT="$1"
-    local WIDTH="$2"
+    local INNER_WIDTH="$2"
     local LEN=${#TEXT}
-    if (( LEN >= WIDTH )); then
+    if (( LEN >= INNER_WIDTH )); then
         echo "===== ${TEXT} ====="
     else
+        local LEFT_PAD=$(( (INNER_WIDTH - LEN) / 2))
+        local RIGHT_PAD=$(( INNER_WIDTH - LEN - LEFT_PAD ))
         # Calculate spaces on each side
-        local PAD_SIZE=$(( (WIDTH - LEN) / 2 + 5))
-        NEW_LINE=$(printf "%*s%s%*s\n" "${PAD_SIZE}" "" "${TEXT}" "$((WIDTH - LEN - PAD_SIZE))" " ")
-        echo "===== ${NEW_LINE} ====="
+        printf "===== %*s%s%*s =====\n" \
+               "${LEFT_PAD}" "" \
+               "${TEXT}" \
+               "${RIGHT_PAD}" ""
+        #NEW_LINE=$(printf "%*s%s%*s\n" "${PAD_SIZE}" "" "${TEXT}" "$((WIDTH - LEN - PAD_SIZE))" " ")
+        #echo "===== ${NEW_LINE} ====="
     fi
 }
 
@@ -39,16 +107,19 @@ print_banner() {
     local BORDERLEN=$((MAXLEN+12))
     if (( BORDERLEN < 80)); then
         BORDERLEN=80
-        MAXLEN=$((BORDERLEN - 12))
+        #MAXLEN=$((BORDERLEN - 12))
     fi
+    local INNER_WIDTH=$((BORDERLEN - 12))
+
     # Print top border
     printf '%*s\n' "${BORDERLEN}" '' | tr ' ' '='
 
     # Print centered lines
     for LINE in "${NEWLINES[@]}"; do
-        center_text "${LINE}" "${MAXLEN}"
+        center_text "${LINE}" "${INNER_WIDTH}"
     done
 
+    # Print the bottom border
     printf '%*s\n' "${BORDERLEN}" '' | tr ' ' '='
 }
 
@@ -87,6 +158,8 @@ if [ ! -d "${BUILD_ENV}" ]; then
     pip install --upgrade pip
     # Install the relevant build dependencies and nothing else
     pip install "meson>=1.10.1" "meson-python" "ninja" "numpy" "pybind11" "setuptools"
+    # Mark that this is a first-build. This is used to make decisions later
+    FIRST_BUILD=1
 else
     # If it already exists (you've run build.sh before) just activate it
     LINES=("Activating build environment at ${BUILD_ENV}")
@@ -102,42 +175,72 @@ LINES=(
 
 print_banner "${LINES[@]}"
 
-# Run meson configure/setup if it hasn't be done yet.
+# Run meson configure/setup if it hasn't be done yet or it has been requested
+# It generally only needs to rerun if install prefix has changed, or meson.build
+# files have been modified.
 if [ ! -d "${BUILD_DIR}" ]; then
     LINES=("Running meson setup for build configuration")
     print_banner "${LINES[@]}"
     meson setup "${BUILD_DIR}" --prefix="${INSTALL_DIR}" -Dbuildtype=release
-else
-    LINES=("Running meson setup configuration")
+elif [[ ${FIRST_BUILD} || ${NEED_RECONFIG} ]]; then
+    LINES=("Running meson setup reconfiguration")
     print_banner "${LINES[@]}"
     # Reconfigure in case prefix or options changed, but keep cache
     meson setup "${BUILD_DIR}" --reconfigure --prefix="${INSTALL_DIR}"
+else
+    LINES=(
+        "!!!!! Skipping meson setup reconfiguration !!!!!"
+        "This is normally fine; however, if you have modified any meson.build"
+        "files, have changed meson options, or the install prefix, you should"
+        "re-run this script with the -r option to reconfigure meson."
+    )
+    print_banner "${LINES[@]}"
 fi
 
-# Build... This is mostly for `maestro` and C/C++ extensions
+# Build... This is mostly for maestro and C/C++ extensions
 LINES=("Compiling...")
 print_banner "${LINES[@]}"
 meson compile -C "${BUILD_DIR}"
 
+# Installation - this always needs to run. This does do the installation of
+# the Python source code as well
 LINES=("Installing files in ${INSTALL_DIR}...")
 print_banner "${LINES[@]}"
 meson install -C "${BUILD_DIR}"
 
-# Run `pip` at the end - this gets the entrypoints defined in `pyproject.toml`
-# It can be pointed at the build directory to prevent `pip` from trying to rebuild
+# Run pip at the end - this gets the entrypoints defined in pyproject.toml
+# It can be pointed at the build directory to prevent pip from trying to rebuild
 # the rest of the stuff from scratch.
 
 # We will also use the underlying Python (e.g. from psconda.sh)
 # This way, the build env can be kept small, and it can be deleted as well.
 # Otherwise, the Python scripts would end up pointing to the Python from that env.
-LINES=("Creating Python entry points")
-print_banner "${LINES[@]}"
+if [[ ${FIRST_BUILD} || ${NEED_ENTRYPOINTS} ]]; then
+    LINES=("Creating Python entry points")
+    print_banner "${LINES[@]}"
+    BUILD_VENV_SITE_PACKAGES=(${BUILD_ENV}/lib/python*/site-packages)
+    PYTHONPATH="${BUILD_VENV_SITE_PACKAGES}:${PYTHONPATH}" \
+    PATH="${BUILD_ENV}/bin:${PATH}" \
+    ${HOST_PYTHON} -m pip install . \
+        --prefix="${INSTALL_DIR}" \
+        --no-dependencies \
+        --no-build-isolation \
+        --config-settings=build-dir="${BUILD_DIR}"
+else
+    LINES=(
+        "!!!!! Skipping entry-point recreation !!!!!"
+        "This is normally fine; however, if you have modified pyproject.toml"
+        "you may need to rerun this script with the -e argument to recreate"
+        "the entry points."
+    )
+    print_banner "${LINES[@]}"
+fi
 
-BUILD_VENV_SITE_PACKAGES=(${BUILD_ENV}/lib/python*/site-packages)
-PYTHONPATH="${BUILD_VENV_SITE_PACKAGES}:${PYTHONPATH}" \
-PATH="${BUILD_ENV}/bin:${PATH}" \
-${HOST_PYTHON} -m pip install . \
-    --prefix="${INSTALL_DIR}" \
-    --no-dependencies \
-    --no-build-isolation \
-    --config-settings=build-dir="${BUILD_DIR}"
+if [[ ${NEED_CLEANUP} ]]; then
+    LINES=(
+        "!!!!! Cleaning up the build environment !!!!!"
+        "It will be re-created if you re-run this script."
+    )
+    print_banner "${LINES[@]}"
+    rm -rf "${BUILD_ENV}"
+fi

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -20,6 +20,38 @@ You can run it using:
 
 This will create an `install` directory inside the top-level of `LUTE`, and build and install all components there.
 
+The `build.sh` script will create a build environment and cache it in your home directory (under `~/.cache/lute_build_env_XXXX`). The full path is determined from a hash of the installation location. Caching this build environment speeds up subsequent re-builds significantly; however, it can be deleted by passing `-c` to the `build.sh` script when it is run. The full set of options for this script are:
+
+```bash
+> ./build.sh -h
+build.sh:
+    Build an installation of LUTE.
+
+    This build script will create an isolated build environment. It is cached in
+    your home directory under ~/.cache/lute_build_env_XXXX where the final portion
+    is created from a hash of base installation directory.
+
+    Subsequent runs of the build will not need to re-create the build environment,
+    speeding up the process significantly. You can of course delete the build environment
+    from the specified folder at any time, and it will be recreated next time the script
+    is run. You can pass a parameter to this script to do cleanup as well.
+
+    Options:
+        -c|--clean
+          Clean up the build environment
+        -h|--help
+          Display this message.
+
+    Options that apply on subsequent runs of the build script:
+        -e|--entry_points
+          Re-run the pip install command. This is only needed if pyproject.toml is
+          modified.
+        -r|--reconfigure
+          Re-run the meson setup. This is only required if meson.build files have been
+          modified, or meson options/the install prefix have changed since the last
+          time it was run.
+```
+
 The installation can be "activated" after being built. This will put all the relevant scripts and binaries into your path.
 
 ```bash


### PR DESCRIPTION
# Description

This PR updates `build.sh` to create an isolated build environment, and then cache it. This allows us to use `meson` directly instead of pip. Its faster for the initial build, and then much faster for incremental rebuilds (when you only change a file or two).

Example timing results on S3DF (this is doing all steps):
| Build Type | Build Script | Build Time |
|:------------------------:|:-----------------:|:----------:|
| Initial                    | Old script     | 2m 17s |
| Rebuild  (C++)     | Old script     | 2m 5s   |
| Rebuild (no C++) | Old script     | 2m 10s |
| Initial                    | New script   | 2m 8s    |
| Rebuild  (C++)     | New script     | 1m 17s |
| Rebuild (no C++) | New script     | 1m 3s  |

By default, the `meson setup reconfigure` and the `pip install` are turned off for subsequent re-builds. This is normally fine, since those steps only need to run when build options change, `meson.build` files are modified, or `pyproject.toml` is modified (for entry-points, what the `pip install` step handles).

This means that in general the re-builds are on the order of seconds:
| Build Type | Build Script | Build Time |
|:------------------------:|:-----------------:|:------:|
| Rebuild  (C++)     | New script     | 23 s |
| Rebuild (no C++) | New script     | 7.6 s|

## Checklist
- [x] Update `build.sh`

## PR Type:
- [x] Utility

## Address issues:
- NA

# Testing
## On first build - creates environment first
Environment is stored in `~/.cache`.

```bash
================================================================================
=====                 Sourcing the Psana1 environment (for Python3)        =====
================================================================================
=================================================================================================================================
===== Creating isolated build environment in /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1... =====
=================================================================================================================================
Requirement already satisfied: pip in /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1/lib/python3.9/site-packages (23.0.1)
Collecting pip
  Using cached pip-26.0-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 23.0.1
    Uninstalling pip-23.0.1:
      Successfully uninstalled pip-23.0.1
Successfully installed pip-26.0
Collecting meson>=1.10.1
  Using cached meson-1.10.1-py3-none-any.whl.metadata (1.8 kB)
Collecting meson-python
  Using cached meson_python-0.19.0-py3-none-any.whl.metadata (2.1 kB)
Collecting ninja
  Using cached ninja-1.13.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (5.1 kB)
Collecting numpy
  Using cached numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Collecting pybind11
  Using cached pybind11-3.0.1-py3-none-any.whl.metadata (10.0 kB)
Requirement already satisfied: setuptools in /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1/lib/python3.9/site-packages (58.1.0)
Collecting packaging>=23.2 (from meson-python)
  Using cached packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pyproject-metadata>=0.9.0 (from meson-python)
  Using cached pyproject_metadata-0.10.0-py3-none-any.whl.metadata (6.3 kB)
Collecting tomli>=1.0.0 (from meson-python)
  Using cached tomli-2.4.0-py3-none-any.whl.metadata (10 kB)
Using cached meson-1.10.1-py3-none-any.whl (1.1 MB)
Using cached meson_python-0.19.0-py3-none-any.whl (28 kB)
Using cached ninja-1.13.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (180 kB)
Using cached numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.5 MB)
Using cached pybind11-3.0.1-py3-none-any.whl (293 kB)
Using cached packaging-26.0-py3-none-any.whl (74 kB)
Using cached pyproject_metadata-0.10.0-py3-none-any.whl (19 kB)
Using cached tomli-2.4.0-py3-none-any.whl (14 kB)
Installing collected packages: tomli, pybind11, packaging, numpy, ninja, meson, pyproject-metadata, meson-python
Successfully installed meson-1.10.1 meson-python-0.19.0 ninja-1.13.0 numpy-2.0.2 packaging-26.0 pybind11-3.0.1 pyproject-metadata-0.10.0 tomli-2.4.0
=========================================================================================================================
=====              Will build and installation of LUTE at /sdf/scratch/users/d/dorlhiac/work/lute_build/install     =====
=====                    (Build cache available at: /sdf/scratch/users/d/dorlhiac/work/lute_build/_build)           =====
===== (Build environment available at: /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1) =====
=========================================================================================================================
# ....
```

## On rebuild - faster rebuilds since C++ not recompiled (+ Env not recreated)
```bash
> ./build.sh 
================================================================================
=====                 Sourcing the Psana1 environment (for Python3)        =====
================================================================================
=======================================================================================================================
===== Activating build environment at /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1 =====
=======================================================================================================================
=========================================================================================================================
=====              Will build and installation of LUTE at /sdf/scratch/users/d/dorlhiac/work/lute_build/install     =====
=====                    (Build cache available at: /sdf/scratch/users/d/dorlhiac/work/lute_build/_build)           =====
===== (Build environment available at: /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1) =====
=========================================================================================================================
# ....
================================================================================
=====                                  Compiling...                        =====
================================================================================
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /sdf/home/d/dorlhiac/.cache/lute_build_env_355864ca0320177b56a184194caeadf1/bin/ninja -C /sdf/scratch/users/d/dorlhiac/work/lute_build/_build
ninja: Entering directory `/sdf/scratch/users/d/dorlhiac/work/lute_build/_build'
ninja: no work to do.
========================================================================================
===== Installing files in /sdf/scratch/users/d/dorlhiac/work/lute_build/install... =====
========================================================================================
# ....
```

## Functional
I removed the XSSAnalyzer from the multi-node test. We know that fails, but the rest of the infrastructure should still work. All tests should then pass.

```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/scratch --no_delete --partition=milano --account=lcls:data
Sourced latest psconda.sh
# ...
Submitted batch job 20206268
> tail -f slurm-20206268.out 
INFO:Launch_Func_Tests:Will attempt running 5 tests
INFO:Launch_Func_Tests:Running test: smd2_multi_node
INFO:Launch_Func_Tests:experiment: "mfx101262725"

INFO:Launch_Func_Tests:run: 96

[2026-02-04 13:22:31.575] [LWM:Manager] [info] Running workflows with SlurmLauncher.

# ..... skipping content .... 
# Final result:
[2026-02-04 13:36:02.157] [HTTP:Server] [info] Shutting down server...
[2026-02-04 13:36:02.158] [HTTP:Server] [info] All server threads exited.
[2026-02-04 13:36:02.158] [LWM:Manager] [info] Exiting after workflow completed successfully.
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow smd_xpp_default completed successfully.
INFO:Launch_Func_Tests:Ran 5 tests. 5 were successful.
```


## Unit tests
```bash
> pytest tests/unit/
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/scratch/users/d/dorlhiac/work/lute_build
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 27 items                                                                                                                                                                                              

tests/unit/test_db_common.py .....                                                                                                                                                                        [ 18%]
tests/unit/test_db_v1.py .                                                                                                                                                                                [ 22%]
tests/unit/test_db_v2.py .                                                                                                                                                                                [ 25%]
tests/unit/test_executor.py ......                                                                                                                                                                        [ 48%]
tests/unit/test_ipc.py ..                                                                                                                                                                                 [ 55%]
tests/unit/test_launch_utils.py ....                                                                                                                                                                      [ 70%]
tests/unit/test_parsing.py .....                                                                                                                                                                          [ 88%]
tests/unit/test_task.py ...                                                                                                                                                                               [100%]

============================================================================================== 27 passed in 2.25s ===============================================================================================
> test_http 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
> test_server 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-02-04 13:21:19.663] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 13:21:19.663] [HTTP:Server] [info] Shutting down server...
[2026-02-04 13:21:19.663] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-02-04 13:21:19.663] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 13:21:19.764] [HTTP:Server] [info] Shutting down server...
[2026-02-04 13:21:19.764] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-02-04 13:21:19.764] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-04 13:21:19.865] [HTTP:Server] [info] Shutting down server...
[2026-02-04 13:21:19.865] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (202 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (202 ms total)
[  PASSED  ] 3 tests.
```

# Screenshots
NA
