### PR TITLE
UTL Setup automated builds via GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Build wheels and create release
 on:
   push:
     # Disable this for forks. Its expensive, and the PyPI portion will fail later
-    #if: github.repository_owner == "slac-lcls"
+    if: github.repository_owner == "slac-lcls"
     # For now, only build for release tags
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: Build wheels and create release
 
 on:
   push:
+    # Disable this for forks. Its expensive, and the PyPI portion will fail later
+    if: github.repository_owner == "slac-lcls"
     # For now, only build for release tags
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+# Will change name once `psrel` PyPI account can be created
+# name: Build wheels, create release, and publish to PyPI
+name: Build wheels and create release
+
+on:
+  push:
+    # For now, only build for release tags
+    tags:
+      - 'v*'
+  #  branches:
+  #    - main
+  #pull_request:
+  #  branches:
+  #    - main
+
+jobs:
+  # Build binaries
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        # Check pyproject.toml for supported versions and additional config
+        uses: pypa/cibuildwheel@v2.22.0
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  # Build source distribution
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11" # Shouldn't matter
+
+      # Meson setup runs, so we still need these unfortunately (for subprojects)
+      # The code will not actually be compiled for the sdist
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y cmake ninja-build
+
+      - name: Build sdist
+        run: |
+          python -m pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  # Create release, publish
+  # Will change name once `psrel` PyPI account can be created
+  # create_release_and_publish_to_pypi:
+  create_release:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Gather build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      # Will enable once `psrel` PyPI account can be created
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
-# Will change name once `psrel` PyPI account can be created
-# name: Build wheels, create release, and publish to PyPI
-name: Build wheels and create release
+name: Build wheels and create release and publish to PyPI
 on:
   push:
     # Disable this for forks. Its expensive, and the PyPI portion will fail later
@@ -88,9 +86,7 @@ jobs:
           path: dist/*.tar.gz
 
   # Create release, publish
-  # Will change name once `psrel` PyPI account can be created
-  # create_release_and_publish_to_pypi:
-  create_release:
+  create_release_and_publish_to_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: pypi
@@ -106,9 +102,9 @@ jobs:
           path: dist
           merge-multiple: true
 
-      # Will enable once `psrel` PyPI account can be created
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      # This will publish to PyPI as `psrel`. Only this workflow is linked to the PyPI account
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 # Will change name once `psrel` PyPI account can be created
 # name: Build wheels, create release, and publish to PyPI
 name: Build wheels and create release
-
 on:
   push:
     # Disable this for forks. Its expensive, and the PyPI portion will fail later
-    if: github.repository_owner == "slac-lcls"
+    #if: github.repository_owner == "slac-lcls"
     # For now, only build for release tags
     tags:
       - 'v*'
@@ -23,13 +22,36 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # Add back Mac and Windows builds when maestro supports them
+        # os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
 
+      # Cache pip (for speedup)
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Cache ccache (for speedup)
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-ccache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+
       - name: Build wheels
         # Check pyproject.toml for supported versions and additional config
         uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_AFTER_BUILD: "ccache -s"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # LUTE
 [![Docs](https://img.shields.io/badge/Docs-GH_Pages-blue)](https://slac-lcls.github.io/lute/dev)
+[![Release build](https://github.com/slac-lcls/lute/actions/workflows/build.yml/badge.svg)](https://github.com/slac-lcls/lute/actions/workflows/release.yml)
+
 ## Description
-`lute`, or `LUTE`, is the LCLS Unified Task Executor - an automated workflow package for running analysis pipelines at SLAC's LCLS. This project is the next iteration of [btx](https://github.com/lcls-users/btx), and is still in very early stages of development. `btx` is still maintained and should be used until further notice.
+`lute`, or `LUTE`, is the LCLS Unified Task Executor - an automated workflow package for running analysis pipelines at SLAC's LCLS. This project is the next iteration of [btx](https://github.com/lcls-users/btx).
 
 This package is used to run arbitrary analysis code (first-party or third-party) in the form of individual analysis `Task`s. `Task`s can be linked together to form complete end-to-end analysis pipelines or workflows. For workflow management, the package interfaces with Airflow running on S3DF.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ install = ['--skip-subprojects', 'spdlog']
 # pp* (PyPy)
 # cp36-* (Python 3.6)
 # cp37-* (Python 3.7)
-# *-manylinux_i686 (32-bit builds)
+# *i686 (32-bit builds)
 # Once code updated, will need to exclude: *-win32
 # -- But maestro code is Linux only atm
-skip = ["pp*", "cp36-*", "cp37-*", "*-manylinux_i686"]
+skip = ["pp*", "cp36-*", "cp37-*", "*i686"]
 
 # Setup tests for build CI - not working atm
 # test-requires = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
 ]
 
 [tool.meson-python.args]
@@ -41,12 +41,14 @@ classifiers = [
 install = ['--skip-subprojects', 'spdlog']
 
 [tool.cibuildwheel]
-# Build for everything except:
+# Build for everything on Linux except:
 # pp* (PyPy)
 # cp36-* (Python 3.6)
 # cp37-* (Python 3.7)
-# *-win32 and *-manylinux_i686 (32-bit builds)
-skip = ["pp*", "cp36-*", "cp37-*", "*-win32", "*-manylinux_i686"]
+# *-manylinux_i686 (32-bit builds)
+# Once code updated, will need to exclude: *-win32
+# -- But maestro code is Linux only atm
+skip = ["pp*", "cp36-*", "cp37-*", "*-manylinux_i686"]
 
 # Setup tests for build CI - not working atm
 # test-requires = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy", "mypy", "meson-python", "pybind11", "meson>=1.10.1"]
+requires = ["numpy", "mypy", "meson-python", "pybind11", "meson>=1.10.1"]
 build-backend = "mesonpy"
 
 [project]
@@ -15,6 +15,24 @@ dependencies = [
     "zmq",
     "jinja2",
 ]
+authors = [
+    { name = "psrel", email = "psrel@slac.stanford.edu" },
+]
+license = { text = "BSD-3-Clause" }
+readme = "README.md"
+urls = { Homepage = "https://github.com/slac-lcls/lute" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
 
 [tool.meson-python.args]
 # Need to do this.... I couldn't for the life of me figure out how to get meson
@@ -22,6 +40,17 @@ dependencies = [
 # shared library...
 install = ['--skip-subprojects', 'spdlog']
 
+[tool.cibuildwheel]
+# Build for everything except:
+# pp* (PyPy)
+# cp36-* (Python 3.6)
+# cp37-* (Python 3.7)
+# *-win32 and *-manylinux_i686 (32-bit builds)
+skip = ["pp*", "cp36-*", "cp37-*", "*-win32", "*-manylinux_i686"]
+
+# Setup tests for build CI - not working atm
+# test-requires = "pytest"
+# test-command = "pytest ./tests/unit"
 
 [project.optional-dependencies]
 mypy = ["mypy"]
@@ -34,6 +63,7 @@ docs = [
     "mkdocs-material-extensions",
 ]
 mpi = ["mpi4py"]
+test = ["pytest"]
 
 [project.scripts]
 run_task = "run_task:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,43 @@ skip = ["pp*", "cp36-*", "cp37-*", "*i686"]
 # test-requires = "pytest"
 # test-command = "pytest ./tests/unit"
 
+# Try to set things up to cache what's possible to make things faster
+build-frontend = { name = "pip", args = ["--no-build-isolation"] }
+
+before-build = [
+    "pip install -U pip",
+    "pip install 'meson>=1.10.1' meson-python ninja numpy pybind11 setuptools",
+    "ccache -z",
+]
+[tool.cibuildwheel.linux]
+before-all = [
+    """
+    if command -v apt-get >/dev/null; then
+        apt-get update && apt-get install -y ccache
+    elif command -v dnf >/dev/null; then
+        dnf install -y ccache
+    elif command -v yum >/dev/null; then
+        yum install -y ccache
+    elif command -v apk >/dev/null; then
+        apk add ccache
+    fi
+    """,
+]
+[tool.cibuildwheel.linux.environment]
+CC = "ccache gcc"
+CXX = "ccache g++"
+CCACHE_DIR = "/project/.ccache"
+
+#[tool.cibuildwheel.macos.environment]
+#CC = "ccache clang"
+#CXX = "ccache clang++"
+#CCACHE_DIR = "/project/.ccache"
+
+#[tool.cibuildwheel.windows.environment]
+#CMAKE_C_COMPILER_LAUNCHER = "sccache"
+#CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+#SCCACHE_DIR = "/project/.ccache"
+
 [project.optional-dependencies]
 mypy = ["mypy"]
 docs = [


### PR DESCRIPTION
# Description

This PR creates an action to automatically build wheels. It adds a badge to the README to track status.

A number of comments:
- This is Linux only at the moment - `maestro` now includes Linux-specific code. Not high priority, but if its easy it would be nice to add Mac/Windows support back. Tracked with issue #116 
- There is a few lines in the action commented for PyPI publishing. Just waiting on the `psrel` account to be reactivated, and then this can be automatically published.

In the meantime, wheels are built for all Python 3.8+, and a release is created with these build artifacts on GitHub. The action is run for tags only. And it is specifically disabled on forks, even if someone creates a tag there (with the exception of the test I ran before adding that line to verify it worked on my own fork).


## Checklist
- [x] Setup GitHub action to build wheels

## PR Type:
- [x] Utility

## Address issues:
- N/A

# Testing
N/A

# Screenshots
As a test I enabled builds on forks, and made a tag on mine. This correctly built wheels for all linux versions and attached them to a release
<img width="1237" height="906" alt="image" src="https://github.com/user-attachments/assets/a71ec707-9859-4973-ad1a-ea8f246aa65e" />

