### PR TITLE
BUG/ENH PyFAI Azav bad indentation + SmalldataProducer2Test

### DIFF
--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -170,24 +170,10 @@ def get_azav_pyfai(run):
     if run>0:
         az_dict = {}
 {% for detector, params in getAzIntPyFAIParams.items() %}
-{%- if params['poni_file'] -%}
-        az_dict['poni_file'] = {{ params['poni_file'] }}
-{% else %}
-        ai_kwargs = {}
-        ai_kwargs['dist'] = {{ params['ai_kwargs']['dist'] }}
-        ai_kwargs['poni1'] = {{ params['ai_kwargs']['poni1'] }}
-        ai_kwargs['poni2'] = {{ params['ai_kwargs']['poni2'] }}
-        az_dict['ai_kwargs'] = ai_kwargs
-{% endif %}
-        az_dict['npts'] = {{ params['npts'] }}
-        az_dict['npts_az'] = {{ params['npts_az'] }}
-        az_dict['int_units'] = {{ params['int_units'] | pprint }}
-        az_dict['return2d'] = {{ params['return2d'] }}
-
-        ret_dict['{{ detector }}'] = az_dict
+        {{- step_parameters("az_dict", detector, params) }}
 {% endfor %}
     return ret_dict
-{%- endif %}
+{% endif %}
 
 {%- if getPolynomialCorrection is defined and getWfIntegrate %}
 def get_polynomial_correction(run):

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -64,6 +64,20 @@ SmallDataProducer2.add_tasklet(
 )
 SmallDataProducer2.update_environment(setup_smd2_env)
 
+SmallDataProducer2Test: Executor = Executor("SubmitSMD")
+"""Runs the production of a LCLS2 smalldata HDF5 file using the test environment."""
+SmallDataProducer2Test.shell_source(
+    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/pscondatest.sh"
+)
+SmallDataProducer2Test.add_tasklet(
+    clone_smalldata,
+    ["{{ producer }}", f"{os.getenv('LUTE_PATH')}/config/templates/smd.patch"],
+    when="before",
+    set_result=False,
+    set_summary=False,
+)
+SmallDataProducer2Test.update_environment(setup_smd2_env)
+
 SmallDataProducerSpack: Executor = Executor("SubmitSMD")
 """Runs the production of a LCLS2 smalldata HDF5 file using the spack environment."""
 SmallDataProducerSpack.shell_source(


### PR DESCRIPTION
# Description

This PR fixes a bug where the config template producer was giving a bad indentation of one of the parameters. This PR also adds the possibility to run the LCLS2 production of hdf5 using the test psconda environment.

## Checklist

- [x] Fix template in `smd2_prod_config_template.py`
- [x] Add managed task `SmallDataProducer2Test`

## PR Type

- [x] Bug fix: in production of template config file
- [x] Enhancement: running SubmitSMD using `pscondatest`

## Address Issues

- N\A

# Testing

## Functional

```bash
>./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok
Sourced latest psconda.sh
# ....
Submitted batch job 20634121
>tail -f slurm-20634121.out 
# ....
Time SmallDataProducer2 spent: 
- Pending: 49 s
- Running: 508 s
[2026-02-10 19:02:32.209] [HTTP:Server] [info] Shutting down server...
[2026-02-10 19:02:32.211] [HTTP:Server] [info] All server threads exited.
[2026-02-10 19:02:32.224] [LWM:Manager] [info] Exiting after workflow completed successfully.
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow smd2_mfx_prod completed successfully.
INFO:Launch_Func_Tests:Test workflow smd2_mfx_prod completed successfully.
INFO:Launch_Func_Tests:Ran 6 tests. 5 were successful.
INFO:Launch_Func_Tests:Ran 6 tests. 5 were successful.
```

## Unit

```bash
>pytest unit
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=================================================================================================== test session starts ===================================================================================================
# ...                                                                                                                                                                                                    

unit/test_db_common.py .....                                                                                                                                                                                        [ 17%]
unit/test_db_v1.py .                                                                                                                                                                                                [ 21%]
unit/test_db_v2.py .                                                                                                                                                                                                [ 25%]
unit/test_executor.py ......                                                                                                                                                                                        [ 46%]
unit/test_ipc.py ..                                                                                                                                                                                                 [ 53%]
unit/test_launch_utils.py ....                                                                                                                                                                                      [ 67%]
unit/test_parsing.py ......                                                                                                                                                                                         [ 89%]
unit/test_task.py ...                                                                                                                                                                                               [100%]

=================================================================================================== 28 passed in 2.14s ====================================================================================================
>test_http
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
# ....

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
>test_server
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
# ....
[----------] 3 tests from ServerTest (201 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (201 ms total)
[  PASSED  ] 3 tests.
