### PR TITLE
BUG Building is failing because bad lute cloning path

### DIFF
--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -85,12 +85,12 @@ def git_clone(repo: str, location: str, tag: str) -> None:
         "git",
         "clone",
         f"https://github.com/{repo}.git",
-        f"{location}/{repo_only}",
+        location,
     ]
     _run_subprocess_log(cmd)
 
     cwd: str = os.getcwd()
-    os.chdir(f"{location}/{repo_only}")
+    os.chdir(location)
     cmd = ["git", "checkout", tag]
     _run_subprocess_log(cmd)
     os.chdir(cwd)


### PR DESCRIPTION
# Description

This PR aims to debug the `setup_lute.py` to facilitate the `lute` setup for experiments. This PR fixes a bug where the lute building would fail because it could not find the `results/lute/build.sh` script after cloning lute into `results/lute/lute`

## Checklist
- [x] Fix cloning path in `git_clone` function in `setup_lute.py`

## PR Type
- [x] Bug fix

## Address Issues:
- NA

# Testing

Run:
```
cd /sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute
git checkout BUG/setup-lute
source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh
python /sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute/utilities/setup/setup_lute.py -e mfx101262725 -f --directory "bayfai" -w bayfai --test --nodes=1
```

 Lute setup succesfully in `mfx101262725`:
 ```
 (base) [lconreux@sdfiana024 results]$ ll
total 80
drwxrws---+ 1 afollmer ps-data      0 Oct 18 21:47 afollmer
drwxrwxrwx+ 1 lconreux ps-data      0 Feb  6 14:17 bayfai
drwxrws---+ 1 dehe     ps-data      0 Oct 15 05:46 calib_view
drwxrws---+ 1 fpoitevi ps-data      0 Oct 10 14:21 cctbx
drwxrws---+ 1 awolff   ps-data      0 Oct  8 11:54 common
drwxrws---+ 1 mai12345 ps-users     0 Jan 26 11:35 doris
drwxrws---+ 1 fpoitevi ps-data      0 Oct 23 11:25 fpoitevi
-rw-rw----+ 1 awolff   ps-data    258 Oct 23 17:04 setup_archive.sh
-rw-rw----+ 1 awolff   ps-data    260 Nov 15 14:29 setup_archiveV2.sh
-rw-rw----+ 1 awolff   ps-data    224 Nov 15 14:31 setup.sh
drwxr-s---+ 1 awolff   ps-data      0 Oct 15 08:09 smalldata_tools
drwxrws---+ 1 syagh    ps-data      0 Dec 18 18:36 syaghoubi
-rw-r-----+ 1 lbgee    ps-data  67482 Oct 17 12:27 T_jump_basic.ipynb
-rw-rw----+ 1 afollmer ps-data      0 Oct 17 12:33 untitled.txt
drwxrws---+ 1 awolff   ps-data      0 Oct 18 15:15 wolff
```
```
(base) [lconreux@sdfiana024 results]$ ls bayfai/
lute  lute_output
```