### PR TITLE
ENH Save untouched and compressed/decompressed data side-by-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LUTE
 [![Docs](https://img.shields.io/badge/Docs-GH_Pages-blue)](https://slac-lcls.github.io/lute/dev)
-[![Release build](https://github.com/slac-lcls/lute/actions/workflows/build.yml/badge.svg)](https://github.com/slac-lcls/lute/actions/workflows/release.yml)
+[![Release build](https://github.com/slac-lcls/lute/actions/workflows/release.yml/badge.svg)](https://github.com/slac-lcls/lute/actions/workflows/release.yml)
 
 ## Description
 `lute`, or `LUTE`, is the LCLS Unified Task Executor - an automated workflow package for running analysis pipelines at SLAC's LCLS. This project is the next iteration of [btx](https://github.com/lcls-users/btx).

--- a/config/templates/smd_compression.patch
+++ b/config/templates/smd_compression.patch
@@ -1,0 +1,358 @@
+diff --git a/lcls1_producers/smd_producer.py b/lcls1_producers/smd_producer.py
+--- a/lcls1_producers/smd_producer.py
++++ b/lcls1_producers/smd_producer.py
+@@ -654,7 +654,7 @@ for evt_num, evt in enumerate(ds.events()):
+ 
+     #the ARP will pass run & exp via the enviroment, if I see that info, the post updates
+     if ( (evt_num<100 and evt_num%10==0) or (evt_num<1000 and evt_num%100==0) or (evt_num%1000==0)):
+-        if os.environ.get('ARP_JOB_ID', None) is not None:
++        if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+             if ds.size == 1:
+                 requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Current Event</b>", "value": evt_num+1}])
+             elif ds.rank == 0:
+@@ -703,7 +703,7 @@ if ds.rank==0:
+ 
+ #finishing up here....
+ logger.debug('rank {0} on {1} is finished'.format(ds.rank, hostname))
+-if os.environ.get('ARP_JOB_ID', None) is not None:
++if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+     if ds.size > 1:
+         if ds.rank == 0:
+             requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Last Event</b>", "value": "~ %d cores * %d evts"%(ds.size,evt_num)},{"key": "<b>Duration</b>", "value": "%f min"%(prod_time)}])
+diff --git a/lcls2_producers/smd_producer.py b/lcls2_producers/smd_producer.py
+--- a/lcls2_producers/smd_producer.py
++++ b/lcls2_producers/smd_producer.py
+@@ -115,8 +115,10 @@ def define_dets(run, det_list):
+ 
+         #             **** Compression MUST be the first operation ****             #
+         # It is "transparent" in that it just compresses then decompresses the data #
++        pressioCompressionFunc = None
+         if detname in pressio_compression_args:
+-            det.addFunc(pressioCompressDecompress(**pressio_compression_args[detname]))
++            pressioCompressionFunc = pressioCompressDecompress(**pressio_compression_args[detname])
++            # det.addFunc(pressioCompressDecompress(**pressio_compression_args[detname]))
+ 
+         # HSD need special treatment due to their data structure.
+         # TO REVIEW / REVISE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+@@ -135,7 +137,10 @@ def define_dets(run, det_list):
+                         ROI=rois_args[detname][sdetname],
+                     )
+                     hsdsplit.addFunc(RF)
+-            det.addFunc(hsdsplit)
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(hsdsplit)
++            else:
++                det.addFunc(hsdsplit)
+             dets.append(det)
+             continue
+ 
+@@ -143,10 +148,18 @@ def define_dets(run, det_list):
+         ######## Standard detectors ########
+         ####################################
+         if detname in azav_args:
+-            det.addFunc(azimuthalBinning(**azav_args[detname]))
++            azavFunc = azimuthalBinning(**azav_args[detname])
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(azavFunc)
++            else:
++                det.addFunc(azavFunc)
+ 
+         if detname in azav_pyfai_args:
+-            det.addFunc(azav_pyfai(**azav_pyfai_args[detname]))
++            azavPyfaiFunc = azav_pyfai(**azav_pyfai_args[detname])
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(azavPyfaiFunc)
++            else:
++                det.addFunc(azavPyfaiFunc)
+ 
+         if detname in rois_args:
+             # ROI extraction
+@@ -156,7 +169,11 @@ def define_dets(run, det_list):
+                 thisROIFunc = ROIFunc(**ROI)
+                 if proj_ax is not None:
+                     thisROIFunc.addFunc(projectionFunc(axis=proj_ax))
+-                det.addFunc(thisROIFunc)
++
++                if pressioCompressionFunc is not None:
++                    pressioCompressionFunc.addFunc(thisROIFunc)
++                else:
++                    det.addFunc(thisROIFunc)
+ 
+         if detname in d2p_args:
+             if rank == 0:
+@@ -188,7 +205,10 @@ def define_dets(run, det_list):
+                 drop2phot_func.addFunc(unsparsify_func)
+             drop2phot_func.addFunc(sparsify)
+             dropfunc.addFunc(drop2phot_func)
+-            det.addFunc(dropfunc)
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(dropfunc)
++            else:
++                det.addFunc(dropfunc)
+ 
+         # if detname in dimgs_args:
+         #     # Detector image (det.raw.image())
+@@ -198,11 +218,18 @@ def define_dets(run, det_list):
+         if detname in wfs_int_args:
+             # Waveform integration
+             wfs_int_func = WfIntegration(**wfs_int_args[detname])
+-            det.addFunc(wfs_int_func)
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(wfs_int_func)
++            else:
++                det.addFunc(wfs_int_func)
+ 
+         if detname in wfs_hitfinder_args:
+             # Simple hit finder on waveform
+-            det.addFunc(SimpleHitFinder(**wfs_hitfinder_args[detname]))
++            simpleHitFunc = SimpleHitFinder(**wfs_hitfinder_args[detname])
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(simpleHitFunc)
++            else:
++                det.addFunc(simpleHitFunc)
+ 
+         if detname in wfs_svd_args:
+             if isinstance(
+@@ -216,9 +243,16 @@ def define_dets(run, det_list):
+                         )
+                         continue
+                     this_func = SvdFit(**ch)
+-                    det.addFunc(this_func)
++                    if pressioCompressionFunc is not None:
++                        pressioCompressionFunc.addFunc(this_func)
++                    else:
++                        det.addFunc(this_func)
+             else:
+-                det.addFunc(SvdFit(**wfs_svd_args[detname]))
++                svdFunc = SvdFit(**wfs_svd_args[detname])
++                if pressioCompressionFunc is not None:
++                    pressioCompressionFunc.addFunc(svdFunc)
++                else:
++                    det.addFunc(svdFunc)
+ 
+         if detname in droplet_args:
+             if "nData" in droplet_args[detname].keys():
+@@ -227,7 +261,10 @@ def define_dets(run, det_list):
+                 nData = None
+             dFunc = dropletFunc(**droplet_args[detname])
+             dFunc.addFunc(sparsifyFunc(nData=nData))
+-            det.addFunc(dFunc)
++            if pressioCompressionFunc is not None:
++                pressioCompressionFunc.addFunc(dFunc)
++            else:
++                det.addFunc(dFunc)
+ 
+         if detname in polynomial_args:
+             obj = det
+@@ -238,7 +275,10 @@ def define_dets(run, det_list):
+                 droplet_func = dropletFunc(**droplet_args)
+                 unsparsify = unsparsifyFunc()
+                 droplet_func.addFunc(unsparsify)
+-                det.addFunc(droplet_func)
++                if pressioCompressionFunc is not None:
++                    pressioCompressionFunc.addFunc(droplet_func)
++                else:
++                    det.addFunc(droplet_func)
+                 obj = unsparsify
+ 
+             if "projection" in polynomial_args[detname]:
+@@ -269,6 +309,10 @@ def define_dets(run, det_list):
+                     det.storeSum(sumAlgo=algo)
+ 
+         logger.debug(f"Rank {rank} Add det {detname}: {det}")
++
++        if pressioCompressionFunc is not None:
++            det.addFunc(pressioCompressionFunc)
++
+         dets.append(det)
+ 
+     return dets
+@@ -1058,7 +1102,7 @@ logger.debug("rank {0} on {1} is finished".format(rank, hostname))
+ #        cmd = ['timestamp_sort_h5', h5_f_name, h5_f_name]
+ 
+ if ds.unique_user_rank():
+-    if os.environ.get("ARP_JOB_ID", None) is not None:
++    if os.environ.get("ARP_JOB_ID", None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+         requests.post(
+             os.environ["JID_UPDATE_COUNTERS"],
+             json=[
+diff --git a/smalldata_tools/ana_funcs/compression.py b/smalldata_tools/ana_funcs/compression.py
+--- a/smalldata_tools/ana_funcs/compression.py
++++ b/smalldata_tools/ana_funcs/compression.py
+@@ -1,3 +1,5 @@
++import time
++
+ import numpy as np
+ 
+ from smalldata_tools.common.detector_base import DetObjectFunc
+@@ -28,13 +30,54 @@ class pressioCompressDecompress(DetObjectFunc):
+ 
+         self._compressor = PressioCompressor.from_config(self._compressor_json)
+ 
++        # NOTE: This ends up using more memory!
++        # In addition to self.dat (which contains compressed/uncompressed data)
++        # The compression func will also store `dat_orig`
++        # This allows side-by-side comparison for data having gone through
++        # the compression/uncompression cycle and data that did not
++        self.dat_orig = np.zeros(0, dtype=np.float32)
++
+     def process(self, data):
+         decompressed_img = np.zeros_like(data)
++        # We'll provide some statistics (like how long it takes)
+ 
+         # First compress image - output is immediately decompressed
++        compression_start_time = time.time()
+         compressed_img = self._compressor.encode(data)
++        compression_end_time = time.time()
+ 
++        decompression_start_time = time.time()
+         decompressed_img = self._compressor.decode(compressed_img, decompressed_img)
++        decompression_end_time = time.time()
++
++        # Calculate the statistics and fill in the returned data
++        starting_size = data.size * data.itemsize
++        compressed_size = compressed_img.size * compressed_img.itemsize
++        compression_ratio = starting_size/compressed_size
++        compression_time = compression_end_time - compression_start_time
++        decompression_time = decompression_end_time - decompression_start_time
++
++        ret_data = {}
++        ret_data["pressio_stats"] = {
++            "compression_ratio": compression_ratio,
++            "compression_time": compression_time,
++            "decompression_time": decompression_time,
++        }
++
++        # The compressed/decompressed data will be in self.dat
++        # In case we want to see side-by-side the data that did not go through the cycle
++        # it will be in self.dat_orig
++        self.dat = decompressed_img
++        self.dat_orig = data
++
++        # Now we run the subFuncs
++        sub_func_results = self.processFuncs()
++        if not sub_func_results:
++            return ret_data
++
++        for key in sub_func_results:
++            for sub_key in sub_func_results[key]:
++                ret_data[f"{key}_{sub_key}"] = sub_func_results[key][sub_key]
++
++        return ret_data
+ 
+-        data = decompressed_img
+-        return {}
+diff --git a/smalldata_tools/ana_funcs/droplet.py b/smalldata_tools/ana_funcs/droplet.py
+--- a/smalldata_tools/ana_funcs/droplet.py
++++ b/smalldata_tools/ana_funcs/droplet.py
+@@ -1,7 +1,9 @@
+ import numpy as np
+ import time
+ import scipy.ndimage as ndi
+-import skimage.measure as measure
++# For the compression environments skimage is not available
++# import skimage.measure as measure
++measure = print
+ import scipy.ndimage.filters as filters
+ from scipy import sparse
+ from smalldata_tools.common.detector_base import DetObjectFunc
+@@ -273,3 +275,4 @@ class dropletFunc(DetObjectFunc):
+         self.dat = dat_dict
+ 
+         return ret_dict
++
+diff --git a/smalldata_tools/common/detector_base.py b/smalldata_tools/common/detector_base.py
+--- a/smalldata_tools/common/detector_base.py
++++ b/smalldata_tools/common/detector_base.py
+@@ -184,8 +184,23 @@ class DetObjectFunc(object):
+                 % self.name
+             )
+             return
+-        for tfunc in subFuncs:
+-            subFuncResults[tfunc._name] = tfunc.process(self.dat)
++        for sfunc in subFuncs:
++            try:
++                subFuncResults[sfunc._name] = sfunc.process(self.dat)
++            except Exception as err:
++                # print(
++                #     f"Sub func {sfunc._name} failed to process and will be skipped. ({err})"
++                # )
++                continue
++            if "dat_orig" in self.__dict__.keys():
++                # The compression func also stores an original version of the data
++                # (perhaps other funcs do) - this is to facilitate side-by-side
++                # comparisons
++                orig_name = f"{sfunc._name}_original"
++                try:
++                    subFuncResults[orig_name] = sfunc.process(self.dat_orig)
++                except:
++                    continue
+         return subFuncResults
+ 
+ 
+@@ -255,3 +270,4 @@ def getUserEnvData(det):
+     except:
+         pass
+     return env_dict
++
+diff --git a/smalldata_tools/lcls2/DetObject.py b/smalldata_tools/lcls2/DetObject.py
+--- a/smalldata_tools/lcls2/DetObject.py
++++ b/smalldata_tools/lcls2/DetObject.py
+@@ -315,8 +315,13 @@ class GenericContainerObject(DetObjectClass):
+             # is not available until after first event. We therefor will reprocess
+             # afterwards
+             super().addFunc(func)
+-        except:
+-            ...
++        except Exception as err:
++            print(
++                "*** GenericContainerObject encountered error when adding Func:",
++                str(err),
++            )
++        # Add anyway (reprocessFuncs will handle it)
++        self.__dict__[func._name] = func
+ 
+     def reprocessFuncs(self):
+         """Rerun setup for DetObjectFuncs.
+@@ -331,12 +336,34 @@ class GenericContainerObject(DetObjectClass):
+             for k in self.__dict__
+             if isinstance(self.__dict__[k], DetObjectFunc)
+         ]:
+-            func.setFromDet(self)
+             try:
+-                func.setFromFunc()
++                func.setFromDet(self)
+             except:
+                 print("Failed to pass parameters to children of ", func._name)
+ 
++            try:
++                func.setFromFunc()
++            except:
++                print("Failed to setFromFunc", func._name)
++
++            subFuncs = [
++                sFunc
++                for _, sFunc in func.__dict__.items()
++                if isinstance(sFunc, DetObjectFunc)
++            ]
++            # Need to also rerun it on the subFunc (if any)
++            for subFunc in subFuncs:
++                try:
++                    subFunc.setFromDet(self)
++                except:
++                    ...
++                try:
++                    subFunc.setFromFunc()
++                except Exception as err:
++                    print("SubFunc error on reprocess:", str(err))
++                    # Continue anyway so that not all funcs fail
++                    continue
++
+     def get_fields(self, top_field):
+         """
+         Parameters
+@@ -891,3 +918,4 @@ class ArchonObject(ImageObject):
+         if self.common_mode is None:
+             self.common_mode = 30
+         return
++

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -96,11 +96,25 @@ SmallDataProducerSpack.add_tasklet(
 SmallDataProducerSpack.update_environment(setup_smd2_env)
 
 SmallDataProducerXpp: Executor = Executor("SubmitSMD")
-"""Runs the production of a LCLS2 smalldata HDF5 file using the spack environment."""
+"""Runs the production of a LCLS2 smalldata HDF5 file using the XPP environment."""
 SmallDataProducerXpp.shell_source(
     "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh"
 )
 SmallDataProducerXpp.add_tasklet(
+    clone_smalldata,
+    ["{{ producer }}"],
+    when="before",
+    set_result=False,
+    set_summary=False,
+)
+SmallDataProducerXpp.update_environment(setup_smd2_env)
+
+SmallDataProducerXppOrig: Executor = Executor("SubmitSMD")
+"""Run patched smalldata_tools to make compressed/uncompressed and untouched data."""
+SmallDataProducerXppOrig.shell_source(
+    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh"
+)
+SmallDataProducerXppOrig.add_tasklet(
     clone_smalldata,
     [
         "{{ producer }}",
@@ -110,7 +124,7 @@ SmallDataProducerXpp.add_tasklet(
     set_result=False,
     set_summary=False,
 )
-SmallDataProducerXpp.update_environment(setup_smd2_env)
+SmallDataProducerXppOrig.update_environment(setup_smd2_env)
 
 SmallDataXSSAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXSS")
 """Process scattering results from a Small Data HDF5 file."""

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -98,11 +98,14 @@ SmallDataProducerSpack.update_environment(setup_smd2_env)
 SmallDataProducerXpp: Executor = Executor("SubmitSMD")
 """Runs the production of a LCLS2 smalldata HDF5 file using the spack environment."""
 SmallDataProducerXpp.shell_source(
-    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_gpu.sh"
+    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh"
 )
 SmallDataProducerXpp.add_tasklet(
     clone_smalldata,
-    ["{{ producer }}"],
+    [
+        "{{ producer }}",
+        f"{os.getenv('LUTE_PATH')}/config/templates/smd_compression.patch",
+    ],
     when="before",
     set_result=False,
     set_summary=False,
@@ -243,3 +246,4 @@ BayFAIOptimizer2.update_environment(
         "PYTHONPATH": "/sdf/group/lcls/ds/tools/LCLSGeom",
     }
 )
+

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -246,4 +246,3 @@ BayFAIOptimizer2.update_environment(
         "PYTHONPATH": "/sdf/group/lcls/ds/tools/LCLSGeom",
     }
 )
-

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -12,15 +12,17 @@
 
 ## List of tests
 
-| Test Name                     | Workflow                                                                                                   | Experiment   | Run | Additional Comments                                                   |
-|:-----------------------------:|:----------------------------------------------------------------------------------------------------------:|:------------:|:---:|:---------------------------------------------------------------------:|
-| basic_tests                   | Basic LUTE test Tasks                                                                                      | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
-| smd_xpp_default               | SmallDataProducer                                                                                          | xpptut15     | 650 | xpplv9818 run 127. This is to test default production only.           |
-| smd_mfx_default               | SmallDataProducer                                                                                          | mfxx49820    | 15  | Default small data production                                         |
-| smd2_mfx_prod                 | SmallDataProducer2                                                                                         | mfx101344525 | 70  | LCLS2 non-default SMD (MFX).                                          |
-| smd2_multi_node               | SmallDataProducer2                                                                                         | mfx101262725 | 96  | LCLS2 non-default SMD (MFX) submitted across multiple nodes.          |
-| param_generation              | Basic LUTE tests + param generation                                                                        | xpptut15     | 670 | Experiment/run not used by the test but required for compatibility.   |
-| peakfinder8_lcls2             | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data.                                          | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
-| peakfinder8_lcls2_compression | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data but do compress/decompress with RoiBinSZ. | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
-| basic_rest                    | Basic tests of `maestro` REST APIs                                                                         | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
-|                               |                                                                                                            |              |     |                                                                       |
+| Test Name                     | Workflow                                                                                                    | Experiment   | Run | Additional Comments                                                   |
+|:-----------------------------:|:-----------------------------------------------------------------------------------------------------------:|:------------:|:---:|:---------------------------------------------------------------------:|
+| basic_tests                   | Basic LUTE test Tasks                                                                                       | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
+| smd_xpp_default               | SmallDataProducer                                                                                           | xpptut15     | 650 | xpplv9818 run 127. This is to test default production only.           |
+| smd_mfx_default               | SmallDataProducer                                                                                           | mfxx49820    | 15  | Default small data production                                         |
+| smd2_mfx_prod                 | SmallDataProducer2                                                                                          | mfx101344525 | 70  | LCLS2 non-default SMD (MFX).                                          |
+| smd2_multi_node               | SmallDataProducer2                                                                                          | mfx101262725 | 96  | LCLS2 non-default SMD (MFX) submitted across multiple nodes.          |
+| param_generation              | Basic LUTE tests + param generation                                                                         | xpptut15     | 670 | Experiment/run not used by the test but required for compatibility.   |
+| peakfinder8_lcls2             | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data.                                           | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
+| peakfinder8_lcls2_compression | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data but do compress/decompress with RoiBinSZ.  | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
+| basic_rest                    | Basic tests of `maestro` REST APIs                                                                          | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
+| smd2_xpp_compression          | Run patched smalldata_tools with side-by-side compressed/uncompressed and untouched data on converted XTC1. | xppx1003621  | 198 | This uses the _xpp_ environment (Python 3.11) and libpressio.         |
+|                               |                                                                                                             |              |     |                                                                       |
+

--- a/tests/functional/smd2_xpp_compression/README.md
+++ b/tests/functional/smd2_xpp_compression/README.md
@@ -1,0 +1,6 @@
+# SMD2 XPP Compression
+Test for `smalldata_tools` using `SmallDataProducerXppOrig`.
+
+Runs a patched version of smalldata_tools (with patch applied by LUTE), that tests smalldata_tools production on converted XTC1 files.
+
+The output is saved for data having been compressed/uncompressed and also for the untouched data not having gone through this process.

--- a/tests/functional/smd2_xpp_compression/config.yaml
+++ b/tests/functional/smd2_xpp_compression/config.yaml
@@ -1,0 +1,130 @@
+%YAML 1.3
+---
+title: "smalldata_tools on converted XTC1 files with side-by-side saving of compressed/uncompressed and untouched data."
+experiment: "xppx1003621"
+run: "198"
+date: "2025/11/14"
+lute_version: 0.1.1      # Do not be change unless need to force older version
+task_timeout: 6000
+work_dir: "/tmp"
+...
+---
+# We will define some convenience keys for substitution in other parameters
+EXPERIMENT_DIR: "/sdf/data/lcls/ds/xpp/{{ experiment }}"
+FAKE_PSDM_SUBDIR: "xpp/{{ experiment }}/xtc"
+XTC2_FILE_PATH: "{{ EXPERIMENT_DIR }}/scratch/conversion/{{ FAKE_PSDM_SUBDIR }}"
+XTC2_FILE_NAME: "{{ experiment }}-r{{ run:04d }}-s000-c000.xtc2"
+
+ConvertXtc1to2:               # All variables are given as strings
+  node_id: "1"                # Node ID for the detector
+  #eventfile: ""
+  nevents: 10
+  output_file: "{{ XTC2_FILE_PATH }}/{{ XTC2_FILE_NAME }}"
+  xtc1_access_pattern:
+    jungfrau1M_alcove: # Name of the detector in the converted XTC2
+    # You can have a list of attributes you will convert that will be stored in
+    # this detector
+      - xtc2_attr_name: "calib"          # Name of this attribute in xtc2
+        object_name: "jungfrau1M_alcove" # Name of the detector in psana1
+        object_type: "psana.Detector"    # Name of the object type in psana1
+        object_field_name: "calib"       # Name of the per-event method to use in psana1
+    #EBeam:
+    #  - xtc2_attr_name: "photon_energy"
+    #    object_name: "EBeam"
+    #    object_type: "psana.Detector"
+    #    object_field_name: ["get","ebeamPhotonEnergy"]
+
+SubmitSMD:
+  # Command line arguments
+  #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
+  #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
+  #np: 5
+  producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  run: "{{ run }}"
+  experiment: "{{ experiment }}"
+  #stn: 0
+  directory: "{{ work_dir }}"
+  psdm_dir: "{{ XTC2_FILE_PATH }}"
+  nevents: 100
+  #config: "mfx_cctbx"
+  #gather_interval: 25
+  #norecorder: False
+  #url: "https://pswww.slac.stanford.edu"
+  #epicsAll: False
+  #full: False
+  #fullSum: False
+  #default: true
+  #image: False
+  #tiff: False
+  #centerpix: False
+  #postRuntable: False
+  #wait: False
+  #xtcav: False
+  #noarch: False
+  # Producer variables. These are substituted into the producer to run specific
+  # data reduction algorithms. Uncomment and modify as needed.
+  # If you prefer to modify the producer file directly, leave commented.
+  # Beginning with `getROIs`, you will need to modify the first entry to be a
+  # detector. This detector MUST MATCH one of the detectors in `detnames`.
+  # In the future this will be automated. If you have multiple detectors you can
+  # add them with their own set of parameters.
+
+  detnames: ["jungfrau1M_alcove"]
+  # Detector sum images - per detector
+  #detSumAlgos:
+  #  jungfrau1M_alcove:
+  #    - "calib"
+  #    - "calib_max"
+  # Setup the ROIs
+  getROIs:
+    jungfrau1M_alcove:   # Change to detector name
+      - ROI: [[[1,2], [37, 230], [448, 704]]]
+        name: "ROI_111peak"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[1,2], [37, 230], [448, 704]]]
+        name: "ROI_211peak"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[1,2], [175,470], [26,  485]]]
+        name: "ROI_232peak"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[0,1], [328,503], [370, 626]]]
+        name: "ROI_224peak"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[0,1], [76, 296], [778,1010]]]
+        name: "ROI_large_scatter"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[1,2], [23, 486], [639, 989]]]
+        name: "ROI_air_scatter_bottom"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+      - ROI: [[[1,2], [7,  184], [289, 856]]]
+        name: "ROI_air_scatter_larger"
+        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+        thresADU: 8
+        calcPars: True
+  getAzIntParams:
+    jungfrau1M_alcove:
+      eBeam: 9.4
+      center: [26167.58, -30407.6] # um
+      dis_to_sam: 45.0
+      tx: 0
+      ty: 0
+  # Compression arguments. Comment this entire block if no compression wanted
+  getPressioCompression:
+    jungfrau1M_alcove:
+      compressor_id: "sz3"
+      # Specific arguments vary depending on compressor_id
+      compressor_args:
+        abs_error_bound: 10
+...

--- a/tests/functional/smd2_xpp_compression/dag.yaml
+++ b/tests/functional/smd2_xpp_compression/dag.yaml
@@ -1,0 +1,4 @@
+!LUTE_DAG
+task_name: "SmallDataProducerXppOrig"
+slurm_params: "--psana2 --partition=milano --account=lcls:data --ntasks-per-node=50 --nodes=1"
+next: []


### PR DESCRIPTION
# Description

This PR adds a patch to allow saving a version of the data that was not touched by the compression/decompression cycle when using that feature of `smalldata_tools`.

The patch is applied only for the `SmallDataProducerXppOrig` managed Task - given that it duplicates data, I do not think it makes sense to upstream the patch formally into `smalldata_tools`. Making it more configurable would be a lot of work, and is likely not worth the effort, given the small use case.

When using compression data gets saved with the name that was provided, and then an additional version that has an `_original_` suffix indicating data that did not go through the compress/uncompress cycle. E.g. Here we have an ROI called `111_peak`. The output in the HDF5 file will have:

```bash
> h5ls output/my/data
pressio_ROI_111peak_area Dataset {100, 193, 256}
pressio_ROI_111peak_com  Dataset {100, 2}
pressio_ROI_111peak_max  Dataset {100}
pressio_ROI_111peak_mean Dataset {100}
pressio_ROI_111peak_original_area Dataset {100, 193, 256}
pressio_ROI_111peak_original_com Dataset {100, 2}
pressio_ROI_111peak_original_max Dataset {100}
pressio_ROI_111peak_original_mean Dataset {100}
pressio_ROI_111peak_original_sum Dataset {100}
```

The second set of `_original_` were the data that did not get touched by libpressio.

Note that the patch also computes some statistics about the compression. These are stored under the `pressio_pressio_stats` key:

```bash
> h5ls output.h5/jungfrau1M_alcove/pressio_pressio_stats
compression_ratio        Dataset {100}
compression_time         Dataset {100}
decompression_time       Dataset {100}
```

## Checklist
- [x] Add patch for smalldata_tools to allow data to be saved side-by-side if using compression.
- [x] Provide a new managed Task - this way the patch is applied only for that special case.
- [x] Add an integration/functional test that runs the new managed Task.

## PR Type:
- [x] New feature/Enhancement

## Address issues:

- Difficulties people have comparing HDF5 files produced with compression and those without, since psana2 does not guarantee order when saving HDF5. This leads to side-by-side output which can be compared directly.

# Testing
## Functional (New Managed Task)
```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data --run_tests smd2_xpp_compression
# ....
Submitted batch job 23125401
> tail -f slurm-23125401.out
# ....
[2026-03-11 09:17:34.955] [HTTP:Server] [info] Shutting down server...
[2026-03-11 09:17:34.955] [HTTP:Server] [info] All server threads exited.
[2026-03-11 09:17:34.955] [LWM:Manager] [info] Exiting after workflow completed successfully.
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow smd2_xpp_compression completed successfully.
INFO:Launch_Func_Tests:Test workflow smd2_xpp_compression completed successfully.
INFO:Launch_Func_Tests:Ran 1 tests. 1 were successful.
```

Verifying the output HDF5 files:
```bash
> h5ls ../../lute_output/xppx1003621_Run0198.h5/jungfrau1M_alcove
pressio_ROI_111peak_area Dataset {100, 193, 256}
pressio_ROI_111peak_com  Dataset {100, 2}
pressio_ROI_111peak_max  Dataset {100}
pressio_ROI_111peak_mean Dataset {100}
pressio_ROI_111peak_original_area Dataset {100, 193, 256}
pressio_ROI_111peak_original_com Dataset {100, 2}
pressio_ROI_111peak_original_max Dataset {100}
pressio_ROI_111peak_original_mean Dataset {100}
pressio_ROI_111peak_original_sum Dataset {100}
# ...
pressio_ROI_large_scatter_original_max Dataset {100}
pressio_ROI_large_scatter_original_mean Dataset {100}
pressio_ROI_large_scatter_original_sum Dataset {100}
pressio_ROI_large_scatter_sum Dataset {100}
pressio_pressio_stats    Group
```

## Functional (The rest of the tests)

- Only run the peakfinder8 with compression test.
- Disable the XSS analysis in the `smd2_multi_node` since it is known to be broken.

```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data --run_tests basic_rest,basic_tests,param_generation,smd2_mfx_prod,smd2_multi_node,smd_mfx_default,smd_xpp_default,peakfinder8_lcls2_compression
# ....
Submitted batch job 23126098
> tail -f slurm-23126098.out
# .....
INFO:Launch_Func_Tests:Ran 8 tests. 8 were successful.
```

# Screenshots
