### PR TITLE
BUG Cleaner temp file handling for `maestro` submission

### DIFF
--- a/workflows/maestro/src/lwm/launcher.cc
+++ b/workflows/maestro/src/lwm/launcher.cc
@@ -11,9 +11,9 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
-#include <iostream> // Consider removing this later!
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -22,6 +22,41 @@
 #include <vector>
 
 namespace fs = std::filesystem;
+
+namespace {
+  /**
+   * RAII helper for temporary files.
+   * Uses mkstemp for unique filename generation and ensures the file is
+   * deleted upon destruction.
+   */
+  struct ScopedTempFile {
+    fs::path path;
+    int fd = -1;
+
+    ScopedTempFile() {
+      char temp_template[] = "/tmp/lute_maestro_XXXXXX";
+      fd = mkstemp(temp_template);
+      if (fd == -1) {
+        throw std::runtime_error("Failed to create temporary file using mkstemp");
+      }
+      path = temp_template;
+      // We close the descriptor immediately as we only need the unique filename
+      // for shell redirection. The file exists now with 0600 permissions.
+      close(fd);
+      fd = -1;
+    }
+
+    ~ScopedTempFile() {
+      if (fd != -1) {
+        close(fd);
+      }
+      if (!path.empty()) {
+        std::error_code ec;
+        fs::remove(path, ec);
+      }
+    }
+  };
+} // anonymous namespace
 
 namespace LWM {
 
@@ -222,23 +257,19 @@ namespace LWM {
   std::pair<std::string,int> SubprocessLauncher::run_subprocess_log(const std::string& cmd,
                                                                     bool return_output) {
     std::string final_cmd = cmd;
-    std::FILE* tmp_file;
-    std::string tmp_filename;
+    std::unique_ptr<ScopedTempFile> tmp_file;
+
     if (return_output) {
-      tmp_file = std::tmpfile();
-      if (!tmp_file) {
-        m_logger->critical("Cannot create a temporary file!");
-        throw std::runtime_error("Cannot create a temporary file.");
+      try {
+        tmp_file.reset(new ScopedTempFile());
+        m_logger->debug("Will redirect subprocess logs to: {}", tmp_file->path.string());
+        final_cmd = cmd + " > " + tmp_file->path.string() + " 2>&1";
+      } catch (const std::exception& e) {
+        m_logger->critical("Cannot create a temporary file: {}", e.what());
+        throw;
       }
-      tmp_filename = fs::read_symlink(
-        fs::path("/proc/self/fd") / std::to_string(fileno(tmp_file))
-      );
-      // This includes a `(deleted)` in the name
-      std::regex deleted_pattern("\\s*\\(deleted\\)");
-      tmp_filename = std::regex_replace(tmp_filename, deleted_pattern, "");
-      m_logger->trace("Will redirect subprocess logs to: " + tmp_filename);
-      final_cmd = cmd + " > " + tmp_filename + " 2>&1";
     }
+
     int status = std::system(final_cmd.c_str());
 
     if (WEXITSTATUS(status)) {
@@ -249,10 +280,10 @@ namespace LWM {
     }
 
     if (!return_output) {
-      return std::make_pair("",status);
+      return std::make_pair("", status);
     } else {
       std::string result;
-      std::ifstream in(tmp_filename);
+      std::ifstream in(tmp_file->path);
       if (in.is_open()) {
         result.assign((std::istreambuf_iterator<char>(in)),
                       std::istreambuf_iterator<char>());
@@ -260,12 +291,11 @@ namespace LWM {
       } else {
         std::string err =
           "Unable to open temporary command output file: ";
-        err += tmp_filename;
+        err += tmp_file->path.string();
         throw std::runtime_error(err.c_str());
       }
       return std::make_pair(result, status);
     }
-    return std::make_pair("", status);
   }
 
   JobReturn SubprocessLauncher::launch_task(const JobStep& job, bool is_daq2, MaybeJobFutures_t wait_for) {
@@ -292,7 +322,7 @@ namespace LWM {
       std::tie(log, ret_status) = run_subprocess_log(launch_cmd, true);
       if (ret_status != 0) {
         status = "SUBPROCESS_FAILED";
-        return std::move(JobReturn(managed_task_name, status, log, splits));
+        return JobReturn(managed_task_name, status, log, splits);
       }
       std::regex jobid_regex(R"(Submitted batch job ([0-9]{0,100}))");
       std::smatch jobid_match;
@@ -317,7 +347,7 @@ namespace LWM {
             }
           }
         }
-        logger()->debug(managed_task_name + "'s current status is " + status);
+        logger()->trace(managed_task_name + "'s current status is " + status);
       }
       JobRegistry::unregister_job(managed_task_name);
       update_log(log, jobid);
@@ -330,7 +360,7 @@ namespace LWM {
     }
     splits.end_point = std::chrono::steady_clock::now();
     m_status_handler->remove_running_splits(managed_task_name);
-    return std::move(JobReturn(managed_task_name, status, log, splits));
+    return JobReturn(managed_task_name, status, log, splits);
   }
 
   JobReturn SubprocessLauncher::operator()(const JobStep& job, bool is_daq2, MaybeJobFutures_t wait_for) {


### PR DESCRIPTION
# Description

This PR adds a small RAII handler to create temp files used by `maestro` when submitting subprocesses. This reduces the chance of name collisions, and helps cleanup.

This turns out to actually be a fairly important bug fix. The current code-base (i.e. without this PR's changes) is messy with temp files. These get left around after job submission. As a result, due to the permissions they are created with, other user's jobs can fail. So, for multi-user work to be reliable, this PR is needed. Additionally, its just messy to leave these stray files around.

--- *NOTE:* We may need to do additional work on the `PythonLauncher` (with respect to this PR, and more generally). Anyway, its not really used at the moment, so will be left for another time.
 
## Checklist
- [x] `ScopedTempFile` class to cleanup temp file used for subprocess shell redirection during job submission.

## PR Type:
- [x] Bug fix

## Address issues:
- Issues in multi-user environment.

# Testing
## Functional
As previously, the only test failing currently is the second step of the multi-node test. The XSS analysis `Task` needs more work. Otherwise, these are all working.

```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data 
Sourced latest psconda.sh
# ...
Submitted batch job 20358363
> tail -f slurm-20358363.out
# ....
DEBUG:urllib3.connectionpool:http://sdfmilan261:41239 "POST /log HTTP/11" 200 13
DEBUG:lute.execution.executor:Task did not change from RUNNING status. Assume COMPLETED.
INFO:Launch_Func_Tests:Running test: smd2_multi_node
INFO:Launch_Func_Tests:experiment: "mfx101262725"
# ....
[2026-02-06 18:00:33.709] [LWM:Manager] [info] Providing logs for SmallDataProducer2 [Exited as: COMPLETED]
-----------------------------------------------------------------------
# ....
INFO:lute.execution.executor:Exiting after Task completion.

Time SmallDataProducer2 spent: 
- Pending: 51 s
- Running: 199 s
[2026-02-06 18:01:43.774] [LWM:Manager] [error] Providing logs for SmallDataXSSAnalyzer [Exited as: FAILED]
# ....
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow smd_mfx_default completed successfully.
INFO:Launch_Func_Tests:Ran 5 tests. 4 were successful.
```

## Unit

```bash
> pytest  unit/
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/scratch/users/d/dorlhiac/work/lute_tmpfile
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 27 items                                                                                                                                                                                              

unit/test_db_common.py .....                                                                                                                                                                              [ 18%]
unit/test_db_v1.py .                                                                                                                                                                                      [ 22%]
unit/test_db_v2.py .                                                                                                                                                                                      [ 25%]
unit/test_executor.py ......                                                                                                                                                                              [ 48%]
unit/test_ipc.py ..                                                                                                                                                                                       [ 55%]
unit/test_launch_utils.py ....                                                                                                                                                                            [ 70%]
unit/test_parsing.py .....                                                                                                                                                                                [ 88%]
unit/test_task.py ...                                                                                                                                                                                     [100%]

============================================================================================== 27 passed in 1.39s ===============================================================================================
> test_http 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
> test_server 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-02-06 17:44:15.067] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-06 17:44:15.067] [HTTP:Server] [info] Shutting down server...
[2026-02-06 17:44:15.067] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-02-06 17:44:15.068] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-06 17:44:15.168] [HTTP:Server] [info] Shutting down server...
[2026-02-06 17:44:15.168] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-02-06 17:44:15.168] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-02-06 17:44:15.269] [HTTP:Server] [info] Shutting down server...
[2026-02-06 17:44:15.269] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (201 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (201 ms total)
[  PASSED  ] 3 tests.
```