### PR TITLE
ENH Add `FindPeaksSFX` to support `PyAlgos` and `Peakfinder8` in LCLS1 and LCLS2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,9 @@ $(basename "$0"):
           Re-run the meson setup. This is only required if meson.build files have been
           modified, or meson options/the install prefix have changed since the last
           time it was run.
+        -s|--source_pyenv
+          Use an additional source environment. Can be used to build multiple versions
+          of the extensions. E.g. to have 3.9 and 3.11 Python extension libraries.
 EOF
 }
 
@@ -54,6 +57,11 @@ do
         ;;
     -r|--reconfigure)
         NEED_RECONFIG=1
+        shift
+        ;;
+    -s|--source_pyenv)
+        SOURCE_PYENV="${2}"
+        shift
         shift
         ;;
     -h|--help)
@@ -83,8 +91,6 @@ center_text() {
                "${LEFT_PAD}" "" \
                "${TEXT}" \
                "${RIGHT_PAD}" ""
-        #NEW_LINE=$(printf "%*s%s%*s\n" "${PAD_SIZE}" "" "${TEXT}" "$((WIDTH - LEN - PAD_SIZE))" " ")
-        #echo "===== ${NEW_LINE} ====="
     fi
 }
 
@@ -123,27 +129,33 @@ print_banner() {
     printf '%*s\n' "${BORDERLEN}" '' | tr ' ' '='
 }
 
-
-# Determine build directories, install directory, and where to put the build env
-BASE_DIR="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )"
-BUILD_DIR="${BASE_DIR}/_build"
-INSTALL_DIR="${BASE_DIR}/install"
-
-# Virtual environment needs to be outside the source tree
-# Otherwise you get some path errors with meson
-# At least I couldn't figure out any other way to do it...
-BUILD_ENV="${HOME}/.cache/lute_build_env_$(echo ${BASE_DIR} | md5sum | cut -d' ' -f1)"
-
-mkdir -p "${INSTALL_DIR}"
-mkdir -p "${BUILD_DIR}"
-mkdir -p "${HOME}/.cache"
-
-# On S3DF get a standard Python3 - otherwise you're on your own
-if [[ $HOSTNAME =~ "sdf" ]]; then
+# On S3DF get a standard Python3, unless a source directive provided explicitly
+if [[ $SOURCE_PYENV ]]; then
+    LINES=("Sourcing ${SOURCE_PYENV}")
+    print_banner "${LINES[@]}"
+    source "${SOURCE_PYENV}"
+elif [[ $HOSTNAME =~ "sdf" ]]; then
     LINES=("Sourcing the Psana1 environment (for Python3)")
     print_banner "${LINES[@]}"
     source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 fi
+
+# We will append Python Version info to the build directories for side-by-side builds
+PY_VER=$(python3 -V | awk '{print $2}')
+
+# Determine build directories, install directory, and where to put the build env
+BASE_DIR="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )"
+BUILD_DIR="${BASE_DIR}/_build_${PY_VER}"
+INSTALL_DIR="${BASE_DIR}/install" # All Python versions go in install, though
+
+# Virtual environment needs to be outside the source tree
+# Otherwise you get some path errors with meson
+# At least I couldn't figure out any other way to do it...
+BUILD_ENV="${HOME}/.cache/lute_build_env_$(echo ${BASE_DIR} | md5sum | cut -d' ' -f1)_${PY_VER}"
+
+mkdir -p "${INSTALL_DIR}"
+mkdir -p "${BUILD_DIR}"
+mkdir -p "${HOME}/.cache"
 
 # Save host/conda env Python for later
 HOST_PYTHON=$(which python3)
@@ -215,7 +227,7 @@ meson install -C "${BUILD_DIR}"
 # We will also use the underlying Python (e.g. from psconda.sh)
 # This way, the build env can be kept small, and it can be deleted as well.
 # Otherwise, the Python scripts would end up pointing to the Python from that env.
-if [[ ${FIRST_BUILD} || ${NEED_ENTRYPOINTS} ]]; then
+if [[ ${NEED_ENTRYPOINTS} ]]; then
     LINES=("Creating Python entry points")
     print_banner "${LINES[@]}"
     BUILD_VENV_SITE_PACKAGES=(${BUILD_ENV}/lib/python*/site-packages)

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ $(basename "$0"):
     Build an installation of LUTE.
 
     This build script will create an isolated build environment. It is cached in
-    your home directory under ~/.cache/lute_build_env_XXXX where the final portion
+    your home directory under ~/.cache/lute_build_env_XXXX_PYVER where the final portion
     is created from a hash of base installation directory.
 
     Subsequent runs of the build will not need to re-create the build environment,

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -16,24 +16,21 @@ Parameters:
 - `-f, --fresh_install`: Install a new version of LUTE in the experiment folder. This allows for local modifications of code. Otherwise, the central installation will be used (which cannot be modified).
 - `--test`: Use test Airflow instance. Only needed for bleeding-edge workflows.
 - `-v VERSION, --version VERSION`: Version of LUTE to use. Corresponds to release tag or `dev`. Defaults to `dev`.
-- `-w WORKFLOW, --workflow WORKFLOW`: Which analysis workflow to run. Defaults to `smd_summaries`.
+- `-W WORKFLOW, --workflow WORKFLOW`: Which analysis workflow to run. Defaults to `smd`.
 - `-d, --debug`: Turn on verbose logging.
 - `[SLURM ARGS]`: This is any number of SLURM arguments you want to run your workflow with. You will likely want to provide `--ntasks` at a minimum.
 
-The only required argument is `-e <EXPERIMENT>`. This should be the experiment you are setting up for. You will likely also want to provide the `-w <WORKFLOW>` argument. This determines what default job to setup (i.e., the workflow to run). The current list of workflows is:
+The only required argument is `-e <EXPERIMENT>`. This should be the experiment you are setting up for. You will likely also want to provide the `-W <WORKFLOW>` argument. These are written in YAML, and will be copied in from the `workflows/common` directory (see description below). Because these are YAML, it is recommended (and highly likely) that you will modify the definition slightly.
 
-- `find_peaks_index` : Perform peak finding and indexing.
-- `psocake_sfx_phasing` : Perform end-to-end SFX analysis with experimental phasing. This uses a legacy peak finder and is **not** recommended unless you need experimental phasing.
-- `pyalgos_sfx` : Perform end-to-end SFX analysis with molecular replacement. Also sets up `smalldata_tools`.
+The example starting points are:
+
+- `bayfai` : Perform geometry optimization using BayFAI.
+- `sfx` : Perform end-to-end SFX analysis with molecular replacement.
 - `smd` : Run managed `smalldata_tools` and downstream analysis/summaries.
-- `smd_summaries` : Perform XAS, XES, and XSS analysis of `smalldata_tools` reduction. Does not setup `smalldata_tools`.
-- `smd_xss` : Perform only XSS analysis of `smalldata_tools` reduction. Does not setup `smalldata_tools`.
-- `smd_xes` : Perform only XES analysis of `smalldata_tools` reduction. Does not setup `smalldata_tools`.
-- `smd_xas` : Perform only XAS analysis of `smalldata_tools` reduction. Does not setup `smalldata_tools`.
 
 Providing SLURM arguments is not required, but **highly recommended**. The setup script will try to set some default values for `--partition`, `--account`, and `--ntasks`, depending on the experiment and workflow you are running. If these three arguments are not provided, it will prompt you for each one and tell you the default it has selected. Press enter (or any key) to accept. Otherwise, press `Ctrl-C` to exit the setup, and pass the arguments manually.
 
-The `setup_lute` script will create the eLog job for your selected workflow. Results will be presented back to you in the eLog. The script will also produce a configuration file which will live at `/sdf/data/lcls/ds/<hutch>/<experiment>/results/<hutch>.yaml`. You will want to modify this configuration prior to running. See `Basic Usage` below for more information.
+The `setup_lute` script will create the eLog job for your selected workflow. Results will be presented back to you in the eLog. The script will also produce a configuration file which will live at `/sdf/data/lcls/ds/<hutch>/<experiment>/results/lute_output/<hutch>.yaml`. You will want to modify this configuration prior to running. See [Basic Usage](/#basic-usage) below for more information.
 
 #### Locally or otherwise
 LUTE is publically available on [GitHub](https://github.com/slac-lcls/lute). In order to run it, the first step is to clone the repository:
@@ -48,27 +45,35 @@ The repository directory structure is as follows:
 lute
   |--- config             # Configuration YAML files (see below) and templates for third party config
   |--- docs               # Documentation (including this page)
+  |--- extensions         # Python extensions (written in C and C++), includes algorithms like Peakfinder8
   |--- launch_scripts     # Entry points for using SLURM and communicating with Airflow
   |--- lute               # Code
         |--- run_task.py  # Script to run an individual managed Task
         |--- ...
+  |--- subprojects        # Vendored dependencies (should not be relevant for most users)
+  |--- tests              # As you'd expect
   |--- utilities          # Help utility programs
   |--- workflows          # This directory contains workflow definitions. It is synced elsewhere and not used directly.
-
+        |--- airflow      # DAGs and components written for the Airflow backend
+        |--- common       # Examples (only examples!) for YAML DAGs
+        |--- maestro      # *** Contains the source code for the `maestro` workflow manager
+        |--- prefect      # DAGs and components written for the Prefect backend
 ```
 
 In general, most interactions with the software will be through scripts located in the `launch_scripts` directory. Some users (for certain use-cases) may also choose to run the `run_task.py` script directly - it's location has been highlighted within hierarchy. To begin with you will need a YAML file, templates for which are available in the `config` directory. The structure of the YAML file and how to use the various launch scripts are described in more detail in the Usage and Developer documentation on this site.
 
 ## Basic Usage
 ### Overview
-LUTE runs code as `Task`s that are managed by an `Executor`. The `Executor` provides modifications to the environment the `Task` runs in, as well as controls details of inter-process communication, reporting results to the eLog, etc. Combinations of specific `Executor`s and `Task`s are already provided, and are referred to as **managed** `Task`s. **Managed** `Task`s are submitted as a single unit. They can be run individually, or a series of independent steps can be submitted all at once in the form of a workflow, or **directed acyclic graph** (**DAG**). This latter option makes use of Airflow to manage the individual execution steps.
+LUTE runs code as `Task`s that are managed by an `Executor`. The `Executor` provides modifications to the environment the `Task` runs in, as well as controls details of inter-process communication, reporting results to the eLog, etc. Combinations of specific `Executor`s and `Task`s are already provided, and are referred to as **managed** `Task`s.
+
+**Managed** `Task`s are submitted as a single unit. They can be run individually, or a series of independent steps can be submitted all at once in the form of a workflow, or **directed acyclic graph** (**DAG**). This latter option makes use of [maestro](/development/maestro), a workflow manager built for this project, to manage the individual execution steps. Additional backends, such as Airflow and Prefect, are also supported, but are not the default.
 
 Running analysis with LUTE is the process of submitting one or more **managed** `Task`s. This is generally a two step process.
 
 1. First, a configuration YAML file is prepared. This contains the parameterizations of all the `Task`s which you may run.
 2. Individual **managed** `Task` submission, or workflow (**DAG**) submission.
 
-**Note:** You configure `Task`s, but submit **managed** `Task`s. If you run the help utility described below, and in the usage manual, you can find which **managed** `Task`s correspond to which `Task`s. In general, `Task`s are verbs and the `Executor`s that run them (i.e. **managed** `Task`s) are nouns. E.g. the `FindPeaksPyAlgos` `Task`, is run by submitting the `PeakFinderPyAlgos` **managed** `Task`.
+**Note:** You configure `Task`s, but submit **managed** `Task`s. If you run the help utility described below, and in the usage manual, you can find which **managed** `Task`s correspond to which `Task`s. In general, `Task`s are verbs and the `Executor`s that run them (i.e. **managed** `Task`s) are nouns. E.g. the `FindPeaksSFX` `Task`, is run by submitting the `PeakFinderSFX` **managed** `Task`. There may be many **managed** `Task`s which submit the same underlying `Task`, but in different environments.
 
 ### Config YAML
 If you ran the `setup_lute` script you will already have a `<hutch>.yaml` file located in your experiment results folder. This YAML file is commented by `Task`. You will **need** to modify a few of these parameters for some of the `Task`s. E.g. a partial example of the config file may look like this:
@@ -76,7 +81,7 @@ If you ran the `setup_lute` script you will already have a `<hutch>.yaml` file l
 ```yaml
 %YAML 1.3
 ---
-title: "LUTE Task Configuration" # Include experiment description if desired
+title: "Doing Peakfinding" # Include experiment description if desired
 experiment: "{{ $EXPERIMENT }}"
 #run: "{{ $RUN }}"
 date: "2023/10/25"
@@ -94,26 +99,29 @@ work_dir: ""
 # It can be a PV, or alternative a float for a fixed offset
 # Example PVs are commented below, ask beamline staff for relevant PV
 # Change outdir to an appropriate directory for CXI files.
-FindPeaksPyAlgos:
-    outdir: "/path/to/cxi_out"
-    det_name: "epix10k2M"
-    event_receiver: "evr0"
-    tag: "lyso"
-    event_logic: false
-    psana_mask: false
-    mask_file: null
-    min_peaks: 10
-    max_peaks: 2048
-    npix_min: 2
-    npix_max: 30
-    amax_thr: 40
-    atot_thr: 180
-    son_min: 10.0
-    peak_rank: 3
-    r0: 3.0
-    dr: 2.0
-    nsigm: 10.0
-    #pv_camera_length: "MFX:ROB:CONT:POS:Z"  # MFX epix10k2M
+FindPeaksSFX:
+  algorithm: "Peakfinder8"
+  outdir: "/path/to/cxi_out"
+  det_name: "epix10k2M"
+  event_receiver: "evr0"
+  tag: "lyso"
+  event_logic: false
+  psana_mask: false
+  mask_file: null
+  min_peaks: 10
+  max_peaks: 2048
+  npix_min: 2
+  npix_max: 30
+  amax_thr: 40
+  atot_thr: 180
+  son_min: 10.0
+  peak_rank: 3
+  r0: 3.0
+  dr: 2.0
+  nsigm: 10.0
+  #pv_camera_length: "MFX:ROB:CONT:POS:Z"  # MFX epix10k2M
+  make_powder_plots: true
+  geometry_file: /path/to/my/crystfel.geom
 ```
 
 If you are running from the eLog you do not need to modify the first section at all, unless you want to provide a title for your experiment. You may want to adjust the `task_timeout` if you believe some of your `Task`s are long running. It is in units of seconds. You can change the `work_dir` parameter if you want to write output to some other location, when running the setup script it will be automatically set to your experiment results folder.
@@ -126,4 +134,5 @@ If you are attempting to create a configuration file from scratch refer first to
 In the `utilities` directory (in the main `lute` directory) there are two useful programs to provide assistance with using the software:
 
 - `utilities/dbview`: LUTE stores all parameters for every analysis routine it runs (as well as results) in a database. This database is stored in the `work_dir` defined in the YAML file. The `dbview` utility is a TUI application (Text-based user interface) which runs in the terminal. It allows you to navigate a LUTE database using the arrow keys, etc. Usage is: `utilities/dbview -p <path/to/lute.db>`. You will only have a database after your first **managed** `Task` completes (whether it succeeds or not). (**NOTE:** If using the new database specification v0.2, you can additionally pass the `--summarize` option to `utilities/dbview`. This will pivot and reorganize the data since the table structure is harder to parse at a glance in the new specification.)
-- `utilities/lute_help`: This utility provides help and usage information for running LUTE software. It provides access to parameter descriptions to assist in properly filling out a configuration YAML. It's usage is described in slightly more detail in the `Usage Manual`. Briefly you can run `lute_help -t <TaskName>` to retrieve parameters for a single `Task` (to put in your configuration YAML), or `lute_help -l` to list all `Task`s (and their associated **managed** `Task`s).
+- `utilities/help`: Source code here builds the `lute_help` utility. This utility provides help and usage information for running LUTE software. It provides access to parameter descriptions to assist in properly filling out a configuration YAML. It's usage is described in slightly more detail in the `Usage Manual`. Briefly you can run `lute_help -t <TaskName>` to retrieve parameters for a single `Task` (to put in your configuration YAML), or `lute_help -l` to list all `Task`s (and their associated **managed** `Task`s).
+- `utilities/setup`: Source code for building the setup script described at the top.

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -15,12 +15,12 @@ At the top level of the directory is a script `build.sh` for building the code o
 
 You can run it using:
 ```bash
-> ./build.sh # in top level of the repository you just cloned
+> ./build.sh -e # in top level of the repository you just cloned
 ```
 
 This will create an `install` directory inside the top-level of `LUTE`, and build and install all components there.
 
-The `build.sh` script will create a build environment and cache it in your home directory (under `~/.cache/lute_build_env_XXXX`). The full path is determined from a hash of the installation location. Caching this build environment speeds up subsequent re-builds significantly; however, it can be deleted by passing `-c` to the `build.sh` script when it is run. The full set of options for this script are:
+The `build.sh` script will create a build environment and cache it in your home directory (under `~/.cache/lute_build_env_XXXX_{PYVER}`). The full path is determined from a hash of the installation location. Caching this build environment speeds up subsequent re-builds significantly; however, it can be deleted by passing `-c` to the `build.sh` script when it is run. The full set of options for this script are:
 
 ```bash
 > ./build.sh -h
@@ -50,6 +50,9 @@ build.sh:
           Re-run the meson setup. This is only required if meson.build files have been
           modified, or meson options/the install prefix have changed since the last
           time it was run.
+        -s|--source_pyenv
+          Use an additional source environment. Can be used to build multiple versions
+          of the extensions. E.g. to have 3.9 and 3.11 Python extension libraries.
 ```
 
 The installation can be "activated" after being built. This will put all the relevant scripts and binaries into your path.
@@ -59,3 +62,26 @@ The installation can be "activated" after being built. This will put all the rel
 ```
 
 This activation script is sourced automatically by submission scripts to make the LUTE code available to various job steps.
+
+
+### Important Notes
+
+- You should run the script the first time using the `-e` flag - this will create the Python entry points, i.e. the executables you will use.
+- You may want to provide the `--source_pyenv` flag and build a **second** time. This allows you to have multiple versions of LUTE for different Python versions. LUTE is capable of submitting Tasks across Python versions; however, any C-extensions require that a version be compiled for the target `Task` Python. See example below.
+
+### Running for Different Python Versions
+You may find that you have a first-party `Task` that requires an environment that uses a different Python version than the base-environment that LUTE uses. In this case, you can build LUTE for both the base environment, and the target `Task` environment.
+
+An example of this sort of setup is when runnning the `FindPeaksSFXXpp` `Task`s. The base environment is Python 3.9, but the `..._xpp.sh` environments are Python 3.11. The peak finding algorithms are C-extensions so need to be compiled against that interpreter version.
+
+To deal with this situation, you will build twice.
+
+```bash
+# First time pass `-e` to get the entry-points/executables
+> ./build.sh -e
+# ... building ...
+> ./build.sh --source_pyenv /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh
+# ... building ...
+```
+
+After running twice, you will have two `_buildXYZ` directories. In `install/lib` you will see a `python3.9` and `python3.11` installation.

--- a/extensions/algorithms/peakfinders.cpp
+++ b/extensions/algorithms/peakfinders.cpp
@@ -400,18 +400,18 @@ extern "C" {
         int* rstats_pidx = NULL;
         int* rstats_radius = NULL;
         if (rstats_pidx_obj != Py_None) {
-            if (!is_array_okay(rstats_pidx_obj, 2, NPY_INT32)) {
+            if (!is_array_okay(rstats_pidx_obj, 1, NPY_INT32)) {
                 PyErr_SetString(Peakfinder8Exception,
-                                "rstats_pidx must be a 2D NumPy array of int or None.");
+                                "rstats_pidx must be a 1D NumPy array of int or None.");
                 return NULL;
             }
             PyArrayObject* rstats_pidx_arr = reinterpret_cast<PyArrayObject*>(rstats_pidx_obj);
             rstats_pidx = reinterpret_cast<int*>(PyArray_DATA(rstats_pidx_arr));
         }
         if (rstats_radius_obj != Py_None) {
-            if (!is_array_okay(rstats_radius_obj, 2, NPY_INT32)) {
+            if (!is_array_okay(rstats_radius_obj, 1, NPY_INT32)) {
                 PyErr_SetString(Peakfinder8Exception,
-                                "rstats_radius must be a 2D NumPy array of int or None.");
+                                "rstats_radius must be a 1D NumPy array of int or None.");
                 return NULL;
             }
             PyArrayObject* rstats_radius_arr = reinterpret_cast<PyArrayObject*>(rstats_radius_obj);

--- a/lute/execution/executor.py
+++ b/lute/execution/executor.py
@@ -525,11 +525,15 @@ class BaseExecutor(ABC):
         if not os.path.exists(self._shell_source_script):
             logger.error(f"Cannot source environment from {self._shell_source_script}!")
             return
-
+        # Get both the environment and the python version of the target environment
         script: str = (
             f"set -a\n"
             f'source "{self._shell_source_script}" >/dev/null\n'
-            f'{sys.executable} -c "import os; print(dict(os.environ))"\n'
+            f'NEW_PYVER=$(python3 -c "import sys; '
+            "print(f'python{sys.version_info.major}.{sys.version_info.minor}')\")\n"
+            f'python3 -c "import os; env=dict(os.environ); '
+            "env['LUTE_NEW_PYVER']=os.environ.get('NEW_PYVER', ''); "
+            'print(env)"\n'
         )
         logger.info(f"Sourcing file {self._shell_source_script}")
         subproc_env: Dict[str, str] = {}
@@ -541,6 +545,10 @@ class BaseExecutor(ABC):
         ).communicate()
         tmp_environment: Dict[str, str] = eval(o)
         new_environment: Dict[str, str] = {}
+
+        # For picking up LUTE, the new environment may be a different python version
+        # So we need to make sure to pick it up appropriately for C-extension usage
+        new_pyver: str = tmp_environment.get("LUTE_NEW_PYVER", "python3.9")
         for key, value in tmp_environment.items():
             # Make sure LUTE vars are available
             if "LUTE_" in key or "SLURM_" in key or key in ("RUN", "EXPERIMENT"):
@@ -552,28 +560,55 @@ class BaseExecutor(ABC):
                     # Add identical items first
                     new_environment[key] = value
                 elif key in ("PYTHONPATH", "PATH"):
-                    # Handle PYTHONPATH specifically if above doesn't catch it
                     curr: Optional[str] = os.getenv(key)
                     if curr is not None:
                         if curr in value:
-                            new_environment[key] = value
+                            new_environment[key] = f"{curr}:{value}"
                         else:
-                            # Not in PYTHONPATH, make sure to add it in
-                            new_environment[key] = curr
+                            # Make sure to keep our env first, for dependencies
+                            # e.g. pydantic
+                            new_environment[key] = f"{curr}:{value}"
+                            # For the TENV, make sure they get the environment requested
                             new_environment[f"LUTE_TENV_{key}"] = f"{value}:{curr}"
 
         # Until we make LUTE installable... Need to make sure this is available
         # for first-party Tasks, regardless of the directory they run in if using
         # a new environment
         old_python_path: str = new_environment.get("PYTHONPATH", "")
+        new_python_path: str = new_environment.get("LUTE_TENV_PYTHONPATH", "")
         lute_path: Optional[str] = os.getenv("LUTE_PATH")
+        new_lute_path: Optional[str] = lute_path
         if lute_path is None:
             logger.warning("LUTE_PATH not defined! Task may fail to find LUTE!")
         else:
+            assert new_lute_path
             if old_python_path:
                 new_environment["PYTHONPATH"] = f"{lute_path}:{old_python_path}"
             else:
                 new_environment["PYTHONPATH"] = lute_path
+
+            if new_pyver not in lute_path:
+                # We have a new lute_path to use for a different Python version
+                old_pyver: str = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+                new_lute_path = lute_path.replace(old_pyver, new_pyver)
+                logger.debug(f"Task will use LUTE from: {new_lute_path}")
+
+            if not os.path.exists(new_lute_path):
+                logger.warning(
+                    f"Task will be running in {new_pyver}, but no LUTE installation "
+                    "for that version exists! Things may fail if depending on C "
+                    "extensions!"
+                )
+
+            if new_python_path:
+                new_environment["LUTE_TENV_PYTHONPATH"] = (
+                    f"{new_lute_path}:{new_python_path}"
+                )
+            elif new_lute_path:
+                new_environment["LUTE_TENV_PYTHONPATH"] = new_lute_path
+            else:
+                logger.warning("Could not determine a new Python version LUTE_PATH!")
+
         self._analysis_desc.task_env = new_environment
 
     def _pre_task(self) -> str:

--- a/lute/execution/subprocess_utils.py
+++ b/lute/execution/subprocess_utils.py
@@ -34,7 +34,6 @@ param_values: Dict[str, Any]
 definition, param_values = get_task_parameters_defn_and_params(db_dir="{work_dir}", row_ids=row_ids)
 new_params: TaskParameters = construct_task_parameters(schema=definition, values=param_values)
 new_params.lute_config.work_dir = "{work_dir}"
-print("Running a first-party Task in a new environment.", flush=True)
 task: Task = TaskType(params=new_params, row_ids=row_ids)
 task.run()
 """

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -52,7 +52,7 @@ class FindPeaksSFXParameters(TaskParameters):
         "",
         description="Tag to add to the output file names",
     )
-    pv_camera_length: Union[str, float] = Field(
+    pv_camera_length: Union[float, str] = Field(
         description="PV associated with camera length "
         "(if a number, camera length directly)",
     )
@@ -126,7 +126,7 @@ class FindPeaksSFXParameters(TaskParameters):
         is_result=True,
     )
 
-    geometry_file: Optional[Union[str, os.PathLike]] = Field(
+    geometry_file: Optional[str] = Field(
         None,
         description="A path to a CrystFEL geometry file (for pf8).",
     )

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -20,7 +20,12 @@ class SZCompressorParameters(BaseModel):
 
 
 class FindPeaksSFXParameters(TaskParameters):
-    """Parameters for crystallographic (Bragg) peak finding using PyAlgos.
+    """Parameters for crystallographic (Bragg) peak finding using PyAlgos or Peakfinder8.
+
+    The Peakfinder8 algorithm comes in two flavors "Peakfinder8" and "Peakfinder8_v2",
+    the latter does not use a "slab" geometry. This, however, is not currently supported
+    by downstream CrystFEL so should not yet be used for full pipelines.
+
 
     This peak finding Task optionally has the ability to compress/decompress
     data with SZ for the purpose of compression validation.
@@ -30,9 +35,9 @@ class FindPeaksSFXParameters(TaskParameters):
         set_result: bool = True
         """Whether the Executor should mark a specified parameter as a result."""
 
-    algorithm: Literal["PyAlgos", "Peakfinder8"] = Field(
+    algorithm: Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"] = Field(
         default="Peakfinder8",
-        description="The peakfinding algorithm to use. Either Peakfinder8 or PyAlgos.",
+        description="The peakfinding algorithm to use. Either Peakfinder8 (v1 or v2) or PyAlgos.",
     )
 
     outdir: str = Field(
@@ -125,10 +130,13 @@ class FindPeaksSFXParameters(TaskParameters):
         description="Path to output file.",
         is_result=True,
     )
-
     geometry_file: Optional[str] = Field(
         None,
         description="A path to a CrystFEL geometry file (for pf8).",
+    )
+    make_powder_plots: bool = Field(
+        True,
+        description="Whether to generate assembled powder plots in the eLog.",
     )
 
     @validator("out_file", always=True)

--- a/lute/io/models/sfx_find_peaks.py
+++ b/lute/io/models/sfx_find_peaks.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, PositiveInt, validator, root_validator
 
-from .base import ThirdPartyParameters, TaskParameters, TemplateConfig
+from lute.io.models.base import ThirdPartyParameters, TaskParameters, TemplateConfig
 
 
 class SZCompressorParameters(BaseModel):
@@ -19,7 +19,7 @@ class SZCompressorParameters(BaseModel):
     )
 
 
-class FindPeaksPyAlgosParameters(TaskParameters):
+class FindPeaksSFXParameters(TaskParameters):
     """Parameters for crystallographic (Bragg) peak finding using PyAlgos.
 
     This peak finding Task optionally has the ability to compress/decompress
@@ -29,6 +29,11 @@ class FindPeaksPyAlgosParameters(TaskParameters):
     class Config(TaskParameters.Config):
         set_result: bool = True
         """Whether the Executor should mark a specified parameter as a result."""
+
+    algorithm: Literal["PyAlgos", "Peakfinder8"] = Field(
+        default="Peakfinder8",
+        description="The peakfinding algorithm to use. Either Peakfinder8 or PyAlgos.",
+    )
 
     outdir: str = Field(
         description="Output directory for cxi files",
@@ -118,9 +123,12 @@ class FindPeaksPyAlgosParameters(TaskParameters):
     out_file: str = Field(
         "",
         description="Path to output file.",
-        flag_type="-",
-        rename_param="o",
         is_result=True,
+    )
+
+    geometry_file: Optional[Union[str, os.PathLike]] = Field(
+        None,
+        description="A path to a CrystFEL geometry file (for pf8).",
     )
 
     @validator("out_file", always=True)

--- a/lute/io/models/sfx_index.py
+++ b/lute/io/models/sfx_index.py
@@ -416,9 +416,9 @@ class IndexCrystFELParameters(ThirdPartyParameters):
                 "result.payload",
             )
             if filename is None:
-                # Check PyAlgos
+                # Check FindPeaksSFX
                 filename = read_latest_db_entry(
-                    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "out_file"
+                    f"{values['lute_config'].work_dir}", "FindPeaksSFX", "out_file"
                 )
                 if filename is None:
                     # Check Psocake last
@@ -464,7 +464,7 @@ class IndexCrystFELParameters(ThirdPartyParameters):
                 run: int = int(values["lute_config"].run)
                 work_dir: str = values["lute_config"].work_dir
                 tag: Optional[str] = read_latest_db_entry(
-                    f"{values['lute_config'].work_dir}", "FindPeaksPyAlgos", "tag"
+                    f"{values['lute_config'].work_dir}", "FindPeaksSFX", "tag"
                 )
                 if tag is None:
                     tag = read_latest_db_entry(

--- a/lute/io/parameters.py
+++ b/lute/io/parameters.py
@@ -71,7 +71,7 @@ def handle_field_attrs(self, *args, **kwargs):
     """"""
     for param_name, param_val in kwargs.items():
         setattr(self, param_name, param_val)
-        type(self)._dict[param_name] = param_val
+        self._dict[param_name] = param_val
 
 
 class RowIds(TypedDict):
@@ -108,7 +108,8 @@ class AnalysisHeader(ContainerBase):
     work_dir: str
 
     def __init__(self, schema: Dict[str, Any], *args, **kwargs):
-        type(self)._schema = schema
+        self._dict = {}
+        self._schema = schema
         handle_field_attrs(self, *args, **kwargs)
 
 
@@ -179,7 +180,8 @@ class TaskParameters(ContainerBase):
     _dict: Dict[str, Any] = {}
 
     def __init__(self, schema: Dict[str, Any], *args, **kwargs):
-        type(self)._schema = schema
+        self._schema = schema
+        self._dict = {}
         handle_field_attrs(self, *args, **kwargs)
 
     def schema(self):
@@ -226,7 +228,8 @@ class TemplateConfig:
     _schema: Dict[str, Any] = {}
 
     def __init__(self, schema: Dict[str, Any], *args, **kwargs):
-        type(self)._schema = schema
+        self._schema = schema
+        self._dict: Dict[str, Any] = {}
         handle_field_attrs(self, *args, **kwargs)
 
 

--- a/lute/io/parameters.py
+++ b/lute/io/parameters.py
@@ -417,4 +417,9 @@ def construct_task_parameters(schema: Dict[str, Any], values: Dict[str, Any]) ->
         obj = obj_type(**fields_for_params)
     else:
         obj = obj_type(schema, **fields_for_params)
+
+    if hasattr(obj, "_dict"):
+        # This is messy - leftover from the object construction.
+        # TODO: The above process should be cleaned up at some point.
+        del obj._dict
     return obj

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -187,6 +187,12 @@ DimpleSolver.add_tasklet(
 PeakFinderSFX: MPIExecutor = MPIExecutor("FindPeaksSFX")
 """Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
 
+PeakFinderSFXPressio: MPIExecutor = MPIExecutor("FindPeaksSFX")
+"""Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
+PeakFinderSFXPressio.shell_source(
+    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh"
+)
+
 SHELXCRunner: Executor = Executor("RunSHELXC")
 """Runs CCP4 SHELXC - needed for crystallographic phasing."""
 SHELXCRunner.shell_source("/sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -184,8 +184,14 @@ DimpleSolver.add_tasklet(
     set_summary=True,
 )
 
-PeakFinderPyAlgos: MPIExecutor = MPIExecutor("FindPeaksPyAlgos")
-"""Performs Bragg peak finding using the PyAlgos algorithm."""
+PeakFinderSFX: MPIExecutor = MPIExecutor("FindPeaksSFX")
+"""Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
+PeakFinderSFX.shell_source("/sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh")
+
+PeakFinderSFX2: MPIExecutor = MPIExecutor("FindPeaksSFX")
+"""Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
+PeakFinderSFX2.shell_source("/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh")
+
 
 SHELXCRunner: Executor = Executor("RunSHELXC")
 """Runs CCP4 SHELXC - needed for crystallographic phasing."""

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -187,10 +187,16 @@ DimpleSolver.add_tasklet(
 PeakFinderSFX: MPIExecutor = MPIExecutor("FindPeaksSFX")
 """Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
 
-PeakFinderSFXPressio: MPIExecutor = MPIExecutor("FindPeaksSFX")
+PeakFinderSFXXpp: MPIExecutor = MPIExecutor("FindPeaksSFX")
 """Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
-PeakFinderSFXPressio.shell_source(
+PeakFinderSFXXpp.shell_source(
     "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_cpu.sh"
+)
+
+PeakFinderSFXXppGpu: MPIExecutor = MPIExecutor("FindPeaksSFX")
+"""Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
+PeakFinderSFXXppGpu.shell_source(
+    "/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/xpp_drp_gpu.sh"
 )
 
 SHELXCRunner: Executor = Executor("RunSHELXC")

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -186,12 +186,6 @@ DimpleSolver.add_tasklet(
 
 PeakFinderSFX: MPIExecutor = MPIExecutor("FindPeaksSFX")
 """Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
-PeakFinderSFX.shell_source("/sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh")
-
-PeakFinderSFX2: MPIExecutor = MPIExecutor("FindPeaksSFX")
-"""Performs Bragg peak finding using the PyAlgos or Peakfinder8 algorithm."""
-PeakFinderSFX2.shell_source("/sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh")
-
 
 SHELXCRunner: Executor = Executor("RunSHELXC")
 """Runs CCP4 SHELXC - needed for crystallographic phasing."""

--- a/lute/tasks/__init__.py
+++ b/lute/tasks/__init__.py
@@ -56,10 +56,10 @@ def import_task(task_name: str) -> Type[Task]:
 
         return TestWriteOutput
 
-    if task_name == "FindPeaksPyAlgos":
-        from .sfx_find_peaks import FindPeaksPyAlgos
+    if task_name == "FindPeaksSFX":
+        from .sfx_find_peaks import FindPeaksSFX
 
-        return FindPeaksPyAlgos
+        return FindPeaksSFX
 
     if task_name == "ConcatenateStreamFiles":
         from .sfx_index import ConcatenateStreamFiles

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -4,8 +4,9 @@ Classes for peak finding tasks in SFX.
 Classes:
     CxiWriter: utility class for writing peak finding results to CXI files.
 
-    FindPeaksPyAlgos: peak finding using psana's PyAlgos algorithm. Optional data
-        compression and decompression with libpressio for data reduction tests.
+    FindPeaksSFX: peak finding using psana's PyAlgos algorithm or peakfinder8.
+        Optional data compression and decompression with libpressio for data
+        reduction tests.
 """
 
 __all__ = ["CxiWriter", "FindPeaksSFX"]
@@ -22,10 +23,11 @@ from typing import (
     Generator,
     List,
     Literal,
+    Optional,
     TextIO,
     Tuple,
     TypedDict,
-    Optional,
+    TYPE_CHECKING,
     Union,
     cast,
 )
@@ -44,10 +46,17 @@ from mpi4py.MPI import COMM_WORLD, SUM
 
 from lute.execution.logging import get_logger
 from lute.execution.ipc import Message
-from lute.io.models.sfx_find_peaks import FindPeaksSFXParameters
 from lute.tasks.algorithms import _peakfinders_ext  # type: ignore
 from lute.tasks.task import Task
 from lute.tasks.dataclasses import TaskStatus, ElogSummaryPlots
+
+if TYPE_CHECKING:
+    from lute.io.models.sfx_find_peaks import FindPeaksSFXParameters
+else:
+    from lute.io.parameters import TaskParameters
+
+    FindPeaksSFXParameters = TaskParameters
+
 
 hv.extension("bokeh")
 pn.extension()
@@ -850,9 +859,11 @@ class FindPeaksSFX(Task):
     writes the peak information to CXI files.
     """
 
-    def __init__(self, *, params: FindPeaksSFXParameters, use_mpi: bool = True) -> None:
+    def __init__(
+        self, *, params: FindPeaksSFXParameters, use_mpi: bool = True, row_ids=None
+    ) -> None:
         self._task_parameters: FindPeaksSFXParameters = params
-        super().__init__(params=params, use_mpi=use_mpi)
+        super().__init__(params=params, use_mpi=use_mpi, row_ids=row_ids)
 
         self._algo: Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"] = (
             self._task_parameters.algorithm

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -8,30 +8,75 @@ Classes:
         compression and decompression with libpressio for data reduction tests.
 """
 
-__all__ = ["CxiWriter", "FindPeaksPyAlgos"]
+__all__ = ["CxiWriter", "FindPeaksSFX"]
 __author__ = "Valerio Mariani, Gabriel Dorlhiac"
 
+import random
 import sys
+from collections import namedtuple
 from pathlib import Path
-from typing import Any, Dict, List, Literal, TextIO, Tuple, Optional, cast, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Literal,
+    TextIO,
+    Tuple,
+    TypedDict,
+    Optional,
+    Union,
+    cast,
+)
+
+try:
+    from typing import TypeAlias  # type: ignore
+except ImportError:
+    from typing_extensions import TypeAlias
 
 import h5py  # type: ignore
 import holoviews as hv  # type: ignore
-import numpy
+import numpy as np
+import numpy.typing as npt
 import panel as pn
 from mpi4py.MPI import COMM_WORLD, SUM
-from numpy.typing import NDArray
-from psalgos.pypsalgos import PyAlgos  # type: ignore
-from psana import Detector, EventId, MPIDataSource  # type: ignore
-from PSCalib import GeometryAccess  # type: ignore
 
+from lute.tasks.algorithms import _peakfinders_ext  # type: ignore
 from lute.execution.ipc import Message
-from lute.io.models.sfx_find_peaks import FindPeaksPyAlgosParameters
+from lute.io.models.sfx_find_peaks import FindPeaksSFXParameters
 from lute.tasks.task import Task
 from lute.tasks.dataclasses import TaskStatus, ElogSummaryPlots
 
 hv.extension("bokeh")
 pn.extension()
+
+
+class RadialStatistics(TypedDict):
+    rstats_pixel_index: npt.NDArray[np.int32]
+    rstats_radius: npt.NDArray[np.int32]
+    rstats_num_pix: int
+    radial_map: npt.NDArray[np.float64]
+
+
+class Peakfinder8PeakList(TypedDict):
+    num_peaks: int
+    fs: List[float]
+    ss: List[float]
+    intensity: List[float]
+    num_pixels: List[float]
+    max_pixel_intensity: List[float]
+    snr: List[float]
+
+
+EventData = namedtuple(
+    "EventData",
+    ["data", "mask", "seconds", "nanoseconds", "fiducials", "clen", "photon_energy"],
+)
+
+DetectorGeomInfo = namedtuple("DetectorGeomInfo", ["i_x", "i_y", "ipx", "ipy"])
+
+PyAlgos: TypeAlias = Any
+Detector: TypeAlias = Any
 
 
 class CxiWriter:
@@ -52,6 +97,7 @@ class CxiWriter:
         ipx: Any,  # Not typed becomes it comes from psana
         ipy: Any,  # Not typed becomes it comes from psana
         tag: str,
+        algo: Literal["Peakfinder8", "PyAlgos"] = "Peakfinder8",
     ):
         """
         Set up the CXI files to which peak finding results will be saved.
@@ -87,6 +133,8 @@ class CxiWriter:
             ipy (Any): Pixel indexes with respect to detector origin (y component)
 
             tag (str): Tag to append to cxi file names.
+
+            algo (str): The algorithm being used - either Peakfinder8 or PyAlgos.
         """
         self._det_shape: Tuple[int, ...] = det_shape
         self._raw_det_shape: Tuple[int, ...] = raw_det_shape
@@ -103,20 +151,33 @@ class CxiWriter:
 
         # Entry_1 entry for processing with CrystFEL
         entry_1: Any = self._outh5.create_group("entry_1")
-        keys: List[str] = [
-            "nPeaks",
-            "peakXPosRaw",
-            "peakYPosRaw",
-            "rcent",
-            "ccent",
-            "rmin",
-            "rmax",
-            "cmin",
-            "cmax",
-            "peakTotalIntensity",
-            "peakMaxIntensity",
-            "peakRadius",
-        ]
+
+        keys: List[str]
+        if algo == "Peakfinder8":
+            keys = [
+                "nPeaks",
+                "peakXPosRaw",
+                "peakYPosRaw",
+                "peakNPixels",
+                "peakTotalIntensity",
+                "peakMaxIntensity",
+                "peakSNR",
+            ]
+        else:
+            keys = [
+                "nPeaks",
+                "peakXPosRaw",
+                "peakYPosRaw",
+                "rcent",
+                "ccent",
+                "rmin",
+                "rmax",
+                "cmin",
+                "cmax",
+                "peakTotalIntensity",
+                "peakMaxIntensity",
+                "peakRadius",
+            ]
         ds_expId: Any = entry_1.create_dataset(
             "experimental_identifier", (n_events,), maxshape=(None,), dtype=int
         )
@@ -126,7 +187,7 @@ class CxiWriter:
             (n_events, det_shape[0], det_shape[1]),
             chunks=(1, det_shape[0], det_shape[1]),
             maxshape=(None, det_shape[0], det_shape[1]),
-            dtype=numpy.float32,
+            dtype=np.float32,
         )
         data_1.attrs["axes"] = "experiment_identifier"
         key: str
@@ -188,20 +249,21 @@ class CxiWriter:
 
     def write_event(
         self,
-        img: NDArray[numpy.float64],
+        img: npt.NDArray[np.float64],
         peaks: Any,  # Not typed becomes it comes from psana
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
         timestamp_fiducials: int,
         photon_energy: float,
         clen: float,
+        algo: Literal["Peakfinder8", "PyAlgos"] = "Peakfinder8",
     ):
         """
         Write peak finding results for an event into the HDF5 file.
 
         Parameters:
 
-            img (NDArray[numpy.float64]): Detector data for the event
+            img (npt.NDArray[np.float64]): Detector data for the event
 
             peaks: (Any): Peak information for the event, as recovered from the PyAlgos
                 algorithm
@@ -218,10 +280,104 @@ class CxiWriter:
 
             clen (float): Camera length/detector distance.
         """
-        ch_rows: NDArray[numpy.float64] = (
+        if algo == "PyAlgos":
+            self._write_event_pyalgos(
+                img=img,
+                peaks=peaks,
+                timestamp_seconds=timestamp_seconds,
+                timestamp_nanoseconds=timestamp_nanoseconds,
+                timestamp_fiducials=timestamp_fiducials,
+                photon_energy=photon_energy,
+                clen=clen,
+            )
+        elif algo == "Peakfinder8":
+            self._write_event_peakfinder8(
+                img=img,
+                peaks=peaks,
+                timestamp_seconds=timestamp_seconds,
+                timestamp_nanoseconds=timestamp_nanoseconds,
+                timestamp_fiducials=timestamp_fiducials,
+                photon_energy=photon_energy,
+                clen=clen,
+            )
+        else:
+            raise ValueError(f"Unsupported peakfinding algorithm {algo}!")
+
+    def _write_event_peakfinder8(
+        self,
+        img: npt.NDArray[np.float64],
+        peaks: Peakfinder8PeakList,
+        timestamp_seconds: int,
+        timestamp_nanoseconds: int,
+        timestamp_fiducials: int,
+        photon_energy: float,
+        clen: float,
+    ) -> None:
+        if self._outh5["/entry_1/data_1/data"].shape[0] <= self._index:
+            self._outh5["entry_1/data_1/data"].resize(self._index + 1, axis=0)
+            ds_key: str
+            for ds_key in self._outh5["/entry_1/result_1"].keys():
+                self._outh5[f"/entry_1/result_1/{ds_key}"].resize(
+                    self._index + 1, axis=0
+                )
+            for ds_key in (
+                "machineTime",
+                "machineTimeNanoSeconds",
+                "fiducial",
+                "photon_energy_eV",
+                "detector_1/EncoderValue",
+            ):
+                self._outh5[f"/LCLS/{ds_key}"].resize(self._index + 1, axis=0)
+
+        # Entry_1 entry for processing with CrystFEL
+        self._outh5["/entry_1/data_1/data"][self._index, :, :] = img.reshape(
+            -1, img.shape[-1]
+        )
+        num_peaks: int = peaks["num_peaks"]
+        self._outh5["/entry_1/result_1/nPeaks"][self._index] = num_peaks
+        self._outh5["/entry_1/result_1/peakXPosRaw"][self._index, :num_peaks] = (
+            np.array(peaks["fs"], dtype=np.float32)
+        )
+        self._outh5["/entry_1/result_1/peakYPosRaw"][self._index, :num_peaks] = (
+            np.array(peaks["ss"], dtype=np.float32)
+        )
+        self._outh5["/entry_1/result_1/peakNPixels"][self._index, :num_peaks] = (
+            np.array(peaks["num_pixels"], dtype=np.float32)
+        )
+        self._outh5["/entry_1/result_1/peakTotalIntensity"][self._index, :num_peaks] = (
+            np.array(peaks["intensity"], dtype=np.float32)
+        )
+        self._outh5["/entry_1/result_1/peakMaxIntensity"][self._index, :num_peaks] = (
+            np.array(peaks["max_pixel_intensity"], dtype=np.float32)
+        )
+        self._outh5["/entry_1/result_1/peakSNR"][self._index, :num_peaks] = np.array(
+            peaks["snr"], dtype=np.float32
+        )
+
+        # LCLS entry dataset
+        self._outh5["/LCLS/machineTime"][self._index] = timestamp_seconds
+        self._outh5["/LCLS/machineTimeNanoSeconds"][self._index] = timestamp_nanoseconds
+        self._outh5["/LCLS/fiducial"][self._index] = timestamp_fiducials
+        self._outh5["/LCLS/photon_energy_eV"][self._index] = photon_energy
+
+        # Add clen distance
+        self._outh5["/LCLS/detector_1/EncoderValue"][self._index] = clen
+        self._index += 1
+
+    def _write_event_pyalgos(
+        self,
+        img: npt.NDArray[np.float64],
+        peaks: Any,  # Not typed becomes it comes from psana
+        timestamp_seconds: int,
+        timestamp_nanoseconds: int,
+        timestamp_fiducials: int,
+        photon_energy: float,
+        clen: float,
+    ) -> None:
+        ch_rows: npt.NDArray[np.float64] = (
             peaks[:, 0] * self._raw_det_shape[-2] + peaks[:, 1]
         )
-        ch_cols: NDArray[numpy.float64] = peaks[:, 2]
+        ch_cols: npt.NDArray[np.float64] = peaks[:, 2]
 
         if self._outh5["/entry_1/data_1/data"].shape[0] <= self._index:
             self._outh5["entry_1/data_1/data"].resize(self._index + 1, axis=0)
@@ -276,25 +432,25 @@ class CxiWriter:
         ] = peaks[:, 4]
 
         # Calculate and write pixel radius
-        peaks_cenx: NDArray[numpy.float64] = (
+        peaks_cenx: npt.NDArray[np.float64] = (
             self._i_x[
-                numpy.array(peaks[:, 0], dtype=numpy.int64),
-                numpy.array(peaks[:, 1], dtype=numpy.int64),
-                numpy.array(peaks[:, 2], dtype=numpy.int64),
+                np.array(peaks[:, 0], dtype=np.int64),
+                np.array(peaks[:, 1], dtype=np.int64),
+                np.array(peaks[:, 2], dtype=np.int64),
             ]
             + 0.5
             - self._ipx
         )
-        peaks_ceny: NDArray[numpy.float64] = (
+        peaks_ceny: npt.NDArray[np.float64] = (
             self._i_y[
-                numpy.array(peaks[:, 0], dtype=numpy.int64),
-                numpy.array(peaks[:, 1], dtype=numpy.int64),
-                numpy.array(peaks[:, 2], dtype=numpy.int64),
+                np.array(peaks[:, 0], dtype=np.int64),
+                np.array(peaks[:, 1], dtype=np.int64),
+                np.array(peaks[:, 2], dtype=np.int64),
             ]
             + 0.5
             - self._ipy
         )
-        peak_radius: NDArray[numpy.float64] = numpy.sqrt(
+        peak_radius: npt.NDArray[np.float64] = np.sqrt(
             (peaks_cenx**2) + (peaks_ceny**2)
         )
         self._outh5["/entry_1/result_1/peakRadius"][
@@ -313,20 +469,20 @@ class CxiWriter:
 
     def write_non_event_data(
         self,
-        powder_hits: NDArray[numpy.float64],
-        powder_misses: NDArray[numpy.float64],
-        mask: NDArray[numpy.uint16],
+        powder_hits: npt.NDArray[np.float64],
+        powder_misses: npt.NDArray[np.float64],
+        mask: npt.NDArray[np.uint16],
     ):
         """
         Write to the file data that is not related to a specific event (masks, powders)
 
         Parameters:
 
-            powder_hits (NDArray[numpy.float64]): Virtual powder pattern from hits
+            powder_hits (npt.NDArray[np.float64]): Virtual powder pattern from hits
 
-            powder_misses (NDArray[numpy.float64]): Virtual powder pattern from hits
+            powder_misses (npt.NDArray[np.float64]): Virtual powder pattern from hits
 
-            mask: (NDArray[numpy.uint16]): Pixel ask to write into the file
+            mask: (npt.NDArray[np.uint16]): Pixel ask to write into the file
 
         """
         # Add powders and mask to files, reshaping them to match the crystfel
@@ -451,9 +607,9 @@ def write_master_file(
 
     # Compute cumulative powder hits and misses for all files
     # Copy mask as well
-    mask: Optional[NDArray[numpy.uint16]] = None
-    powder_hits: Optional[NDArray[numpy.float64]] = None
-    powder_misses: Optional[NDArray[numpy.float64]] = None
+    mask: Optional[npt.NDArray[np.uint16]] = None
+    powder_hits: Optional[npt.NDArray[np.float64]] = None
+    powder_misses: Optional[npt.NDArray[np.float64]] = None
     for fn in fnames:
         f = h5py.File(fn, "r")
         if mask is None:
@@ -463,10 +619,10 @@ def write_master_file(
             powder_misses = f["entry_1/data_1/powderMisses"][:].copy()
         else:
             assert powder_misses is not None
-            powder_hits = numpy.maximum(
+            powder_hits = np.maximum(
                 powder_hits, f["entry_1/data_1/powderHits"][:].copy()
             )
-            powder_misses = numpy.maximum(
+            powder_misses = np.maximum(
                 powder_misses, f["entry_1/data_1/powderMisses"][:].copy()
             )
         f.close()
@@ -521,7 +677,7 @@ def generate_libpressio_configuration(
 
         roi_window_size (int): Default size of the ROI window.
 
-        libpressio_mask (NDArray): mask to be applied to the data.
+        libpressio_mask (npt.NDArray): mask to be applied to the data.
 
     Returns:
 
@@ -588,7 +744,32 @@ def generate_libpressio_configuration(
     return lp_json
 
 
-def add_peaks_to_libpressio_configuration(lp_json, peaks) -> Dict[str, Any]:
+def _libpressio_config_pyalgos(lp_json: Dict[str, Any], peaks: Any) -> Dict[str, Any]:
+    # assert not isinstance(peaks, dict)
+    lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = (
+        np.ascontiguousarray(np.uint64(peaks[:, [2, 1, 0]])).astype(np.uint64)
+    )
+
+    return lp_json
+
+
+def _libpressio_config_pf8(
+    lp_json: Dict[str, Any], peaks: Peakfinder8PeakList
+) -> Dict[str, Any]:
+    peaks_rotated: npt.NDArray[np.uint64] = np.zeros(
+        (peaks["num_peaks"], 2), dtype=np.uint64
+    )
+    peaks_rotated[:, 0] = np.array(peaks["fs"]).astype(np.uint64)
+    peaks_rotated[:, 1] = np.array(peaks["ss"]).astype(np.uint64)
+    lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = peaks_rotated
+    return lp_json
+
+
+def add_peaks_to_libpressio_configuration(
+    lp_json: Dict[str, Any],
+    peaks: Union[Peakfinder8PeakList, Any],
+    algo: Literal["Peakfinder8", "PyAlgos"],
+) -> Dict[str, Any]:
     """
     Add peak infromation to libpressio configuration
 
@@ -603,114 +784,351 @@ def add_peaks_to_libpressio_configuration(lp_json, peaks) -> Dict[str, Any]:
 
         lp_json: Updated configuration JSON structure for the libpressio library.
     """
-    lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = (
-        numpy.ascontiguousarray(numpy.uint64(peaks[:, [2, 1, 0]]))
-    )
-    return lp_json
+    if algo == "Peakfinder8":
+        return _libpressio_config_pf8(lp_json=lp_json, peaks=peaks)
+    else:
+        return _libpressio_config_pyalgos(lp_json=lp_json, peaks=peaks)
 
 
-class FindPeaksPyAlgos(Task):
+class FindPeaksSFX(Task):
     """
     Task that performs peak finding using the PyAlgos peak finding algorithms and
     writes the peak information to CXI files.
     """
 
-    def __init__(
-        self, *, params: FindPeaksPyAlgosParameters, use_mpi: bool = True
-    ) -> None:
+    def __init__(self, *, params: FindPeaksSFXParameters, use_mpi: bool = True) -> None:
+        self._task_parameters: FindPeaksSFXParameters = params
         super().__init__(params=params, use_mpi=use_mpi)
 
+        self._algo: Literal["PyAlgos", "Peakfinder8"] = self._task_parameters.algorithm
+
+    def get_radius_map(self) -> npt.NDArray[np.float64]:
+        from lute.tasks.util.geometry import (
+            CrystfelDetectorGeometry,
+            PixelMaps,
+            crystfel_to_pixel_map,
+            parse_crystfel_geometry_file,
+        )
+
+        if self._task_parameters.geometry_file is not None:
+            geom_desc: CrystfelDetectorGeometry = parse_crystfel_geometry_file(
+                file_path=self._task_parameters.geometry_file
+            )
+            pixel_maps: PixelMaps = crystfel_to_pixel_map(geometry_desc=geom_desc)
+            return pixel_maps["radius_map"]
+        else:
+            raise RuntimeError("Need a geometry file to compute radius map!")
+
+    def compute_radial_statistics(self, num_bins: int = 100) -> RadialStatistics:
+        radius_map: npt.NDArray[np.float64] = self.get_radius_map()
+        radius_map_int: npt.NDArray[np.int8] = np.rint(radius_map).astype(int).ravel()
+        peak_index: List[int] = []
+        radius: List[int] = []
+        for idx in np.split(
+            np.argsort(radius_map_int, kind="mergesort"),
+            np.cumsum(np.bincount(radius_map_int)[:-1]),
+        ):
+            if len(idx) < num_bins:
+                peak_index.extend(idx)
+                radius.extend(radius_map_int[(idx,)])
+            else:
+                idx_sample: List[int] = random.sample(list(idx), num_bins)
+                peak_index.extend(idx_sample)
+                radius.extend(radius_map_int[(idx_sample,)])
+
+        rstats_pixel_index: npt.NDArray[np.int32] = np.array(peak_index).astype(
+            np.int32
+        )
+        rstats_radius: npt.NDArray[np.int32] = np.array(radius).astype(np.int32)
+
+        return {
+            "rstats_pixel_index": rstats_pixel_index,
+            "rstats_radius": rstats_radius,
+            "rstats_num_pix": rstats_pixel_index.shape[0],
+            "radial_map": radius_map,
+        }
+
+    def _retrieve_psana_detector_data(self, lcls2: bool = True) -> DetectorGeomInfo:
+        exp: str = self._task_parameters.lute_config.experiment
+        run_num: int = int(self._task_parameters.lute_config.run)
+
+        if lcls2:
+            import psana  # type: ignore
+
+            ds2: psana.psexp.mpi_ds.ParallelDataSource = psana.DataSource(
+                exp=exp,
+                run=run_num,
+            )
+            run2: psana.psexp.mpi_ds.RunParallel = next(ds2.runs())
+            det2 = run2.Detector(self._task_parameters.det_name)
+
+            i_x, i_y = det2.raw._pixel_coord_indexes()
+
+            ipx, ipy = det2.raw._pixel_xy_at_z()
+            return DetectorGeomInfo(i_x=i_x, i_y=i_y, ipx=ipx, ipy=ipy)
+        else:
+            from psana import Detector, MPIDataSource  # type: ignore
+
+            ds: Any = MPIDataSource(f"exp={exp}:run={run_num}:smd")  # noqa
+
+            det: Any = Detector(self._task_parameters.det_name)
+            det.do_reshape_2d_to_3d(flag=True)
+            i_x = det.indexes_x(self._task_parameters.lute_config.run).astype(np.int64)
+            i_y = det.indexes_y(self._task_parameters.lute_config.run).astype(np.int64)
+            ipx, ipy = det.point_indexes(
+                self._task_parameters.lute_config.run, pxy_um=(0, 0)
+            )
+
+            return DetectorGeomInfo(i_x=i_x, i_y=i_y, ipx=ipx, ipy=ipy)
+
+    def _event_generator(self, lcls2: bool = True) -> Generator[EventData, None, None]:
+        exp: str = self._task_parameters.lute_config.experiment
+        run_num: int = int(self._task_parameters.lute_config.run)
+
+        if lcls2:
+            import psana  # type: ignore
+
+            ds2: psana.psexp.mpi_ds.ParallelDataSource = psana.DataSource(
+                exp=exp,
+                run=run_num,
+            )
+            run2: psana.psexp.mpi_ds.RunParallel = next(ds2.runs())
+            timing2 = run2.Detector("timing")
+
+            det2 = run2.Detector(self._task_parameters.det_name)
+
+            # TODO: Need to handle other BLD?
+            ebeamh = run2.Detector("ebeamh")
+
+            mask2: Optional[npt.NDArray[np.uint8]] = None
+            for evt in run2.events():
+                data: Optional[npt.NDArray[np.float32]] = det2.raw.calib(evt)
+
+                raw_timestamp: Optional[int] = timing2.raw.timestamp(evt)
+
+                # Fiducial only makes sense if actually on LCLS1 timing
+                raw_fiducial2: Optional[int] = None
+                seconds2: Optional[int] = None
+                nanoseconds2: Optional[int] = None
+                if raw_timestamp:
+                    raw_fiducial2 = raw_timestamp & 0x1FFFF
+                    nanoseconds2 = raw_timestamp & 0xFFFFFFFF
+                    seconds2 = raw_timestamp >> 32
+
+                photon_energy2: Optional[float] = None
+                try:
+                    photon_energy2 = ebeamh.raw.ebeamPhotonEnergy(evt)
+                    if photon_energy2 and np.isinf(photon_energy2):
+                        raise ValueError
+
+                except (AttributeError, ValueError):
+                    ebeam_raw: Optional[float] = run2.Detector("SIOC:SYS0:ML00:AO192")(
+                        evt
+                    )
+                    if ebeam_raw:
+                        photon_energy2 = (1.23984197386209e-06 / ebeam_raw) * 1e9
+
+                if isinstance(self._task_parameters.pv_camera_length, float):
+                    clen2: float = self._task_parameters.pv_camera_length
+                else:
+                    clen2 = run2.Detector(self._task_parameters.pv_camera_length)(evt)
+
+                if data is not None:
+                    det2_shape: Tuple[int, ...] = data.shape
+                    if len(det2_shape) == 3:
+                        det2_shape = (det2_shape[0] * det2_shape[1], det2_shape[2])
+                    else:
+                        det2_shape = data.shape
+                    if hasattr(det2.raw, "_mask"):
+                        mask2 = det2.raw._mask()
+                    else:
+                        mask2 = np.ones(det2_shape).astype(np.uint16)
+
+                yield EventData(
+                    data,
+                    mask2,
+                    seconds2,
+                    nanoseconds2,
+                    raw_fiducial2,
+                    clen2,
+                    photon_energy2,
+                )
+        else:
+            from psana import Detector, EventId, MPIDataSource  # type: ignore
+
+            ds: Any = MPIDataSource(f"exp={exp}:run={run_num}:smd")
+            det: Any = Detector(self._task_parameters.det_name)
+            det.do_reshape_2d_to_3d(flag=True)
+            evr: Any = Detector(self._task_parameters.event_receiver)
+
+            if self._task_parameters.n_events != 0:
+                ds.break_after(self._task_parameters.n_events)
+
+            for evt in ds.events():
+                evt_id: Any = evt.get(EventId)
+                seconds: int = evt_id.time()[0]
+                nanoseconds: int = evt_id.time()[1]
+                fiducials: int = evt_id.fiducials()
+                event_codes: Any = evr.eventCodes(evt)
+
+                if isinstance(self._task_parameters.pv_camera_length, float):
+                    clen: float = self._task_parameters.pv_camera_length
+                else:
+                    clen = (
+                        ds.env()
+                        .epicsStore()
+                        .value(self._task_parameters.pv_camera_length)
+                    )
+
+                if self._task_parameters.event_logic:
+                    if self._task_parameters.event_code not in event_codes:
+                        continue
+
+                data = det.calib(evt)
+                mask: Optional[npt.NDArray[np.uint16]] = None
+                if data:
+                    det_shape: Tuple[int, ...] = data.shape
+                    if len(det_shape) == 3:
+                        det_shape = (det_shape[0] * det_shape[1], det_shape[2])
+                    else:
+                        det_shape = data.shape
+
+                        mask = np.ones(det_shape).astype(np.uint16)
+                        mask = det.mask(
+                            self._task_parameters.lute_config.run,
+                            calib=False,
+                            status=True,
+                            edges=False,
+                            centra=False,
+                            unbond=False,
+                            unbondnbrs=False,
+                        ).astype(np.uint16)
+
+                photon_energy: float
+                try:
+                    photon_energy = Detector("EBeam").get(evt).ebeamPhotonEnergy()
+                    if np.isinf(photon_energy):
+                        raise ValueError
+                except (AttributeError, ValueError):
+                    photon_energy = (
+                        1.23984197386209e-06
+                        / ds.env().epicsStore().value("SIOC:SYS0:ML00:AO192")
+                    ) * 1e9
+
+                yield EventData(
+                    data, mask, seconds, nanoseconds, fiducials, clen, photon_energy
+                )
+
     def _run(self) -> None:
-        self._task_parameters = cast(FindPeaksPyAlgosParameters, self._task_parameters)
-        ds: Any = MPIDataSource(
-            f"exp={self._task_parameters.lute_config.experiment}:"
-            f"run={self._task_parameters.lute_config.run}:smd"
-        )
-        if self._task_parameters.n_events != 0:
-            ds.break_after(self._task_parameters.n_events)
+        rank: int = COMM_WORLD.Get_rank()
+        size: int = COMM_WORLD.Get_size()
 
-        det: Any = Detector(self._task_parameters.det_name)
-        det.do_reshape_2d_to_3d(flag=True)
+        i_x, i_y, ipx, ipy = self._retrieve_psana_detector_data()
 
-        evr: Any = Detector(self._task_parameters.event_receiver)
-
-        i_x: Any = det.indexes_x(self._task_parameters.lute_config.run).astype(
-            numpy.int64
-        )
-        i_y: Any = det.indexes_y(self._task_parameters.lute_config.run).astype(
-            numpy.int64
-        )
-        ipx: Any
-        ipy: Any
-        ipx, ipy = det.point_indexes(
-            self._task_parameters.lute_config.run, pxy_um=(0, 0)
-        )
-
-        alg: Any = None
+        alg: Optional[Union[PyAlgos, _peakfinders_ext.peakfinder_8]] = None
         num_hits: int = 0
         num_events: int = 0
         num_empty_images: int = 0
         tag: str = self._task_parameters.tag
+
         if (tag != "") and (tag[0] != "_"):
             tag = "_" + tag
 
-        evt: Any
-        for evt in ds.events():
-
-            evt_id: Any = evt.get(EventId)
-            timestamp_seconds: int = evt_id.time()[0]
-            timestamp_nanoseconds: int = evt_id.time()[1]
-            timestamp_fiducials: int = evt_id.fiducials()
-            event_codes: Any = evr.eventCodes(evt)
-
-            if isinstance(self._task_parameters.pv_camera_length, float):
-                clen: float = self._task_parameters.pv_camera_length
-            else:
-                clen = (
-                    ds.env().epicsStore().value(self._task_parameters.pv_camera_length)
-                )
-
-            if self._task_parameters.event_logic:
-                if self._task_parameters.event_code not in event_codes:
-                    continue
-
-            img: Any = det.calib(evt)
-
+        for event_data in self._event_generator():
+            (
+                img,
+                mask,
+                timestamp_seconds,
+                timestamp_nanoseconds,
+                timestamp_fiducials,
+                clen,
+                photon_energy,
+            ) = event_data
             if img is None:
                 num_empty_images += 1
                 continue
 
+            det_shape: Tuple[int, ...] = img.shape
+            if len(det_shape) == 3:
+                det_shape = (det_shape[0] * det_shape[1], det_shape[2])
+            else:
+                det_shape = img.shape
+
+            shape: Tuple[int, ...] = img.shape
+            img_reshaped: npt.NDArray[np.float32]
+            mask_reshaped: npt.NDArray[np.int8]
+            if len(shape) == 2:
+                img_reshaped = img
+                mask_reshaped = mask
+            else:
+                img_reshaped = img.reshape(shape[0] * shape[1], shape[2])
+                mask_reshaped = mask.reshape(shape[0] * shape[1], shape[2])
+
+            radial_stats: Optional[RadialStatistics] = None
+            base_peakfinder_options: Dict[str, Any]
             if alg is None:
-                det_shape: Tuple[int, ...] = img.shape
-                if len(det_shape) == 3:
-                    det_shape = (det_shape[0] * det_shape[1], det_shape[2])
+                if self._algo == "Peakfinder8":
+                    radial_stats = self.compute_radial_statistics()
+                    alg = _peakfinders_ext.peakfinder_8
+
+                    asic_nx = img_reshaped.shape[1]  # fs size
+                    asic_ny = img_reshaped.shape[0]  # ss size
+                    nasics_x = img.shape[0]  # Number of panels in fs dim
+                    nasics_y = 1  # Number of panels in ss dim
+                    adc_thresh = (
+                        self._task_parameters.amax_thr
+                    )  # Minimum ADC threshold for peak detection
+                    hitfinder_min_snr = self._task_parameters.son_min
+                    hitfinder_min_pix_count = self._task_parameters.npix_min
+                    hitfinder_max_pix_count = self._task_parameters.npix_max
+                    local_bg_radius = self._task_parameters.r0
+
+                    base_peakfinder_options = {
+                        "max_num_peaks": self._task_parameters.max_peaks,
+                        "data": img_reshaped,  # Must be updated each time afterwards
+                        "mask": mask_reshaped,
+                        "pix_r": radial_stats["radial_map"],
+                        "rstats_num_pix": radial_stats["rstats_num_pix"],
+                        "rstats_pidx": radial_stats["rstats_pixel_index"],
+                        "rstats_radius": radial_stats["rstats_radius"],
+                        "fast": 1,
+                        "asic_nx": asic_nx,
+                        "asic_ny": asic_ny,
+                        "nasics_x": nasics_x,
+                        "nasics_y": nasics_y,
+                        "adc_thresh": adc_thresh,
+                        "hitfinder_min_snr": hitfinder_min_snr,
+                        "hitfinder_min_pix_count": hitfinder_min_pix_count,
+                        "hitfinder_max_pix_count": hitfinder_max_pix_count,
+                        "hitfinder_local_bg_radius": local_bg_radius,
+                    }
                 else:
-                    det_shape = img.shape
-
-                mask: NDArray[numpy.uint16] = numpy.ones(det_shape).astype(numpy.uint16)
-
-                if self._task_parameters.psana_mask:
-                    mask = det.mask(
-                        self._task_parameters.lute_config.run,
-                        calib=False,
-                        status=True,
-                        edges=False,
-                        centra=False,
-                        unbond=False,
-                        unbondnbrs=False,
-                    ).astype(numpy.uint16)
-
+                    alg = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
+                    base_peakfinder_options = {
+                        "rank": self._task_parameters.peak_rank,
+                        "r0": self._task_parameters.r0,
+                        "dr": self._task_parameters.dr,
+                        "nsigm": self._task_parameters.nsigm,
+                    }
+                    assert alg is not None
+                    alg.set_peak_selection_pars(
+                        npix_min=self._task_parameters.npix_min,
+                        npix_max=self._task_parameters.npix_max,
+                        amax_thr=self._task_parameters.amax_thr,
+                        atot_thr=self._task_parameters.atot_thr,
+                        son_min=self._task_parameters.son_min,
+                    )
                 hdffh: Any
                 if self._task_parameters.mask_file is not None:
                     with h5py.File(self._task_parameters.mask_file, "r") as hdffh:
-                        loaded_mask: NDArray[numpy.int64] = hdffh[
+                        loaded_mask: npt.NDArray[np.int64] = hdffh[
                             "entry_1/data_1/mask"
                         ][:]
-                        mask *= loaded_mask.astype(numpy.uint16)
+                        mask *= loaded_mask.astype(np.uint16)
 
                 file_writer: CxiWriter = CxiWriter(
                     outdir=self._task_parameters.outdir,
-                    rank=ds.rank,
+                    rank=rank,
                     exp=self._task_parameters.lute_config.experiment,
                     run=int(self._task_parameters.lute_config.run),
                     n_events=self._task_parameters.n_events,
@@ -723,18 +1141,11 @@ class FindPeaksPyAlgos(Task):
                     min_peaks=self._task_parameters.min_peaks,
                     max_peaks=self._task_parameters.max_peaks,
                     tag=tag,
-                )
-                alg = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
-                alg.set_peak_selection_pars(
-                    npix_min=self._task_parameters.npix_min,
-                    npix_max=self._task_parameters.npix_max,
-                    amax_thr=self._task_parameters.amax_thr,
-                    atot_thr=self._task_parameters.atot_thr,
-                    son_min=self._task_parameters.son_min,
+                    algo=self._algo,
                 )
 
+                libpressio_config: Optional[Dict[str, Any]] = None
                 if self._task_parameters.compression is not None:
-
                     libpressio_config = generate_libpressio_configuration(
                         compressor=self._task_parameters.compression.compressor,
                         roi_window_size=self._task_parameters.compression.roi_window_size,
@@ -743,47 +1154,75 @@ class FindPeaksPyAlgos(Task):
                         libpressio_mask=mask,
                     )
 
-                powder_hits: NDArray[numpy.float64] = numpy.zeros(det_shape)
-                powder_misses: NDArray[numpy.float64] = numpy.zeros(det_shape)
+                # powder_hits: npt.NDArray[np.float64] = np.zeros(det_shape)
+                # powder_misses: npt.NDArray[np.float64] = np.zeros(det_shape)
+                powder_hits: npt.NDArray[np.float64] = np.zeros(img.shape)
+                powder_misses: npt.NDArray[np.float64] = np.zeros(img.shape)
 
-            peaks: Any = alg.peak_finder_v3r3(
-                img,
-                rank=self._task_parameters.peak_rank,
-                r0=self._task_parameters.r0,
-                dr=self._task_parameters.dr,
-                nsigm=self._task_parameters.nsigm,
-            )
+            peaks: Union[Peakfinder8PeakList, Any]
+            num_peaks: int = 0
+            assert alg
+            if self._algo == "Peakfinder8":
+                shape = img.shape
+                if len(img.shape) == 2:
+                    img_reshaped = img
+                else:
+                    img_reshaped = img.reshape(shape[0] * shape[1], shape[2])
+
+                # Update the options each time
+                base_peakfinder_options["data"] = img_reshaped
+                raw_pf8_lists: Tuple[
+                    List[float],
+                    List[float],
+                    List[float],
+                    List[int],
+                    List[float],
+                    List[float],
+                    List[float],
+                    List[float],
+                ] = alg(**base_peakfinder_options)
+
+                pf8_peaks: Peakfinder8PeakList = {
+                    "num_peaks": len(raw_pf8_lists[0]),
+                    "fs": raw_pf8_lists[0],
+                    "ss": raw_pf8_lists[1],
+                    "intensity": raw_pf8_lists[2],
+                    "num_pixels": raw_pf8_lists[4],
+                    "max_pixel_intensity": raw_pf8_lists[5],
+                    "snr": raw_pf8_lists[6],
+                }
+                num_peaks = pf8_peaks["num_peaks"]
+
+                peaks = pf8_peaks
+            else:
+                raw_pyalgos_peaks = alg(img, **base_peakfinder_options)
+                num_peaks = raw_pyalgos_peaks.shape[0]
+
+                peaks = raw_pyalgos_peaks
 
             num_events += 1
-
-            if (peaks.shape[0] >= self._task_parameters.min_peaks) and (
-                peaks.shape[0] <= self._task_parameters.max_peaks
+            if (num_peaks >= self._task_parameters.min_peaks) and (
+                num_peaks <= self._task_parameters.max_peaks
             ):
 
                 if self._task_parameters.compression is not None:
                     from libpressio import PressioCompressor  # type: ignore
 
+                    assert libpressio_config
                     libpressio_config_with_peaks = (
-                        add_peaks_to_libpressio_configuration(libpressio_config, peaks)
+                        add_peaks_to_libpressio_configuration(
+                            lp_json=libpressio_config,
+                            peaks=peaks,
+                            algo=self._algo,
+                        )
                     )
                     compressor = PressioCompressor.from_config(
                         libpressio_config_with_peaks
                     )
                     compressed_img = compressor.encode(img)
-                    decompressed_img = numpy.zeros_like(img)
+                    decompressed_img = np.zeros_like(img)
                     _ = compressor.decode(compressed_img, decompressed_img)
                     img = decompressed_img
-
-                photon_energy: float
-                try:
-                    photon_energy = Detector("EBeam").get(evt).ebeamPhotonEnergy()
-                    if numpy.isinf(photon_energy):
-                        raise ValueError
-                except (AttributeError, ValueError):
-                    photon_energy = (
-                        1.23984197386209e-06
-                        / ds.env().epicsStore().value("SIOC:SYS0:ML00:AO192")
-                    ) * 1e9
 
                 file_writer.write_event(
                     img=img,
@@ -798,20 +1237,20 @@ class FindPeaksPyAlgos(Task):
 
             # TODO: Fix bug here
             # generate / update powders
-            if peaks.shape[0] >= self._task_parameters.min_peaks:
-                powder_hits = numpy.maximum(
+            if num_peaks >= self._task_parameters.min_peaks:
+                powder_hits = np.maximum(
                     powder_hits,
                     img.reshape(-1, img.shape[-1]),
                 )
             else:
-                powder_misses = numpy.maximum(
+                powder_misses = np.maximum(
                     powder_misses,
                     img.reshape(-1, img.shape[-1]),
                 )
 
         if num_empty_images != 0:
             msg: Message = Message(
-                contents=f"Rank {ds.rank} encountered {num_empty_images} empty images."
+                contents=f"Rank {rank} encountered {num_empty_images} empty images."
             )
             self._report_to_executor(msg)
 
@@ -833,9 +1272,9 @@ class FindPeaksPyAlgos(Task):
         num_hits_total: int = cast(int, COMM_WORLD.reduce(num_hits, SUM))
         num_events_total: int = cast(int, COMM_WORLD.reduce(num_events, SUM))
 
-        if ds.rank == 0:
+        if rank == 0:
             master_fname: Path = write_master_file(
-                mpi_size=ds.size,
+                mpi_size=size,
                 outdir=self._task_parameters.outdir,
                 exp=self._task_parameters.lute_config.experiment,
                 run=int(self._task_parameters.lute_config.run),
@@ -858,16 +1297,19 @@ class FindPeaksPyAlgos(Task):
                 print(f"No. hits per rank: {num_hits_per_rank}", file=f)
 
             with h5py.File(master_fname, "r") as f:
-                final_powder_hits: NDArray[numpy.float64] = f[
+                final_powder_hits: npt.NDArray[np.float64] = f[
                     "entry_1/data_1/powderHits"
                 ][:]
-                final_powder_misses: NDArray[numpy.float64] = f[
+                final_powder_misses: npt.NDArray[np.float64] = f[
                     "entry_1/data_1/powderMisses"
                 ][:]
                 f.close()
 
             powder_plots: pn.Tabs = self._create_powder_plots(
-                det, final_powder_hits, final_powder_misses
+                powder_hits=final_powder_hits.astype(np.float64),
+                powder_misses=final_powder_misses.astype(np.float64),
+                i_x=i_x,
+                i_y=i_y,
             )
             text_summary: Dict[str, str] = {
                 "Number of events processed": str(num_events_total),
@@ -883,69 +1325,70 @@ class FindPeaksPyAlgos(Task):
             with open(Path(self._task_parameters.out_file), "w") as f:
                 print(f"{master_fname}", file=f)
 
-            # Write out_file
-
     def _post_run(self) -> None:
         super()._post_run()
         self._result.task_status = TaskStatus.COMPLETED
 
     def _assemble_image(
-        self, det: Detector, img: NDArray[numpy.float64]
-    ) -> NDArray[numpy.float64]:
+        self,
+        img: npt.NDArray[np.float64],
+        i_x: npt.NDArray[np.uint64],
+        i_y: npt.NDArray[np.uint64],
+    ) -> npt.NDArray[np.float64]:
         """Assemble an image based on psana geometry.
 
         Args:
-            det (psana.Detector): The detector object for the associated image.
-                Used to access the geometry.
-
-            img (numpy.ndarray[np.float64]): The image to assemble. Should
+            img (np.ndarray[np.float64]): The image to assemble. Should
                 generally be of shape (n_panels, ss, fs)
 
+            i_x (Any): Array of pixel indexes along x
+
+            i_y (Any): Array of pixel indexes along y
+
         Returns:
-            assembled_img(numpy.ndarray[np.float64]): Assembled 2D image.
+            assembled_img(np.ndarray[np.float64]): Assembled 2D image.
         """
-        geom: GeometryAccess = det.geometry(self._task_parameters.lute_config.run)
-        tmp: Tuple[NDArray[numpy.uint64], ...] = geom.get_pixel_coord_indexes()
-        pixel_map: NDArray[numpy.uint64] = numpy.zeros(
-            tmp[0].shape[1:] + (2,), dtype=numpy.uint64
+        pixel_map: npt.NDArray[np.uint64] = np.zeros(
+            i_x.shape[1:] + (2,), dtype=np.uint64
         )
-        pixel_map[..., 0] = tmp[0][0]
-        pixel_map[..., 1] = tmp[1][0]
-        unflattened_img: NDArray[numpy.float64] = img.reshape(pixel_map.shape[:-1])
-        idx_max_y: int = int(numpy.max(pixel_map[..., 0]) + 1)  # Adding one
-        idx_max_x: int = int(numpy.max(pixel_map[..., 1]) + 1)  # casts to float
-        assembled_img: NDArray[numpy.float64] = numpy.zeros((idx_max_y, idx_max_x))
+        pixel_map[..., 0] = i_x[0]
+        pixel_map[..., 1] = i_y[0]
+        unflattened_img: npt.NDArray[np.float64] = img.reshape(pixel_map.shape[:-1])
+        idx_max_y: int = int(np.max(pixel_map[..., 0]) + 1)
+        idx_max_x: int = int(np.max(pixel_map[..., 1]) + 1)
+        assembled_img: npt.NDArray[np.float64] = np.zeros((idx_max_y, idx_max_x))
         assembled_img[pixel_map[..., 0], pixel_map[..., 1]] = unflattened_img
 
         return assembled_img
 
     def _create_powder_plots(
         self,
-        det: Detector,
-        powder_hits: NDArray[numpy.float64],
-        powder_misses: NDArray[numpy.float64],
+        powder_hits: npt.NDArray[np.float64],
+        powder_misses: npt.NDArray[np.float64],
+        i_x: npt.NDArray[np.uint64],
+        i_y: npt.NDArray[np.uint64],
     ) -> pn.Tabs:
         """Create a tabbed display of hits and misses 'powder' plots.
 
         Args:
-            det (psana.Detector): The detector object for the associated image.
-                Used to access the geometry.
-
-            powder_hits (numpy.ndarray[np.float64]): Total max/sum projection of
+            powder_hits (np.ndarray[np.float64]): Total max/sum projection of
                 hits across the run.
 
-            powder_misses (numpy.ndarray[np.float64]): Total max/sum projection of
+            powder_misses (np.ndarray[np.float64]): Total max/sum projection of
                 misses across the run.
+
+            i_x (Any): Array of pixel indexes along x
+
+            i_y (Any): Array of pixel indexes along y
 
         Returns:
             tabs (pn.Tabs): Tabbed display of the image plots.
         """
-        self._task_parameters = cast(FindPeaksPyAlgosParameters, self._task_parameters)
-        assembled_powder_hits: NDArray[numpy.float64] = self._assemble_image(
-            det, powder_hits
+        assembled_powder_hits: npt.NDArray[np.float64] = self._assemble_image(
+            img=powder_hits, i_x=i_x, i_y=i_y
         )
-        assembled_powder_misses: NDArray[numpy.float64] = self._assemble_image(
-            det, powder_misses
+        assembled_powder_misses: npt.NDArray[np.float64] = self._assemble_image(
+            img=powder_misses, i_x=i_x, i_y=i_y
         )
 
         grid_hits: pn.GridSpec = pn.GridSpec(
@@ -956,8 +1399,8 @@ class FindPeaksPyAlgos(Task):
         dim: hv.Dimension = hv.Dimension(
             ("image", "Hits"),
             range=(
-                numpy.nanpercentile(assembled_powder_hits, 1),
-                numpy.nanpercentile(assembled_powder_hits, 99),
+                np.nanpercentile(assembled_powder_hits, 1),
+                np.nanpercentile(assembled_powder_hits, 99),
             ),
         )
         grid_hits[0, 0] = pn.Row(
@@ -974,8 +1417,8 @@ class FindPeaksPyAlgos(Task):
         dim = hv.Dimension(
             ("image", "Misses"),
             range=(
-                numpy.nanpercentile(assembled_powder_misses, 1),
-                numpy.nanpercentile(assembled_powder_misses, 99),
+                np.nanpercentile(assembled_powder_misses, 1),
+                np.nanpercentile(assembled_powder_misses, 99),
             ),
         )
         grid_misses[0, 0] = pn.Row(

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -1187,6 +1187,10 @@ class FindPeaksSFX(Task):
 
         first_event: bool = True
         mask: Optional[npt.NDArray[np.uint8]] = None
+        # Need to make this None.... psana2 ranks don't all get into this loop...
+        file_writer: Optional[CxiWriter] = None
+        powder_hits: Optional[npt.NDArray[np.float64]] = None
+        powder_misses: Optional[npt.NDArray[np.float64]] = None
         for event_data in self._event_generator():
             if first_event:
                 assert isinstance(event_data, EventMaskData)
@@ -1341,7 +1345,7 @@ class FindPeaksSFX(Task):
                         ][:]
                         mask *= loaded_mask.astype(np.uint8)
 
-                file_writer: CxiWriter = CxiWriter(
+                file_writer = CxiWriter(
                     outdir=self._task_parameters.outdir,
                     rank=rank,
                     exp=self._task_parameters.lute_config.experiment,
@@ -1371,8 +1375,8 @@ class FindPeaksSFX(Task):
                         ),
                     )
 
-                powder_hits: npt.NDArray[np.float64] = np.zeros(det_shape)
-                powder_misses: npt.NDArray[np.float64] = np.zeros(det_shape)
+                powder_hits = np.zeros(det_shape)
+                powder_misses = np.zeros(det_shape)
 
             peaks: Union[Peakfinder8PeakList, Any]
             num_peaks: int = 0
@@ -1490,6 +1494,7 @@ class FindPeaksSFX(Task):
                     else:
                         img_reshaped = decompressed_img.reshape(original_shape)
 
+                assert file_writer is not None
                 file_writer.write_event(
                     img=img_reshaped if self._algo == "Peakfinder8" else img,
                     peaks=peaks,
@@ -1503,11 +1508,13 @@ class FindPeaksSFX(Task):
                 num_hits += 1
 
             if num_peaks >= self._task_parameters.min_peaks:
+                assert powder_hits is not None
                 powder_hits = np.maximum(
                     powder_hits,
                     img.reshape(det_shape),
                 )
             else:
+                assert powder_misses is not None
                 powder_misses = np.maximum(
                     powder_misses,
                     img.reshape(det_shape),
@@ -1519,20 +1526,21 @@ class FindPeaksSFX(Task):
             )
             self._report_to_executor(msg)
 
-        assert mask is not None
-        assert powder_hits is not None
-        assert powder_misses is not None
-        file_writer.write_non_event_data(
-            powder_hits=powder_hits,
-            powder_misses=powder_misses,
-            mask=mask,
-        )
+        if file_writer is not None:
+            assert mask is not None
+            assert powder_hits is not None
+            assert powder_misses is not None
+            file_writer.write_non_event_data(
+                powder_hits=powder_hits,
+                powder_misses=powder_misses,
+                mask=mask,
+            )
 
-        file_writer.optimize_and_close_file(
-            num_hits=num_hits,
-            max_peaks=self._task_parameters.max_peaks,
-            algo=self._algo,
-        )
+            file_writer.optimize_and_close_file(
+                num_hits=num_hits,
+                max_peaks=self._task_parameters.max_peaks,
+                algo=self._algo,
+            )
 
         COMM_WORLD.Barrier()
 

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -11,6 +11,7 @@ Classes:
 __all__ = ["CxiWriter", "FindPeaksSFX"]
 __author__ = "Valerio Mariani, Gabriel Dorlhiac"
 
+import logging
 import random
 import sys
 from collections import namedtuple
@@ -41,14 +42,18 @@ import numpy.typing as npt
 import panel as pn
 from mpi4py.MPI import COMM_WORLD, SUM
 
-from lute.tasks.algorithms import _peakfinders_ext  # type: ignore
+from lute.execution.logging import get_logger
 from lute.execution.ipc import Message
 from lute.io.models.sfx_find_peaks import FindPeaksSFXParameters
+from lute.tasks.algorithms import _peakfinders_ext  # type: ignore
 from lute.tasks.task import Task
 from lute.tasks.dataclasses import TaskStatus, ElogSummaryPlots
 
 hv.extension("bokeh")
 pn.extension()
+
+
+logger: logging.Logger = get_logger("FindPeaksSFX", is_task=True)
 
 
 class RadialStatistics(TypedDict):
@@ -68,9 +73,25 @@ class Peakfinder8PeakList(TypedDict):
     snr: List[float]
 
 
+class Peakfinder8_v2PeakList(TypedDict):
+    num_peaks: int
+    fs: List[float]
+    ss: List[float]
+    intensity: List[float]
+    num_pixels: List[float]
+    max_pixel_intensity: List[float]
+    snr: List[float]
+    panel_number: List[int]
+
+
+EventMaskData = namedtuple(
+    "EventMaskData",
+    ["data", "mask", "seconds", "nanoseconds", "fiducials", "clen", "photon_energy"],
+)
+
 EventData = namedtuple(
     "EventData",
-    ["data", "mask", "seconds", "nanoseconds", "fiducials", "clen", "photon_energy"],
+    ["data", "seconds", "nanoseconds", "fiducials", "clen", "photon_energy"],
 )
 
 DetectorGeomInfo = namedtuple("DetectorGeomInfo", ["i_x", "i_y", "ipx", "ipy"])
@@ -97,7 +118,7 @@ class CxiWriter:
         ipx: Any,  # Not typed becomes it comes from psana
         ipy: Any,  # Not typed becomes it comes from psana
         tag: str,
-        algo: Literal["Peakfinder8", "PyAlgos"] = "Peakfinder8",
+        algo: Literal["Peakfinder8", "Peakfinder8_v2", "PyAlgos"] = "Peakfinder8",
     ):
         """
         Set up the CXI files to which peak finding results will be saved.
@@ -153,7 +174,7 @@ class CxiWriter:
         entry_1: Any = self._outh5.create_group("entry_1")
 
         keys: List[str]
-        if algo == "Peakfinder8":
+        if "Peakfinder8" in algo:
             keys = [
                 "nPeaks",
                 "peakXPosRaw",
@@ -163,6 +184,8 @@ class CxiWriter:
                 "peakMaxIntensity",
                 "peakSNR",
             ]
+            if algo == "Peakfinder8_v2":
+                keys.append("peakPanelNumRaw")
         else:
             keys = [
                 "nPeaks",
@@ -190,13 +213,14 @@ class CxiWriter:
             dtype=np.float32,
         )
         data_1.attrs["axes"] = "experiment_identifier"
+
         key: str
         for key in ["powderHits", "powderMisses", "mask"]:
             entry_1.create_dataset(
                 f"/entry_1/data_1/{key}",
-                (det_shape[0], det_shape[1]),
-                chunks=(det_shape[0], det_shape[1]),
-                maxshape=(det_shape[0], det_shape[1]),
+                det_shape,
+                chunks=det_shape,
+                maxshape=det_shape,
                 dtype=float,
             )
 
@@ -256,7 +280,7 @@ class CxiWriter:
         timestamp_fiducials: int,
         photon_energy: float,
         clen: float,
-        algo: Literal["Peakfinder8", "PyAlgos"] = "Peakfinder8",
+        algo: Literal["Peakfinder8", "Peakfinder8_v2", "PyAlgos"] = "Peakfinder8",
     ):
         """
         Write peak finding results for an event into the HDF5 file.
@@ -290,7 +314,15 @@ class CxiWriter:
                 photon_energy=photon_energy,
                 clen=clen,
             )
-        elif algo == "Peakfinder8":
+        elif algo not in ("Peakfinder8", "Peakfinder8_v2"):
+            raise ValueError(f"Unsupported peakfinding algorithm {algo}!")
+        else:
+            v2: bool = False
+            if algo == "Peakfinder8":
+                v2 = False
+            elif algo == "Peakfinder8_v2":
+                v2 = True
+
             self._write_event_peakfinder8(
                 img=img,
                 peaks=peaks,
@@ -299,19 +331,19 @@ class CxiWriter:
                 timestamp_fiducials=timestamp_fiducials,
                 photon_energy=photon_energy,
                 clen=clen,
+                v2=v2,
             )
-        else:
-            raise ValueError(f"Unsupported peakfinding algorithm {algo}!")
 
     def _write_event_peakfinder8(
         self,
         img: npt.NDArray[np.float64],
-        peaks: Peakfinder8PeakList,
+        peaks: Union[Peakfinder8PeakList, Peakfinder8_v2PeakList],
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
         timestamp_fiducials: int,
         photon_energy: float,
         clen: float,
+        v2: bool = False,
     ) -> None:
         if self._outh5["/entry_1/data_1/data"].shape[0] <= self._index:
             self._outh5["entry_1/data_1/data"].resize(self._index + 1, axis=0)
@@ -341,6 +373,11 @@ class CxiWriter:
         self._outh5["/entry_1/result_1/peakYPosRaw"][self._index, :num_peaks] = (
             np.array(peaks["ss"], dtype=np.float32)
         )
+        if v2:
+            peaks = cast(Peakfinder8_v2PeakList, peaks)
+            self._outh5["/entry_1/result_1/peakPanelNumRaw"][
+                self._index, :num_peaks
+            ] = np.array(peaks["panel_number"], dtype=np.float32)
         self._outh5["/entry_1/result_1/peakNPixels"][self._index, :num_peaks] = (
             np.array(peaks["num_pixels"], dtype=np.float32)
         )
@@ -471,7 +508,7 @@ class CxiWriter:
         self,
         powder_hits: npt.NDArray[np.float64],
         powder_misses: npt.NDArray[np.float64],
-        mask: npt.NDArray[np.uint16],
+        mask: npt.NDArray[np.uint8],
     ):
         """
         Write to the file data that is not related to a specific event (masks, powders)
@@ -487,12 +524,8 @@ class CxiWriter:
         """
         # Add powders and mask to files, reshaping them to match the crystfel
         # convention
-        self._outh5["/entry_1/data_1/powderHits"][:] = powder_hits.reshape(
-            -1, powder_hits.shape[-1]
-        )
-        self._outh5["/entry_1/data_1/powderMisses"][:] = powder_misses.reshape(
-            -1, powder_misses.shape[-1]
-        )
+        self._outh5["/entry_1/data_1/powderHits"][:] = powder_hits
+        self._outh5["/entry_1/data_1/powderMisses"][:] = powder_misses
         self._outh5["/entry_1/data_1/mask"][:] = (1 - mask).reshape(
             -1, mask.shape[-1]
         )  # Crystfel expects inverted values
@@ -501,6 +534,7 @@ class CxiWriter:
         self,
         num_hits: int,
         max_peaks: int,
+        algo: Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"] = "Peakfinder8",
     ):
         """
         Resize data blocks and write additional information to the file
@@ -512,6 +546,10 @@ class CxiWriter:
 
             max_peaks (int): Maximum number of peaks (per event) for which information
                 can be written into the file
+
+            algo (Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"]): The algorithm
+                being used for peakfinding. This affects the exact keys that are
+                saved.
         """
 
         # Resize the entry_1 entry
@@ -520,20 +558,36 @@ class CxiWriter:
             (num_hits, data_shape[1], data_shape[2])
         )
         self._outh5["/entry_1/result_1/nPeaks"].resize((num_hits,))
+
+        keys: List[str]
+        if "Peakfinder8" in algo:
+            keys = [
+                "peakXPosRaw",
+                "peakYPosRaw",
+                "peakNPixels",
+                "peakTotalIntensity",
+                "peakMaxIntensity",
+                "peakSNR",
+            ]
+            if algo == "Peakfinder8_v2":
+                keys.append("peakPanelNumRaw")
+        else:
+            keys = [
+                "peakXPosRaw",
+                "peakYPosRaw",
+                "rcent",
+                "ccent",
+                "rmin",
+                "rmax",
+                "cmin",
+                "cmax",
+                "peakTotalIntensity",
+                "peakMaxIntensity",
+                "peakRadius",
+            ]
+
         key: str
-        for key in [
-            "peakXPosRaw",
-            "peakYPosRaw",
-            "rcent",
-            "ccent",
-            "rmin",
-            "rmax",
-            "cmin",
-            "cmax",
-            "peakTotalIntensity",
-            "peakMaxIntensity",
-            "peakRadius",
-        ]:
+        for key in keys:
             self._outh5[f"/entry_1/result_1/{key}"].resize((num_hits, max_peaks))
 
         # Resize LCLS entry
@@ -607,7 +661,7 @@ def write_master_file(
 
     # Compute cumulative powder hits and misses for all files
     # Copy mask as well
-    mask: Optional[npt.NDArray[np.uint16]] = None
+    mask: Optional[npt.NDArray[np.uint8]] = None
     powder_hits: Optional[npt.NDArray[np.float64]] = None
     powder_misses: Optional[npt.NDArray[np.float64]] = None
     for fn in fnames:
@@ -767,8 +821,8 @@ def _libpressio_config_pf8(
 
 def add_peaks_to_libpressio_configuration(
     lp_json: Dict[str, Any],
-    peaks: Union[Peakfinder8PeakList, Any],
-    algo: Literal["Peakfinder8", "PyAlgos"],
+    peaks: Union[Peakfinder8PeakList, Peakfinder8_v2PeakList, Any],
+    algo: Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"],
 ) -> Dict[str, Any]:
     """
     Add peak infromation to libpressio configuration
@@ -784,7 +838,7 @@ def add_peaks_to_libpressio_configuration(
 
         lp_json: Updated configuration JSON structure for the libpressio library.
     """
-    if algo == "Peakfinder8":
+    if "Peakfinder8" in algo:
         return _libpressio_config_pf8(lp_json=lp_json, peaks=peaks)
     else:
         return _libpressio_config_pyalgos(lp_json=lp_json, peaks=peaks)
@@ -800,7 +854,9 @@ class FindPeaksSFX(Task):
         self._task_parameters: FindPeaksSFXParameters = params
         super().__init__(params=params, use_mpi=use_mpi)
 
-        self._algo: Literal["PyAlgos", "Peakfinder8"] = self._task_parameters.algorithm
+        self._algo: Literal["PyAlgos", "Peakfinder8", "Peakfinder8_v2"] = (
+            self._task_parameters.algorithm
+        )
 
     def get_radius_map(self) -> npt.NDArray[np.float64]:
         from lute.tasks.util.geometry import (
@@ -819,10 +875,17 @@ class FindPeaksSFX(Task):
         else:
             raise RuntimeError("Need a geometry file to compute radius map!")
 
+    def _compute_num_radial_bins(
+        self, indices: Tuple[slice, ...], radius_map: npt.NDArray[np.float64]
+    ) -> int:
+        return int(np.ceil(radius_map[indices].max()) + 1)
+
     def compute_radial_statistics(
-        self, shape: Tuple[int, ...], num_bins: int = 100
+        self,
+        radius_map: npt.NDArray[np.float64],
+        shape: Tuple[int, ...],
+        num_bins: int = 100,
     ) -> RadialStatistics:
-        radius_map: npt.NDArray[np.float64] = self.get_radius_map()
         radius_map_int: npt.NDArray[np.int8] = np.rint(radius_map).astype(int).ravel()
         peak_index: List[int] = []
         radius: List[int] = []
@@ -843,10 +906,15 @@ class FindPeaksSFX(Task):
         )
         rstats_radius: npt.NDArray[np.int32] = np.array(radius).astype(np.int32)
 
+        logger.debug(
+            f"Computed radial statistics for {num_bins} bins. "
+            f"rstats_num_pix: {rstats_pixel_index.size}"
+        )
+
         return {
-            "rstats_pixel_index": rstats_pixel_index.reshape(shape),
-            "rstats_radius": rstats_radius.reshape(shape),
-            "rstats_num_pix": rstats_pixel_index.shape[0],
+            "rstats_pixel_index": rstats_pixel_index,
+            "rstats_radius": rstats_radius,
+            "rstats_num_pix": rstats_pixel_index.size,
             "radial_map": radius_map.reshape(shape),
         }
 
@@ -883,17 +951,24 @@ class FindPeaksSFX(Task):
 
             return DetectorGeomInfo(i_x=i_x, i_y=i_y, ipx=ipx, ipy=ipy)
 
-    def _event_generator(self, lcls2: bool = True) -> Generator[EventData, None, None]:
+    def _event_generator(
+        self, lcls2: bool = True
+    ) -> Generator[Union[EventMaskData, EventData], None, None]:
         exp: str = self._task_parameters.lute_config.experiment
         run_num: int = int(self._task_parameters.lute_config.run)
 
+        first_event: bool = True
         if lcls2:
             import psana  # type: ignore
 
-            ds2: psana.psexp.mpi_ds.ParallelDataSource = psana.DataSource(
-                exp=exp,
-                run=run_num,
-            )
+            kwargs: Dict[str, Any] = {
+                "exp": exp,
+                "run": run_num,
+            }
+            if self._task_parameters.n_events != 0:
+                kwargs["max_events"] = self._task_parameters.n_events
+
+            ds2: psana.psexp.mpi_ds.ParallelDataSource = psana.DataSource(**kwargs)
             run2: psana.psexp.mpi_ds.RunParallel = next(ds2.runs())
             timing2 = run2.Detector("timing")
 
@@ -902,7 +977,8 @@ class FindPeaksSFX(Task):
             # TODO: Need to handle other BLD?
             ebeamh = run2.Detector("ebeamh")
 
-            mask2: Optional[npt.NDArray[np.uint8]] = None
+            if first_event:
+                mask2: Optional[npt.NDArray[np.uint8]] = None
             for evt in run2.events():
                 data: Optional[npt.NDArray[np.float32]] = det2.raw.calib(evt)
 
@@ -941,20 +1017,31 @@ class FindPeaksSFX(Task):
                         det2_shape = (det2_shape[0] * det2_shape[1], det2_shape[2])
                     else:
                         det2_shape = data.shape
-                    if hasattr(det2.raw, "_mask"):
-                        mask2 = det2.raw._mask()
-                    else:
-                        mask2 = np.ones(det2_shape).astype(np.uint16)
+                    if first_event:
+                        if hasattr(det2.raw, "_mask"):
+                            mask2 = det2.raw._mask()
+                        else:
+                            mask2 = np.ones(det2_shape, dtype=np.uint8)
 
-                yield EventData(
-                    data,
-                    mask2,
-                    seconds2,
-                    nanoseconds2,
-                    raw_fiducial2,
-                    clen2,
-                    photon_energy2,
-                )
+                        first_event = False
+                        yield EventMaskData(
+                            data,
+                            mask2,
+                            seconds2,
+                            nanoseconds2,
+                            raw_fiducial2,
+                            clen2,
+                            photon_energy2,
+                        )
+                    else:
+                        yield EventData(
+                            data,
+                            seconds2,
+                            nanoseconds2,
+                            raw_fiducial2,
+                            clen2,
+                            photon_energy2,
+                        )
         else:
             from psana import Detector, EventId, MPIDataSource  # type: ignore
 
@@ -986,26 +1073,6 @@ class FindPeaksSFX(Task):
                     if self._task_parameters.event_code not in event_codes:
                         continue
 
-                data = det.calib(evt)
-                mask: Optional[npt.NDArray[np.uint16]] = None
-                if data:
-                    det_shape: Tuple[int, ...] = data.shape
-                    if len(det_shape) == 3:
-                        det_shape = (det_shape[0] * det_shape[1], det_shape[2])
-                    else:
-                        det_shape = data.shape
-
-                        mask = np.ones(det_shape).astype(np.uint16)
-                        mask = det.mask(
-                            self._task_parameters.lute_config.run,
-                            calib=False,
-                            status=True,
-                            edges=False,
-                            centra=False,
-                            unbond=False,
-                            unbondnbrs=False,
-                        ).astype(np.uint16)
-
                 photon_energy: float
                 try:
                     photon_energy = Detector("EBeam").get(evt).ebeamPhotonEnergy()
@@ -1017,9 +1084,50 @@ class FindPeaksSFX(Task):
                         / ds.env().epicsStore().value("SIOC:SYS0:ML00:AO192")
                     ) * 1e9
 
-                yield EventData(
-                    data, mask, seconds, nanoseconds, fiducials, clen, photon_energy
-                )
+                data = det.calib(evt)
+                if first_event:
+                    mask: Optional[npt.NDArray[np.uint8]] = None
+                if data:
+                    det_shape: Tuple[int, ...] = data.shape
+                    if len(det_shape) == 3:
+                        det_shape = (det_shape[0] * det_shape[1], det_shape[2])
+                    else:
+                        det_shape = data.shape
+
+                        if first_event:
+                            mask = np.ones(det_shape, dtype=np.uint8)
+                            psana_mask = det.mask(
+                                self._task_parameters.lute_config.run,
+                                calib=False,
+                                status=True,
+                                edges=False,
+                                centra=False,
+                                unbond=False,
+                                unbondnbrs=False,
+                            ).astype(np.uint8)
+                            if psana_mask:
+                                mask = psana_mask
+
+                            first_event = False
+
+                            yield EventMaskData(
+                                data,
+                                mask,
+                                seconds,
+                                nanoseconds,
+                                fiducials,
+                                clen,
+                                photon_energy,
+                            )
+                        else:
+                            yield EventData(
+                                data,
+                                seconds,
+                                nanoseconds,
+                                fiducials,
+                                clen,
+                                photon_energy,
+                            )
 
     def _run(self) -> None:
         rank: int = COMM_WORLD.Get_rank()
@@ -1027,7 +1135,11 @@ class FindPeaksSFX(Task):
 
         i_x, i_y, ipx, ipy = self._retrieve_psana_detector_data()
 
-        alg: Optional[Union[PyAlgos, _peakfinders_ext.peakfinder_8]] = None
+        alg: Optional[
+            Union[
+                PyAlgos, _peakfinders_ext.peakfinder_8, _peakfinders_ext.peakfinder_8_v2
+            ]
+        ] = None
         num_hits: int = 0
         num_events: int = 0
         num_empty_images: int = 0
@@ -1036,16 +1148,32 @@ class FindPeaksSFX(Task):
         if (tag != "") and (tag[0] != "_"):
             tag = "_" + tag
 
+        first_event: bool = True
+        mask: Optional[npt.NDArray[np.uint8]] = None
         for event_data in self._event_generator():
-            (
-                img,
-                mask,
-                timestamp_seconds,
-                timestamp_nanoseconds,
-                timestamp_fiducials,
-                clen,
-                photon_energy,
-            ) = event_data
+            if first_event:
+                assert isinstance(event_data, EventMaskData)
+                (
+                    img,
+                    mask,
+                    timestamp_seconds,
+                    timestamp_nanoseconds,
+                    timestamp_fiducials,
+                    clen,
+                    photon_energy,
+                ) = event_data
+
+                first_event = False
+            else:
+                assert isinstance(event_data, EventData)
+                (
+                    img,
+                    timestamp_seconds,
+                    timestamp_nanoseconds,
+                    timestamp_fiducials,
+                    clen,
+                    photon_energy,
+                ) = event_data
             if img is None:
                 num_empty_images += 1
                 continue
@@ -1058,27 +1186,25 @@ class FindPeaksSFX(Task):
 
             shape: Tuple[int, ...] = img.shape
             img_reshaped: npt.NDArray[np.float32]
-            mask_reshaped: npt.NDArray[np.int8]
-            if len(shape) == 2:
+            if len(shape) == 2 or self._algo == "Peakfinder8_v2":
                 img_reshaped = img
-                mask_reshaped = mask
             else:
                 img_reshaped = img.reshape(shape[0] * shape[1], shape[2])
-                mask_reshaped = mask.reshape(shape[0] * shape[1], shape[2])
 
             radial_stats: Optional[RadialStatistics] = None
             base_peakfinder_options: Dict[str, Any]
             if alg is None:
-                if self._algo == "Peakfinder8":
-                    radial_stats = self.compute_radial_statistics(
-                        shape=det_shape, num_bins=100
-                    )
-                    alg = _peakfinders_ext.peakfinder_8
+                # Mask should only come on first event
+                assert mask is not None
 
-                    asic_nx = img_reshaped.shape[1]  # fs size
-                    asic_ny = img_reshaped.shape[0]  # ss size
-                    nasics_x = img.shape[0]  # Number of panels in fs dim
-                    nasics_y = 1  # Number of panels in ss dim
+                mask_reshaped: npt.NDArray[np.uint8]
+                if len(shape) == 2 or self._algo == "Peakfinder8_v2":
+                    mask_reshaped = mask
+                else:
+                    mask_reshaped = mask.reshape(shape[0] * shape[1], shape[2])
+
+                if "Peakfinder8" in self._algo:
+                    radius_map: npt.NDArray[np.float64] = self.get_radius_map()
                     adc_thresh = (
                         self._task_parameters.amax_thr
                     )  # Minimum ADC threshold for peak detection
@@ -1087,27 +1213,73 @@ class FindPeaksSFX(Task):
                     hitfinder_max_pix_count = self._task_parameters.npix_max
                     local_bg_radius = self._task_parameters.r0
 
-                    base_peakfinder_options = {
-                        "max_num_peaks": self._task_parameters.max_peaks,
-                        "data": img_reshaped,  # Must be updated each time afterwards
-                        "mask": mask_reshaped.astype(np.int8),
-                        "pix_r": radial_stats["radial_map"],
-                        "rstats_num_pix": radial_stats["rstats_num_pix"],
-                        "rstats_pidx": radial_stats["rstats_pixel_index"],
-                        "rstats_radius": radial_stats["rstats_radius"],
-                        "fast": 1,
-                        "asic_nx": asic_nx,
-                        "asic_ny": asic_ny,
-                        "nasics_x": nasics_x,
-                        "nasics_y": nasics_y,
-                        "adc_thresh": adc_thresh,
-                        "hitfinder_min_snr": hitfinder_min_snr,
-                        "hitfinder_min_pix_count": hitfinder_min_pix_count,
-                        "hitfinder_max_pix_count": hitfinder_max_pix_count,
-                        "hitfinder_local_bg_radius": int(
-                            local_bg_radius
-                        ),  # Must be int
-                    }
+                    if self._algo == "Peakfinder8":
+                        alg = _peakfinders_ext.peakfinder_8
+
+                        num_radial_bins: int = self._compute_num_radial_bins(
+                            indices=tuple(slice(None, dim) for dim in radius_map.shape),
+                            radius_map=radius_map,
+                        )
+                        radial_stats = self.compute_radial_statistics(
+                            radius_map=radius_map,
+                            shape=det_shape,
+                            num_bins=num_radial_bins,
+                        )
+
+                        asic_nx: int  # Size in the fs axis (1 panel/asic)
+                        asic_ny: int  # Size in the ss axis (1 panel/asic)
+                        nasics_x: int  # Number of asics/panels in the fs axis
+                        nasics_y: int  # Number of asics/pnaels in the ss axis
+                        if len(shape) > 2:
+                            asic_nx = img.shape[2]  # fs size
+                            asic_ny = img.shape[1]  # ss size
+                            nasics_x = 1  # Number of panels in fs dim
+                            nasics_y = img.shape[0]  # Number of panels in ss dim
+                        else:
+                            asic_nx = img.shape[1]
+                            asic_ny = img.shape[0]
+                            nasics_x = 1
+                            nasics_y = 1
+                        base_peakfinder_options = {
+                            "max_num_peaks": self._task_parameters.max_peaks,
+                            "data": img_reshaped,  # Must be updated each time afterwards
+                            "mask": mask_reshaped.astype(np.int8),
+                            "pix_r": radial_stats["radial_map"],
+                            "rstats_num_pix": radial_stats["rstats_num_pix"],
+                            "rstats_pidx": radial_stats["rstats_pixel_index"],
+                            "rstats_radius": radial_stats["rstats_radius"],
+                            "fast": 1,
+                            "asic_nx": asic_nx,
+                            "asic_ny": asic_ny,
+                            "nasics_x": nasics_x,
+                            "nasics_y": nasics_y,
+                            "adc_thresh": adc_thresh,
+                            "hitfinder_min_snr": hitfinder_min_snr,
+                            "hitfinder_min_pix_count": hitfinder_min_pix_count,
+                            "hitfinder_max_pix_count": hitfinder_max_pix_count,
+                            "hitfinder_local_bg_radius": int(
+                                local_bg_radius
+                            ),  # Must be int
+                        }
+                    else:
+                        alg = _peakfinders_ext.peakfinder_8_v2
+
+                        base_peakfinder_options = {
+                            "max_num_peaks": self._task_parameters.max_peaks,
+                            "data": img,  # Must be updated each time afterwards
+                            "mask": mask.astype(np.int8),
+                            "pix_r": radius_map,
+                            "adc_thresh": adc_thresh,
+                            "hitfinder_min_snr": hitfinder_min_snr,
+                            "hitfinder_min_pix_count": hitfinder_min_pix_count,
+                            "hitfinder_max_pix_count": hitfinder_max_pix_count,
+                            "hitfinder_local_bg_radius": int(
+                                local_bg_radius
+                            ),  # Must be int
+                        }
+
+                        # Reset the det_shape since we don't use the "slab" in v2
+                        det_shape = img.shape
                 else:
                     alg = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity
                     base_peakfinder_options = {
@@ -1130,7 +1302,7 @@ class FindPeaksSFX(Task):
                         loaded_mask: npt.NDArray[np.int64] = hdffh[
                             "entry_1/data_1/mask"
                         ][:]
-                        mask *= loaded_mask.astype(np.uint16)
+                        mask *= loaded_mask.astype(np.uint8)
 
                 file_writer: CxiWriter = CxiWriter(
                     outdir=self._task_parameters.outdir,
@@ -1160,10 +1332,8 @@ class FindPeaksSFX(Task):
                         libpressio_mask=mask,
                     )
 
-                # powder_hits: npt.NDArray[np.float64] = np.zeros(det_shape)
-                # powder_misses: npt.NDArray[np.float64] = np.zeros(det_shape)
-                powder_hits: npt.NDArray[np.float64] = np.zeros(img.shape)
-                powder_misses: npt.NDArray[np.float64] = np.zeros(img.shape)
+                powder_hits: npt.NDArray[np.float64] = np.zeros(det_shape)
+                powder_misses: npt.NDArray[np.float64] = np.zeros(det_shape)
 
             peaks: Union[Peakfinder8PeakList, Any]
             num_peaks: int = 0
@@ -1197,9 +1367,36 @@ class FindPeaksSFX(Task):
                     "max_pixel_intensity": raw_pf8_lists[5],
                     "snr": raw_pf8_lists[6],
                 }
-                num_peaks = pf8_peaks["num_peaks"]
 
+                num_peaks = pf8_peaks["num_peaks"]
                 peaks = pf8_peaks
+            elif self._algo == "Peakfinder8_v2":
+                # Update the options each time
+                base_peakfinder_options["data"] = img
+                raw_pf8_v2_lists: Tuple[
+                    List[float],
+                    List[float],
+                    List[float],
+                    List[int],
+                    List[float],
+                    List[float],
+                    List[float],
+                    List[float],
+                    List[int],
+                ] = alg(**base_peakfinder_options)
+                pf8_v2_peaks: Peakfinder8_v2PeakList = {
+                    "num_peaks": len(raw_pf8_v2_lists[0]),
+                    "fs": raw_pf8_v2_lists[0],
+                    "ss": raw_pf8_v2_lists[1],
+                    "intensity": raw_pf8_v2_lists[2],
+                    "num_pixels": raw_pf8_v2_lists[4],
+                    "max_pixel_intensity": raw_pf8_v2_lists[5],
+                    "snr": raw_pf8_v2_lists[6],
+                    "panel_number": raw_pf8_v2_lists[8],
+                }
+
+                num_peaks = pf8_v2_peaks["num_peaks"]
+                peaks = pf8_v2_peaks
             else:
                 raw_pyalgos_peaks = alg(img, **base_peakfinder_options)
                 num_peaks = raw_pyalgos_peaks.shape[0]
@@ -1238,20 +1435,19 @@ class FindPeaksSFX(Task):
                     timestamp_fiducials=timestamp_fiducials,
                     photon_energy=photon_energy,
                     clen=clen,
+                    algo=self._algo,
                 )
                 num_hits += 1
 
-            # TODO: Fix bug here
-            # generate / update powders
             if num_peaks >= self._task_parameters.min_peaks:
                 powder_hits = np.maximum(
                     powder_hits,
-                    img.reshape(-1, img.shape[-1]),
+                    img.reshape(det_shape),
                 )
             else:
                 powder_misses = np.maximum(
                     powder_misses,
-                    img.reshape(-1, img.shape[-1]),
+                    img.reshape(det_shape),
                 )
 
         if num_empty_images != 0:
@@ -1260,6 +1456,9 @@ class FindPeaksSFX(Task):
             )
             self._report_to_executor(msg)
 
+        assert mask is not None
+        assert powder_hits is not None
+        assert powder_misses is not None
         file_writer.write_non_event_data(
             powder_hits=powder_hits,
             powder_misses=powder_misses,
@@ -1267,7 +1466,9 @@ class FindPeaksSFX(Task):
         )
 
         file_writer.optimize_and_close_file(
-            num_hits=num_hits, max_peaks=self._task_parameters.max_peaks
+            num_hits=num_hits,
+            max_peaks=self._task_parameters.max_peaks,
+            algo=self._algo,
         )
 
         COMM_WORLD.Barrier()
@@ -1311,23 +1512,31 @@ class FindPeaksSFX(Task):
                 ][:]
                 f.close()
 
-            powder_plots: pn.Tabs = self._create_powder_plots(
-                powder_hits=final_powder_hits.astype(np.float64),
-                powder_misses=final_powder_misses.astype(np.float64),
-                i_x=i_x,
-                i_y=i_y,
-            )
             text_summary: Dict[str, str] = {
                 "Number of events processed": str(num_events_total),
                 "Number of hits found": str(num_hits_total),
                 "Fractional hit rate": f"{num_hits_total/num_events_total:.2f}",
             }
-            self._result.summary = (
-                text_summary,
-                ElogSummaryPlots(
-                    f"r{self._task_parameters.lute_config.run}/powders", powder_plots
-                ),
-            )
+
+            task_summary: Union[Dict[str, str], Tuple[Dict[str, str], ElogSummaryPlots]]
+            if self._task_parameters.make_powder_plots:
+                powder_plots: pn.Tabs = self._create_powder_plots(
+                    powder_hits=final_powder_hits.astype(np.float64),
+                    powder_misses=final_powder_misses.astype(np.float64),
+                    i_x=i_x,
+                    i_y=i_y,
+                )
+                task_summary = (
+                    text_summary,
+                    ElogSummaryPlots(
+                        f"r{self._task_parameters.lute_config.run}/powders",
+                        powder_plots,
+                    ),
+                )
+            else:
+                task_summary = text_summary
+
+            self._result.summary = task_summary
             with open(Path(self._task_parameters.out_file), "w") as f:
                 print(f"{master_fname}", file=f)
 
@@ -1354,16 +1563,13 @@ class FindPeaksSFX(Task):
         Returns:
             assembled_img(np.ndarray[np.float64]): Assembled 2D image.
         """
-        pixel_map: npt.NDArray[np.uint64] = np.zeros(
-            i_x.shape[1:] + (2,), dtype=np.uint64
+        img_reshaped: npt.NDArray[np.float64] = img.reshape(i_x.shape)
+        idx_max_y: int = int(np.max(i_x) + 1)
+        idx_max_x: int = int(np.max(i_y) + 1)
+        assembled_img: npt.NDArray[np.float64] = np.zeros(
+            (idx_max_y, idx_max_x), dtype=np.float64
         )
-        pixel_map[..., 0] = i_x[0]
-        pixel_map[..., 1] = i_y[0]
-        unflattened_img: npt.NDArray[np.float64] = img.reshape(pixel_map.shape[:-1])
-        idx_max_y: int = int(np.max(pixel_map[..., 0]) + 1)
-        idx_max_x: int = int(np.max(pixel_map[..., 1]) + 1)
-        assembled_img: npt.NDArray[np.float64] = np.zeros((idx_max_y, idx_max_x))
-        assembled_img[pixel_map[..., 0], pixel_map[..., 1]] = unflattened_img
+        assembled_img[i_x, i_y] = img_reshaped
 
         return assembled_img
 

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -282,7 +282,7 @@ class CxiWriter:
 
     def write_event(
         self,
-        img: npt.NDArray[np.float64],
+        img: npt.NDArray[np.float32],
         peaks: Any,  # Not typed becomes it comes from psana
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
@@ -296,7 +296,7 @@ class CxiWriter:
 
         Parameters:
 
-            img (npt.NDArray[np.float64]): Detector data for the event
+            img (npt.NDArray[np.float32]): Detector data for the event
 
             peaks: (Any): Peak information for the event, as recovered from the PyAlgos
                 algorithm
@@ -345,7 +345,7 @@ class CxiWriter:
 
     def _write_event_peakfinder8(
         self,
-        img: npt.NDArray[np.float64],
+        img: npt.NDArray[np.float32],
         peaks: Union[Peakfinder8PeakList, Peakfinder8_v2PeakList],
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
@@ -412,7 +412,7 @@ class CxiWriter:
 
     def _write_event_pyalgos(
         self,
-        img: npt.NDArray[np.float64],
+        img: npt.NDArray[np.float32],
         peaks: Any,  # Not typed becomes it comes from psana
         timestamp_seconds: int,
         timestamp_nanoseconds: int,
@@ -1456,7 +1456,7 @@ class FindPeaksSFX(Task):
                         img_reshaped = decompressed_img
 
                 file_writer.write_event(
-                    img=img_reshaped,
+                    img=img_reshaped if self._algo == "Peakfinder8" else img,
                     peaks=peaks,
                     timestamp_seconds=timestamp_seconds,
                     timestamp_nanoseconds=timestamp_nanoseconds,

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -647,10 +647,12 @@ def write_master_file(
     """
     # Retrieve paths to the files containing data
     fnames: List[Path] = []
-    fi: int
+    # Need to keep track of these for indexing later during master file creation
+    ranks_with_hits: List[int] = []
     for fi in range(mpi_size):
         if n_hits_per_rank[fi] > 0:
             fnames.append(Path(outdir) / f"{exp}_r{run:0>4}_{fi}{tag}.cxi")
+            ranks_with_hits.append(fi)
     if len(fnames) == 0:
         sys.exit("No hits found")
 
@@ -692,7 +694,6 @@ def write_master_file(
 
     vfname: Path = Path(outdir) / f"{exp}_r{run:0>4}{tag}.cxi"
     with h5py.File(vfname, "w") as vdf:
-
         # Write the virtual hdf5 file
         for dnum in range(len(dname_list)):
             dname = f"{dname_list[dnum]}/{key_list[dnum]}"
@@ -702,14 +703,19 @@ def write_master_file(
                 )
                 cursor = 0
                 for i, fn in enumerate(fnames):
+                    # Use the correct rank hit count or you get a malformed VDS
+                    rank_idx: int = ranks_with_hits[i]
                     vsrc = h5py.VirtualSource(
-                        fn, dname, shape=(n_hits_per_rank[i],) + shape_list[dnum][1:]
+                        fn,
+                        dname,
+                        shape=(n_hits_per_rank[rank_idx],) + shape_list[dnum][1:],
                     )
+
                     if len(shape_list[dnum]) == 1:
-                        layout[cursor : cursor + n_hits_per_rank[i]] = vsrc
+                        layout[cursor : cursor + n_hits_per_rank[rank_idx]] = vsrc
                     else:
-                        layout[cursor : cursor + n_hits_per_rank[i], :] = vsrc
-                    cursor += n_hits_per_rank[i]
+                        layout[cursor : cursor + n_hits_per_rank[rank_idx], :] = vsrc
+                    cursor += n_hits_per_rank[rank_idx]
                 vdf.create_virtual_dataset(dname, layout, fillvalue=-1)
 
         vdf["entry_1/data_1/powderHits"] = powder_hits

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -757,13 +757,17 @@ def generate_libpressio_configuration(
         pressio_opts = {"pressio:abs": abs_error}
 
     ndims: int = len(libpressio_mask.shape)
-    roi_size: List[int] = [roi_window_size, roi_window_size]
-    bin_dims: List[int] = [bin_size, bin_size]
-    if ndims > 2:
-        other_dims_roi: List[int] = [0] * (ndims - 2)
-        other_dims_bin: List[int] = [1] * (ndims - 2)
-        roi_size = other_dims_roi + roi_size
-        bin_dims = other_dims_bin + bin_dims
+
+    # Add padding for non-row/col dims
+    other_dims: List[int] = [1] * (ndims - 2)
+    roi_size: List[int] = other_dims * (ndims - 2) + [roi_window_size, roi_window_size]
+    bin_dims: List[int] = other_dims * (ndims - 2) + [bin_size, bin_size]
+
+    # Libpressio bug requires 4D data
+    if len(roi_size) < 4:
+        other_dims = [1] * (4 - len(roi_size))
+        roi_size = other_dims + roi_size
+        bin_dims = other_dims + bin_dims
 
     lp_json: Dict[str, Any] = {
         "compressor_id": "pressio",
@@ -794,8 +798,9 @@ def generate_libpressio_configuration(
             "pressio": {
                 "roibin": {
                     "roibin:roi_size": roi_size,
-                    "roibin:centers": None,  # "roibin:roi_strategy": "coordinates",
-                    "roibin:nthreads": 4,
+                    "roibin:centers": None,
+                    "roibin:roi_strategy": "coordinates",
+                    "roibin:nthreads": 1,
                     "roi": {"fpzip:prec": 0},
                     "background": {
                         "mask_binning:mask": None,
@@ -809,18 +814,30 @@ def generate_libpressio_configuration(
         "name": "pressio",
     }
 
+    # Need 4D array for libpressio bug
+    reshaped_mask: npt.NDArray[np.uint8]
+    if libpressio_mask.ndim < 4:
+        new_shape: Tuple[int, ...] = (
+            (1,) * (4 - libpressio_mask.ndim)
+        ) + libpressio_mask.shape
+        reshaped_mask = libpressio_mask.reshape(new_shape)
+    else:
+        reshaped_mask = libpressio_mask
+
     lp_json["compressor_config"]["pressio"]["roibin"]["background"][
         "mask_binning:mask"
-    ] = (1 - libpressio_mask)
+    ] = (1 - reshaped_mask)
 
     return lp_json
 
 
 def _libpressio_config_pyalgos(lp_json: Dict[str, Any], peaks: Any) -> Dict[str, Any]:
     # assert not isinstance(peaks, dict)
-    lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = (
-        np.ascontiguousarray(np.uint64(peaks[:, [2, 1, 0]])).astype(np.uint64)
+    peaks_new: npt.NDArray[np.uint64] = np.zeros((len(peaks), 4), dtype=np.uint64)
+    peaks_new[:, 1:] = np.ascontiguousarray(np.uint64(peaks[:, [0, 1, 2]])).astype(
+        np.uint64
     )
+    lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = peaks_new
 
     return lp_json
 
@@ -829,10 +846,10 @@ def _libpressio_config_pf8(
     lp_json: Dict[str, Any], peaks: Peakfinder8PeakList
 ) -> Dict[str, Any]:
     peaks_rotated: npt.NDArray[np.uint64] = np.zeros(
-        (peaks["num_peaks"], 2), dtype=np.uint64
+        (peaks["num_peaks"], 4), dtype=np.uint64
     )
-    peaks_rotated[:, 0] = np.array(peaks["fs"]).astype(np.uint64)
-    peaks_rotated[:, 1] = np.array(peaks["ss"]).astype(np.uint64)
+    peaks_rotated[:, 2] = np.array(peaks["ss"]).astype(np.uint64)
+    peaks_rotated[:, 3] = np.array(peaks["fs"]).astype(np.uint64)
     lp_json["compressor_config"]["pressio"]["roibin"]["roibin:centers"] = peaks_rotated
     return lp_json
 
@@ -1444,16 +1461,34 @@ class FindPeaksSFX(Task):
                     compressor = PressioCompressor.from_config(
                         libpressio_config_with_peaks
                     )
-                    if self._algo == "Peakfinder8_v2" or self._algo == "PyAlgos":
-                        compressed_img = compressor.encode(img)
-                        decompressed_img = np.zeros_like(img)
-                        _ = compressor.decode(compressed_img, decompressed_img)
-                        img = decompressed_img
+                    # Currently have a bug in libpressio so need 4D array
+                    original_shape: Tuple[int, ...]
+                    new_shape: Tuple[int, ...]
+                    data_for_libpressio: npt.NDArray[np.float32]
+                    if self._algo in ("Peakfinder8_v2", "PyAlgos"):
+                        original_shape = img.shape
+                        if img.ndim < 4:
+                            new_shape = ((1,) * (4 - img.ndim)) + img.shape
+                            data_for_libpressio = img.reshape(new_shape)
+                        else:
+                            data_for_libpressio = img
                     else:
-                        compressed_img = compressor.encode(img_reshaped)
-                        decompressed_img = np.zeros_like(img_reshaped)
-                        _ = compressor.decode(compressed_img, decompressed_img)
-                        img_reshaped = decompressed_img
+                        original_shape = img_reshaped.shape
+                        new_shape = (
+                            1,
+                            1,
+                        ) + img_reshaped.shape
+                        data_for_libpressio = img_reshaped.reshape(new_shape)
+
+                    compressed_img: bytes = compressor.encode(data_for_libpressio)
+                    decompressed_img: npt.NDArray[np.float32] = np.zeros_like(
+                        data_for_libpressio
+                    )
+                    _ = compressor.decode(compressed_img, decompressed_img)
+                    if self._algo in ("Peakfinder8_v2", "PyAlgos"):
+                        img = decompressed_img.reshape(original_shape)
+                    else:
+                        img_reshaped = decompressed_img.reshape(original_shape)
 
                 file_writer.write_event(
                     img=img_reshaped if self._algo == "Peakfinder8" else img,

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -756,6 +756,15 @@ def generate_libpressio_configuration(
     elif compressor == "sz3":
         pressio_opts = {"pressio:abs": abs_error}
 
+    ndims: int = len(libpressio_mask.shape)
+    roi_size: List[int] = [roi_window_size, roi_window_size]
+    bin_dims: List[int] = [bin_size, bin_size]
+    if ndims > 2:
+        other_dims_roi: List[int] = [0] * (ndims - 2)
+        other_dims_bin: List[int] = [1] * (ndims - 2)
+        roi_size = other_dims_roi + roi_size
+        bin_dims = other_dims_bin + bin_dims
+
     lp_json: Dict[str, Any] = {
         "compressor_id": "pressio",
         "early_config": {
@@ -784,13 +793,13 @@ def generate_libpressio_configuration(
         "compressor_config": {
             "pressio": {
                 "roibin": {
-                    "roibin:roi_size": [roi_window_size, roi_window_size, 0],
+                    "roibin:roi_size": roi_size,
                     "roibin:centers": None,  # "roibin:roi_strategy": "coordinates",
                     "roibin:nthreads": 4,
                     "roi": {"fpzip:prec": 0},
                     "background": {
                         "mask_binning:mask": None,
-                        "mask_binning:shape": [bin_size, bin_size, 1],
+                        "mask_binning:shape": bin_dims,
                         "mask_binning:nthreads": 4,
                         "pressio": pressio_opts,
                     },
@@ -1340,7 +1349,9 @@ class FindPeaksSFX(Task):
                         roi_window_size=self._task_parameters.compression.roi_window_size,
                         bin_size=self._task_parameters.compression.bin_size,
                         abs_error=self._task_parameters.compression.abs_error,
-                        libpressio_mask=mask,
+                        libpressio_mask=(
+                            mask_reshaped if self._algo == "Peakfinder8" else mask
+                        ),
                     )
 
                 powder_hits: npt.NDArray[np.float64] = np.zeros(det_shape)
@@ -1433,13 +1444,19 @@ class FindPeaksSFX(Task):
                     compressor = PressioCompressor.from_config(
                         libpressio_config_with_peaks
                     )
-                    compressed_img = compressor.encode(img)
-                    decompressed_img = np.zeros_like(img)
-                    _ = compressor.decode(compressed_img, decompressed_img)
-                    img = decompressed_img
+                    if self._algo == "Peakfinder8_v2" or self._algo == "PyAlgos":
+                        compressed_img = compressor.encode(img)
+                        decompressed_img = np.zeros_like(img)
+                        _ = compressor.decode(compressed_img, decompressed_img)
+                        img = decompressed_img
+                    else:
+                        compressed_img = compressor.encode(img_reshaped)
+                        decompressed_img = np.zeros_like(img_reshaped)
+                        _ = compressor.decode(compressed_img, decompressed_img)
+                        img_reshaped = decompressed_img
 
                 file_writer.write_event(
-                    img=img,
+                    img=img_reshaped,
                     peaks=peaks,
                     timestamp_seconds=timestamp_seconds,
                     timestamp_nanoseconds=timestamp_nanoseconds,

--- a/lute/tasks/sfx_find_peaks.py
+++ b/lute/tasks/sfx_find_peaks.py
@@ -819,7 +819,9 @@ class FindPeaksSFX(Task):
         else:
             raise RuntimeError("Need a geometry file to compute radius map!")
 
-    def compute_radial_statistics(self, num_bins: int = 100) -> RadialStatistics:
+    def compute_radial_statistics(
+        self, shape: Tuple[int, ...], num_bins: int = 100
+    ) -> RadialStatistics:
         radius_map: npt.NDArray[np.float64] = self.get_radius_map()
         radius_map_int: npt.NDArray[np.int8] = np.rint(radius_map).astype(int).ravel()
         peak_index: List[int] = []
@@ -842,10 +844,10 @@ class FindPeaksSFX(Task):
         rstats_radius: npt.NDArray[np.int32] = np.array(radius).astype(np.int32)
 
         return {
-            "rstats_pixel_index": rstats_pixel_index,
-            "rstats_radius": rstats_radius,
+            "rstats_pixel_index": rstats_pixel_index.reshape(shape),
+            "rstats_radius": rstats_radius.reshape(shape),
             "rstats_num_pix": rstats_pixel_index.shape[0],
-            "radial_map": radius_map,
+            "radial_map": radius_map.reshape(shape),
         }
 
     def _retrieve_psana_detector_data(self, lcls2: bool = True) -> DetectorGeomInfo:
@@ -1068,7 +1070,9 @@ class FindPeaksSFX(Task):
             base_peakfinder_options: Dict[str, Any]
             if alg is None:
                 if self._algo == "Peakfinder8":
-                    radial_stats = self.compute_radial_statistics()
+                    radial_stats = self.compute_radial_statistics(
+                        shape=det_shape, num_bins=100
+                    )
                     alg = _peakfinders_ext.peakfinder_8
 
                     asic_nx = img_reshaped.shape[1]  # fs size
@@ -1086,7 +1090,7 @@ class FindPeaksSFX(Task):
                     base_peakfinder_options = {
                         "max_num_peaks": self._task_parameters.max_peaks,
                         "data": img_reshaped,  # Must be updated each time afterwards
-                        "mask": mask_reshaped,
+                        "mask": mask_reshaped.astype(np.int8),
                         "pix_r": radial_stats["radial_map"],
                         "rstats_num_pix": radial_stats["rstats_num_pix"],
                         "rstats_pidx": radial_stats["rstats_pixel_index"],
@@ -1100,7 +1104,9 @@ class FindPeaksSFX(Task):
                         "hitfinder_min_snr": hitfinder_min_snr,
                         "hitfinder_min_pix_count": hitfinder_min_pix_count,
                         "hitfinder_max_pix_count": hitfinder_max_pix_count,
-                        "hitfinder_local_bg_radius": local_bg_radius,
+                        "hitfinder_local_bg_radius": int(
+                            local_bg_radius
+                        ),  # Must be int
                     }
                 else:
                     alg = PyAlgos(mask=mask, pbits=0)  # pbits controls verbosity

--- a/lute/tasks/task.py
+++ b/lute/tasks/task.py
@@ -220,6 +220,13 @@ class Task(ABC):
             comm.Barrier()
             if rank == 0:
                 self._report_to_executor(start_msg)
+
+                # In first-party, different environment Tasks the bootstrap process
+                # will create a file to share RowIds. The path is stored in an env var
+                # and it can now be deleted safely since we're past the Barrier above
+                bootstrap_file: Optional[str] = os.getenv("LUTE_BOOTSTRAP_FILE")
+                if bootstrap_file is not None and os.path.exists(bootstrap_file):
+                    os.remove(bootstrap_file)
         else:
             self._report_to_executor(start_msg)
 

--- a/lute/tasks/util/geometry.py
+++ b/lute/tasks/util/geometry.py
@@ -1,0 +1,255 @@
+"""A set of utilities for managing detector geometry and conversions between formats.
+
+Functions:
+    from_crystfel(fname: str): Parse a CrystFEL geometry file.
+"""
+
+import os
+from typing import Dict, List, Literal, Tuple, TypedDict, Union, cast
+
+import numpy as np
+import numpy.typing as npt
+
+__author__ = "Gabriel Dorlhiac"
+
+
+class CrystfelPanelGeometry(TypedDict):
+    fs: Tuple[float, float, float]
+    ss: Tuple[float, float, float]
+    res: float
+    corner_x: float
+    corner_y: float
+    coffset: float
+    min_fs: int
+    max_fs: int
+    min_ss: int
+    max_ss: int
+    no_index: Literal[0, 1]
+
+
+class CrystfelDetectorGeometry(TypedDict):
+    panels: Dict[str, CrystfelPanelGeometry]
+    rigid_groups: Dict[str, List[str]]
+    rigid_group_collections: Dict[str, List[str]]
+
+
+class PixelMaps(TypedDict):
+    x_map: npt.NDArray[np.float64]
+    y_map: npt.NDArray[np.float64]
+    z_map: npt.NDArray[np.float64]
+    radius_map: npt.NDArray[np.float64]
+    phi_map: npt.NDArray[np.float64]
+
+
+def parse_crystfel_geometry_file(file_path: Union[str, os.PathLike]):
+    """Parse a CrystFEL geometry file.
+
+    Read a text ".geom" file and return the dictionary of geometry components.
+
+    Args:
+    """
+    detector: CrystfelDetectorGeometry = {
+        "panels": {},
+        "rigid_groups": {},
+        "rigid_group_collections": {},
+    }
+    with open(file_path, "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            # Remove comments
+            if line[0] == ";":
+                continue
+            if "=" not in line:
+                continue
+
+            # CrystFEL fmt: object = val
+            obj_value = line.split("=")
+            # object fmt: "panel/parameter"
+            obj: List[str] = obj_value[0].split("/")  # May be len 1 or 2
+            value: str = obj_value[1]
+
+            if len(obj) == 1:  # e.g. rigid_group_quad ...
+                if "collection" in obj[0].strip():
+                    collection_name: str = obj[0].strip().split("_")[-1]
+                    detector["rigid_group_collections"][
+                        collection_name
+                    ] = value.strip().split(",")
+                else:
+                    group_name = obj[0].strip().split("_")[-1]
+                    detector["rigid_groups"][group_name] = value.strip().split(",")
+            elif len(obj) == 2:  # e.g. p0a0/fs = ...
+                pname = obj[0].strip()
+                panel: CrystfelPanelGeometry
+                if pname in detector["panels"]:
+                    panel = detector["panels"][pname]
+                else:
+                    panel = {
+                        "fs": (0, 0, 0),
+                        "ss": (0, 0, 0),
+                        "res": 10000,
+                        "corner_x": 100,
+                        "corner_y": 100,
+                        "coffset": 0.0,
+                        "min_fs": 0,
+                        "max_fs": 123,
+                        "min_ss": 0,
+                        "max_ss": 123,
+                        "no_index": 0,
+                    }
+                    detector["panels"][pname] = panel
+                if "fs" in obj[1].strip()[-2:]:
+                    if "max" in obj[1]:
+                        panel["max_fs"] = int(value)
+                    elif "min" in obj[1]:
+                        panel["min_fs"] = int(value)
+                    else:
+                        strcoords = value.split()
+                        # -1x -2y -3z
+                        fcoords = (
+                            float(strcoords[0].strip("x")),
+                            float(strcoords[1].strip("y")),
+                            float(strcoords[2].strip("z")) if len(strcoords) > 2 else 0,
+                        )
+                        panel["fs"] = fcoords
+                elif "ss" in obj[1].strip()[-2:]:
+                    if "max" in obj[1]:
+                        panel["max_ss"] = int(value)
+                    elif "min" in obj[1]:
+                        panel["min_ss"] = int(value)
+                    else:
+                        strcoords = value.split()
+                        # -1x -2y -3z
+                        fcoords = (
+                            float(strcoords[0].strip("x")),
+                            float(strcoords[1].strip("y")),
+                            float(strcoords[2].strip("z")) if len(strcoords) > 2 else 0,
+                        )
+                        panel["ss"] = fcoords
+                elif "res" in obj[1].strip():
+                    panel["res"] = float(value)
+                elif "corner" in obj[1].strip():
+                    if "x" in obj[1]:
+                        panel["corner_x"] = float(value)
+                    elif "y" in obj[1]:
+                        panel["corner_y"] = float(value)
+                elif "no_index" in obj[1]:
+                    panel["no_index"] = cast(Literal[0, 1], int(value))
+                elif "coffset" in obj[1]:
+                    panel["coffset"] = float(value)
+
+        return detector
+
+
+def crystfel_to_pixel_map(geometry_desc: CrystfelDetectorGeometry) -> PixelMaps:
+    """Compute pixel maps including pixel radius and phi from CrystFEL geometry.
+
+    Args:
+        geometry_desc (CrystfelDetectorGeometry): A description of the detector
+            geometry parsed from a CyrstFEL geometry description.
+
+    Returns:
+        pixel_maps (PixelMaps): The per-pixel coordinate maps as well as radius
+            and phi mappings.
+    """
+    max_fs_in_slab: int = np.array(
+        [geometry_desc["panels"][k]["max_fs"] for k in geometry_desc["panels"]]
+    ).max()
+    max_ss_in_slab: int = np.array(
+        [geometry_desc["panels"][k]["max_ss"] for k in geometry_desc["panels"]]
+    ).max()
+
+    x_map: npt.NDArray[np.float64] = np.zeros(
+        shape=(max_ss_in_slab + 1, max_fs_in_slab + 1), dtype=np.float32
+    )
+    y_map: npt.NDArray[np.float64] = np.zeros(
+        shape=(max_ss_in_slab + 1, max_fs_in_slab + 1), dtype=np.float32
+    )
+    z_map: npt.NDArray[np.float64] = np.zeros(
+        shape=(max_ss_in_slab + 1, max_fs_in_slab + 1), dtype=np.float32
+    )
+
+    panel_name: str
+    for panel_name in geometry_desc["panels"]:
+        if "coffset" in geometry_desc["panels"][panel_name]:
+            first_panel_camera_length: float = geometry_desc["panels"][panel_name][
+                "coffset"
+            ]
+        else:
+            first_panel_camera_length = 0.0
+
+        ss_grid: npt.NDArray[np.int64]
+        fs_grid: npt.NDArray[np.int64]
+        ss_grid, fs_grid = np.meshgrid(
+            np.arange(
+                geometry_desc["panels"][panel_name]["max_ss"]
+                - geometry_desc["panels"][panel_name]["min_ss"]
+                + 1
+            ),
+            np.arange(
+                geometry_desc["panels"][panel_name]["max_fs"]
+                - geometry_desc["panels"][panel_name]["min_fs"]
+                + 1
+            ),
+            indexing="ij",
+        )
+
+        fsx: float
+        fsy: float
+        # fsz: float
+        fsx, fsy, _ = geometry_desc["panels"][panel_name]["fs"]
+
+        ssx: float
+        ssy: float
+        # ssz: float
+        ssx, ssy, _ = geometry_desc["panels"][panel_name]["ss"]
+        y_panel: npt.NDArray[np.float32] = (
+            ss_grid * ssy
+            + fs_grid * fsy
+            + geometry_desc["panels"][panel_name]["corner_y"]
+        )
+        x_panel: npt.NDArray[np.float32] = (
+            ss_grid * ssx
+            + fs_grid * fsx
+            + geometry_desc["panels"][panel_name]["corner_x"]
+        )
+        x_map[
+            geometry_desc["panels"][panel_name]["min_ss"] : geometry_desc["panels"][
+                panel_name
+            ]["max_ss"]
+            + 1,
+            geometry_desc["panels"][panel_name]["min_fs"] : geometry_desc["panels"][
+                panel_name
+            ]["max_fs"]
+            + 1,
+        ] = x_panel
+        y_map[
+            geometry_desc["panels"][panel_name]["min_ss"] : geometry_desc["panels"][
+                panel_name
+            ]["max_ss"]
+            + 1,
+            geometry_desc["panels"][panel_name]["min_fs"] : geometry_desc["panels"][
+                panel_name
+            ]["max_fs"]
+            + 1,
+        ] = y_panel
+        z_map[
+            geometry_desc["panels"][panel_name]["min_ss"] : geometry_desc["panels"][
+                panel_name
+            ]["max_ss"]
+            + 1,
+            geometry_desc["panels"][panel_name]["min_fs"] : geometry_desc["panels"][
+                panel_name
+            ]["max_fs"]
+            + 1,
+        ] = first_panel_camera_length
+
+    r_map: npt.NDArray[np.float64] = np.sqrt(np.square(x_map) + np.square(y_map))
+    phi_map: npt.NDArray[np.float64] = np.arctan2(y_map, x_map)
+
+    return {
+        "x_map": x_map,
+        "y_map": y_map,
+        "z_map": z_map,
+        "radius_map": r_map,
+        "phi_map": phi_map,
+    }

--- a/lute/tasks/util/meson.build
+++ b/lute/tasks/util/meson.build
@@ -1,6 +1,6 @@
 py_sources = [
     'environment.py',
-    'geometry',
+    'geometry.py',
     'html.py',
     '__init__.py',
     'xtc_pull.py',

--- a/lute/tasks/util/meson.build
+++ b/lute/tasks/util/meson.build
@@ -1,5 +1,6 @@
 py_sources = [
     'environment.py',
+    'geometry',
     'html.py',
     '__init__.py',
     'xtc_pull.py',

--- a/subprocess_task.py
+++ b/subprocess_task.py
@@ -1,11 +1,13 @@
 import argparse
+import json
 import logging
 import os
 import re
 import signal
 import sys
+import time
 import types
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Tuple, Type, cast
 
 import lute.execution.subprocess_utils
 from lute.tasks.task import Task, ThirdPartyTask
@@ -52,6 +54,33 @@ def setup_env() -> bool:
     if setup_new_env:
         os.environ.update(new_env)
     return setup_new_env
+
+
+def is_mpi_job() -> Tuple[bool, int]:
+    """Determine whether this is an MPI submission without initializing a context.
+
+    Returns:
+        is_mpi_job (bool): Whether it is an MPI submission.
+
+        mpi_rank (int): The MPI rank for this process, or -1 if not an MPI job.
+    """
+    # MPI rank returned as negative if not an MPI submission
+    mpi_rank: int = -1
+    mpi_size: int = 1
+    if "OMPI_COMM_WORLD_RANK" in os.environ:
+        mpi_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+        mpi_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", 1))
+    elif "PMI_RANK" in os.environ:
+        mpi_rank = int(os.environ["PMI_RANK"])
+        mpi_size = int(os.environ.get("PMI_SIZE", 1))
+    elif "SLURM_PROCID" in os.environ:
+        mpi_rank = int(os.environ["SLURM_PROCID"])
+        mpi_size = int(os.environ.get("SLURM_NTASKS", 1))
+        # When using SLURM to figure out MPI/non-MPI, subtract 1 for Executor core
+        if mpi_size > 1:
+            mpi_size -= 1
+    # Need other env vars? PMIX_RANK, MV2_COMM_WORLD_RANK?
+    return mpi_size > 1, mpi_rank
 
 
 signal.signal(signal.SIGALRM, timeout_handler)
@@ -119,29 +148,39 @@ def main() -> None:
 
         # We are a first-party Task that needs a new environment
         # Record the parameters - but only once if using MPI
-        use_mpi: bool = False
-        rank: int = 0
-        try:
-            from mpi4py import MPI
+        use_mpi: bool
+        rank: int
+        use_mpi, rank = is_mpi_job()
 
-            comm: MPI.Intracomm = MPI.COMM_WORLD
-            size: int = comm.Get_size()
-            rank = comm.Get_rank()
-            if size > 1:
-                use_mpi = True
-                print(f"Running in a MPI world of size: {size}", flush=True)
-        except ModuleNotFoundError:
-            print(
-                "mpi4py not found. Assuming this is not an MPI-based `Task`", flush=True
-            )
         row_ids: Optional[RowIds]
         if use_mpi:
+            # Use args.task_name for the files in case of parameter sweeps
+            row_id_file: str = f"{args.taskname}_row_ids.out"
+            temp_row_id_file: str = f"{args.taskname}_row_ids.inprogress"
             if rank == 0:
+                print("Running a first-party Task in a new environment.", flush=True)
                 row_ids = record_parameters_db(task_parameters)
+                assert row_ids is not None
+                with open(temp_row_id_file, "w") as f:
+                    f.write("\n")
+
+                with open(row_id_file, "w") as f:
+                    json.dump(row_ids, f)
+                os.remove(temp_row_id_file)
+                # This allows rank 0 to delete it later - this is done internally
+                # in Task. It occurs in _signal_start after a Barrier so rank 0 knows
+                # other ranks have actually started before deleting anything
+                os.environ["LUTE_BOOTSTRAP_FILE"] = row_id_file
             else:
-                row_ids = None
-            row_ids = comm.bcast(row_ids, root=0)
+                while not os.path.exists(row_id_file) or os.path.exists(
+                    temp_row_id_file
+                ):
+                    time.sleep(0.01)
+
+                with open(row_id_file, "r") as f:
+                    row_ids = cast(RowIds, json.load(f))
         else:
+            print("Running a first-party Task in a new environment.", flush=True)
             row_ids = record_parameters_db(task_parameters)
         work_dir: str = task_parameters.lute_config.work_dir
 

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -12,12 +12,14 @@
 
 ## List of tests
 
-| Test Name        | Workflow                            | Experiment   | Run | Additional Comments                                                   |
-|:----------------:|:-----------------------------------:|:------------:|:---:|:---------------------------------------------------------------------:|
-| basic_tests      | Basic LUTE test Tasks               | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
-| smd_xpp_default  | SmallDataProducer                   | xpptut15     | 650 | xpplv9818 run 127. This is to test default production only.           |
-| smd_mfx_default  | SmallDataProducer                   | mfxx49820    | 15  | Default small data production                                         |
-| smd2_mfx_prod    | SmallDataProducer2                  | mfx101344525 | 70  | LCLS2 non-default SMD (MFX).                                          |
-| smd2_multi_node  | SmallDataProducer2                  | mfx101262725 | 96  | LCLS2 non-default SMD (MFX) submitted across multiple nodes.          |
-| param_generation | Basic LUTE tests + param generation | xpptut15     | 670 | Experiment/run not used by the test but required for compatibility.   |
-|                  |                                     |              |     |                                                                       |
+| Test Name                     | Workflow                                                                                                   | Experiment   | Run | Additional Comments                                                   |
+|:-----------------------------:|:----------------------------------------------------------------------------------------------------------:|:------------:|:---:|:---------------------------------------------------------------------:|
+| basic_tests                   | Basic LUTE test Tasks                                                                                      | xpptut15     | 670 | Experiment/run are not used by test Tasks. Required for compatibility |
+| smd_xpp_default               | SmallDataProducer                                                                                          | xpptut15     | 650 | xpplv9818 run 127. This is to test default production only.           |
+| smd_mfx_default               | SmallDataProducer                                                                                          | mfxx49820    | 15  | Default small data production                                         |
+| smd2_mfx_prod                 | SmallDataProducer2                                                                                         | mfx101344525 | 70  | LCLS2 non-default SMD (MFX).                                          |
+| smd2_multi_node               | SmallDataProducer2                                                                                         | mfx101262725 | 96  | LCLS2 non-default SMD (MFX) submitted across multiple nodes.          |
+| param_generation              | Basic LUTE tests + param generation                                                                        | xpptut15     | 670 | Experiment/run not used by the test but required for compatibility.   |
+| peakfinder8_lcls2             | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data.                                          | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
+| peakfinder8_lcls2_compression | Run FindPeaksSFX with the peakfinder8 v1 algorithm on LCLS2 data but do compress/decompress with RoiBinSZ. | mfx101343025 | 170 | Some Jungfrau16M data.                                                |
+|                               |                                                                                                            |              |     |                                                                       |

--- a/tests/functional/peakfinder8_lcls2/README.md
+++ b/tests/functional/peakfinder8_lcls2/README.md
@@ -1,0 +1,3 @@
+# Peakfinder8 (V1) LCLS2 Data
+
+This example runs the peakfinder8 (original V1) algorithm on LCLS2 data. The experiment/run were chosen at random and may not have actual data to analyze. This test verifies the infrastructure.

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -37,4 +37,44 @@ FindPeaksSFX:
     n_events: 10 # Only a handful of events
     geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
     make_powder_plots: false # Don't write powder summary to experiment
+
+# You must provide a geometry file. Cell file is optional but improves results
+# mosflm is fast, you can provide additional methods for improved results at cost of speed
+IndexCrystFEL:
+  #in_file: ""            # Location of a `.lst` file listing CXI files
+  #out_file: ""           # Where to write the output stream file
+  geometry: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
+  indexing: "mosflm"      # Indeexing methods - e.g. mosflm,xgandalf
+  int_radius: "3,4,5"     # Integration radii
+  tolerance: "5,5,5,1.5"  # Tolerances
+  multi: True
+  profile: True
+  no_revalidate: True
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
+  peaks: "cxi"
+
+# You must set symmetry
+MergePartialator:
+  #in_file: ""
+  #out_file: ""
+  #model: "unity"
+  #niter: 1
+  symmetry: "2/m_uab"
+
+CompareHKL:
+  #in_files: ""
+  #fom: "Rsplit"
+  #nshells: 10
+  #shell_file: ""
+  #cell_file: ""
+  symmetry: "2/m_uab"
+
+# Select a different output format if desired. Dimple requires mtz
+#ManipulateHKL:
+  #output_format: "mtz"
+  #out_file: "..."
+
+# You must provide a PDB file to use Dimple.
+DimpleSolve:
+  pdb: "/path/to/pdb/XYZ.pdb"
 ...

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -67,8 +67,10 @@ CompareHKL:
   symmetry: "2/m_uab"
 
 # Select a different output format if desired. Dimple requires mtz
-#ManipulateHKL:
+ManipulateHKL:
   #output_format: "mtz"
   #out_file: "..."
+  # Since no cell was provided during indexing, provide it here
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
 ...
 

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -1,0 +1,40 @@
+%YAML 1.3
+---
+title: "Test LUTE Peakfinder8 (v1) LCLS2 Data"
+experiment: "mfx101343025"
+run: 170
+date: "2026/03/05"
+lute_version: 0.1      # Do not be change unless need to force older version
+task_timeout: 30000
+work_dir: "/tmp"
+...
+---
+# You must provide det_name and pv_camera_length
+# pv_camera_length is the detector distance
+# It can be a PV, or alternative a float for a fixed offset
+# Example PVs are commented below, ask beamline staff for relevant PV
+# Change outdir to an appropriate directory for CXI files.
+FindPeaksSFX:
+    outdir: "{{ work_dir }}"
+    det_name: "jungfrau"
+    event_receiver: "evr0"
+    tag: "test"
+    event_logic: false
+    psana_mask: false
+    mask_file: null
+    min_peaks: 10
+    max_peaks: 2048
+    npix_min: 2
+    npix_max: 30
+    amax_thr: 40
+    atot_thr: 180
+    son_min: 10.0
+    peak_rank: 3
+    r0: 3.0
+    dr: 2.0
+    nsigm: 10.0
+    pv_camera_length: 100.0 # Could be PV, but just using fixed distance
+    n_events: 10 # Only a handful of events
+    geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
+    make_powder_plots: false # Don't write powder summary to experiment
+...

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -73,8 +73,4 @@ CompareHKL:
 #ManipulateHKL:
   #output_format: "mtz"
   #out_file: "..."
-
-# You must provide a PDB file to use Dimple.
-DimpleSolve:
-  pdb: "/path/to/pdb/XYZ.pdb"
 ...

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -9,11 +9,8 @@ task_timeout: 30000
 work_dir: "/tmp"
 ...
 ---
-# You must provide det_name and pv_camera_length
-# pv_camera_length is the detector distance
-# It can be a PV, or alternative a float for a fixed offset
-# Example PVs are commented below, ask beamline staff for relevant PV
-# Change outdir to an appropriate directory for CXI files.
+# Parameters here are setup to try and get results through the pipeline.
+# This is not for scientific accuracy.
 FindPeaksSFX:
     outdir: "{{ work_dir }}"
     det_name: "jungfrau"
@@ -26,11 +23,10 @@ FindPeaksSFX:
     max_peaks: 2048
     npix_min: 2
     npix_max: 30
-    amax_thr: 40
-    atot_thr: 180
-    son_min: 10.0
+    amax_thr: 1000 # ADC Threshold (Peakfinder8)
+    son_min: 4.0   # Minimum SNR (Peakfinder8)
     peak_rank: 3
-    r0: 3.0
+    r0: 8.0        # Local background radius (Peakfinder8)
     dr: 2.0
     nsigm: 10.0
     pv_camera_length: 100.0 # Could be PV, but just using fixed distance
@@ -38,22 +34,22 @@ FindPeaksSFX:
     geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
     make_powder_plots: false # Don't write powder summary to experiment
 
-# You must provide a geometry file. Cell file is optional but improves results
-# mosflm is fast, you can provide additional methods for improved results at cost of speed
+# Setting parameters to try to get SOMETHING through the infrastructure.
+# This is just an infrastructure test.
 IndexCrystFEL:
   #in_file: ""            # Location of a `.lst` file listing CXI files
   #out_file: ""           # Where to write the output stream file
   geometry: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
-  indexing: "mosflm"      # Indeexing methods - e.g. mosflm,xgandalf
-  int_radius: "3,4,5"     # Integration radii
-  tolerance: "5,5,5,1.5"  # Tolerances
+  indexing: "mosflm,xgandalf,asdf"  # Trying multiple methods for blind indexing
+  int_radius: "3,4,7"               # Slightly larger background ring
+  tolerance: "10,10,10,2"           # More lenient cell/angle tolerances
   multi: True
-  profile: True
+  # profile: True
   no_revalidate: True
-  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
+  # Not using cell file for the time being
+  # cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
   peaks: "cxi"
 
-# You must set symmetry
 MergePartialator:
   #in_file: ""
   #out_file: ""
@@ -66,7 +62,8 @@ CompareHKL:
   #fom: "Rsplit"
   #nshells: 10
   #shell_file: ""
-  #cell_file: ""
+  # Since no cell was provided during indexing, provide it here
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
   symmetry: "2/m_uab"
 
 # Select a different output format if desired. Dimple requires mtz
@@ -74,3 +71,4 @@ CompareHKL:
   #output_format: "mtz"
   #out_file: "..."
 ...
+

--- a/tests/functional/peakfinder8_lcls2/config.yaml
+++ b/tests/functional/peakfinder8_lcls2/config.yaml
@@ -34,7 +34,7 @@ FindPeaksSFX:
     dr: 2.0
     nsigm: 10.0
     pv_camera_length: 100.0 # Could be PV, but just using fixed distance
-    n_events: 10 # Only a handful of events
+    n_events: 500 # Only a handful of events
     geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
     make_powder_plots: false # Don't write powder summary to experiment
 

--- a/tests/functional/peakfinder8_lcls2/dag.yaml
+++ b/tests/functional/peakfinder8_lcls2/dag.yaml
@@ -1,0 +1,22 @@
+!LUTE_DAG
+task_name: "PeakFinderSFX"
+slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+next:
+- task_name: "CrystFELIndexer"
+  slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+  next:
+  - task_name: "StreamFileConcatenator"
+    slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=2"
+    next:
+    - task_name: "PartialatorMerger"
+      slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+      next:
+      - task_name: "HKLManipulator"
+        slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
+        next:
+        - task_name: "DimpleSolver"
+          slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+          next: []
+      - task_name: "HKLComparer"
+        slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
+        next: []

--- a/tests/functional/peakfinder8_lcls2/dag.yaml
+++ b/tests/functional/peakfinder8_lcls2/dag.yaml
@@ -13,10 +13,11 @@ next:
       next:
       - task_name: "HKLManipulator"
         slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
-        next:
-        - task_name: "DimpleSolver"
-          slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
-          next: []
+        next: []
+        # Skipping the final solver for now
+        # - task_name: "DimpleSolver"
+        #   slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+        #   next: []
       - task_name: "HKLComparer"
         slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
         next: []

--- a/tests/functional/peakfinder8_lcls2_compression/README.md
+++ b/tests/functional/peakfinder8_lcls2_compression/README.md
@@ -1,0 +1,3 @@
+# Peakfinder8 (V1) LCLS2 Data + ROIBinSz
+
+This example runs the peakfinder8 (original V1) algorithm on LCLS2 data. The experiment/run were chosen at random and may not have actual data to analyze. This test verifies the infrastructure. It additionally incorporates the compress/decompress tests with ROIBinSz.

--- a/tests/functional/peakfinder8_lcls2_compression/README.md
+++ b/tests/functional/peakfinder8_lcls2_compression/README.md
@@ -1,3 +1,5 @@
 # Peakfinder8 (V1) LCLS2 Data + ROIBinSz
 
 This example runs the peakfinder8 (original V1) algorithm on LCLS2 data. The experiment/run were chosen at random and may not have actual data to analyze. This test verifies the infrastructure. It additionally incorporates the compress/decompress tests with ROIBinSz.
+
+NOTE: This test is also a good test of the first-party `Task` running in a different environment. The `PeakFinderSFXPressio` **managed** `Task` uses a different environment than the base one used to run the infrastructure (as that environment is not generally required to have `libpressio` yet).

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -42,4 +42,44 @@ FindPeaksSFX:
       abs_error: 1.0
       bin_size: 2
       roi_window_size: 9
+
+# You must provide a geometry file. Cell file is optional but improves results
+# mosflm is fast, you can provide additional methods for improved results at cost of speed
+IndexCrystFEL:
+  #in_file: ""            # Location of a `.lst` file listing CXI files
+  #out_file: ""           # Where to write the output stream file
+  geometry: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
+  indexing: "mosflm"      # Indeexing methods - e.g. mosflm,xgandalf
+  int_radius: "3,4,5"     # Integration radii
+  tolerance: "5,5,5,1.5"  # Tolerances
+  multi: True
+  profile: True
+  no_revalidate: True
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
+  peaks: "cxi"
+
+# You must set symmetry
+MergePartialator:
+  #in_file: ""
+  #out_file: ""
+  #model: "unity"
+  #niter: 1
+  symmetry: "2/m_uab"
+
+CompareHKL:
+  #in_files: ""
+  #fom: "Rsplit"
+  #nshells: 10
+  #shell_file: ""
+  #cell_file: ""
+  symmetry: "2/m_uab"
+
+# Select a different output format if desired. Dimple requires mtz
+#ManipulateHKL:
+  #output_format: "mtz"
+  #out_file: "..."
+
+# You must provide a PDB file to use Dimple.
+DimpleSolve:
+  pdb: "/path/to/pdb/XYZ.pdb"
 ...

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -9,11 +9,8 @@ task_timeout: 30000
 work_dir: "/tmp"
 ...
 ---
-# You must provide det_name and pv_camera_length
-# pv_camera_length is the detector distance
-# It can be a PV, or alternative a float for a fixed offset
-# Example PVs are commented below, ask beamline staff for relevant PV
-# Change outdir to an appropriate directory for CXI files.
+# Parameters here are setup to try and get results through the pipeline.
+# This is not for scientific accuracy.
 FindPeaksSFX:
     outdir: "{{ work_dir }}"
     det_name: "jungfrau"
@@ -26,11 +23,10 @@ FindPeaksSFX:
     max_peaks: 2048
     npix_min: 2
     npix_max: 30
-    amax_thr: 40
-    atot_thr: 180
-    son_min: 10.0
+    amax_thr: 1000 # ADC Threshold (Peakfinder8)
+    son_min: 4.0   # Minimum SNR (Peakfinder8)
     peak_rank: 3
-    r0: 3.0
+    r0: 8.0        # Local background radius (Peakfinder8)
     dr: 2.0
     nsigm: 10.0
     pv_camera_length: 100.0 # Could be PV, but just using fixed distance
@@ -38,27 +34,27 @@ FindPeaksSFX:
     geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
     make_powder_plots: false # Don't write powder summary to experiment
     compression:
-      compressor: "sz3" # "qoz" or "sz3"
+      compressor: "sz3" # "qoz" Does not work currently
       abs_error: 1.0
       bin_size: 2
       roi_window_size: 9
 
-# You must provide a geometry file. Cell file is optional but improves results
-# mosflm is fast, you can provide additional methods for improved results at cost of speed
+# Setting parameters to try to get SOMETHING through the infrastructure.
+# This is just an infrastructure test.
 IndexCrystFEL:
   #in_file: ""            # Location of a `.lst` file listing CXI files
   #out_file: ""           # Where to write the output stream file
   geometry: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
-  indexing: "mosflm"      # Indeexing methods - e.g. mosflm,xgandalf
-  int_radius: "3,4,5"     # Integration radii
-  tolerance: "5,5,5,1.5"  # Tolerances
+  indexing: "mosflm,xgandalf,asdf"  # Trying multiple methods for blind indexing
+  int_radius: "3,4,7"               # Slightly larger background ring
+  tolerance: "10,10,10,2"           # More lenient cell/angle tolerances
   multi: True
-  profile: True
+  # profile: True
   no_revalidate: True
-  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
+  # Not using cell file for the time being
+  # cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
   peaks: "cxi"
 
-# You must set symmetry
 MergePartialator:
   #in_file: ""
   #out_file: ""
@@ -71,7 +67,8 @@ CompareHKL:
   #fom: "Rsplit"
   #nshells: 10
   #shell_file: ""
-  #cell_file: ""
+  # Since no cell was provided during indexing, provide it here
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
   symmetry: "2/m_uab"
 
 # Select a different output format if desired. Dimple requires mtz
@@ -79,3 +76,4 @@ CompareHKL:
   #output_format: "mtz"
   #out_file: "..."
 ...
+

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -34,11 +34,11 @@ FindPeaksSFX:
     dr: 2.0
     nsigm: 10.0
     pv_camera_length: 100.0 # Could be PV, but just using fixed distance
-    n_events: 10 # Only a handful of events
+    n_events: 500 # Only a handful of events
     geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
     make_powder_plots: false # Don't write powder summary to experiment
     compression:
-      compressor: "qoz" # "qoz" or "sz3"
+      compressor: "sz3" # "qoz" or "sz3"
       abs_error: 1.0
       bin_size: 2
       roi_window_size: 9

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -72,8 +72,10 @@ CompareHKL:
   symmetry: "2/m_uab"
 
 # Select a different output format if desired. Dimple requires mtz
-#ManipulateHKL:
+ManipulateHKL:
   #output_format: "mtz"
   #out_file: "..."
+  # Since no cell was provided during indexing, provide it here
+  cell_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/maybe_lyso.cell"
 ...
 

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -1,0 +1,45 @@
+%YAML 1.3
+---
+title: "Test LUTE Peakfinder8 (v1) LCLS2 Data with Compression"
+experiment: "mfx101343025"
+run: 170
+date: "2026/03/05"
+lute_version: 0.1      # Do not be change unless need to force older version
+task_timeout: 30000
+work_dir: "/tmp"
+...
+---
+# You must provide det_name and pv_camera_length
+# pv_camera_length is the detector distance
+# It can be a PV, or alternative a float for a fixed offset
+# Example PVs are commented below, ask beamline staff for relevant PV
+# Change outdir to an appropriate directory for CXI files.
+FindPeaksSFX:
+    outdir: "{{ work_dir }}"
+    det_name: "jungfrau"
+    event_receiver: "evr0"
+    tag: "test"
+    event_logic: false
+    psana_mask: false
+    mask_file: null
+    min_peaks: 10
+    max_peaks: 2048
+    npix_min: 2
+    npix_max: 30
+    amax_thr: 40
+    atot_thr: 180
+    son_min: 10.0
+    peak_rank: 3
+    r0: 3.0
+    dr: 2.0
+    nsigm: 10.0
+    pv_camera_length: 100.0 # Could be PV, but just using fixed distance
+    n_events: 10 # Only a handful of events
+    geometry_file: "/sdf/group/lcls/ds/tools/lute/test_utilities/jf16mgeom.geom"
+    make_powder_plots: false # Don't write powder summary to experiment
+    compression:
+      compressor: "qoz" # "qoz" or "sz3"
+      abs_error: 1.0
+      bin_size: 2
+      roi_window_size: 9
+...

--- a/tests/functional/peakfinder8_lcls2_compression/config.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/config.yaml
@@ -78,8 +78,4 @@ CompareHKL:
 #ManipulateHKL:
   #output_format: "mtz"
   #out_file: "..."
-
-# You must provide a PDB file to use Dimple.
-DimpleSolve:
-  pdb: "/path/to/pdb/XYZ.pdb"
 ...

--- a/tests/functional/peakfinder8_lcls2_compression/dag.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/dag.yaml
@@ -1,5 +1,5 @@
 !LUTE_DAG
-task_name: "PeakFinderSFX"
+task_name: "PeakFinderSFXXpp"
 slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
 next:
 - task_name: "CrystFELIndexer"
@@ -13,10 +13,11 @@ next:
       next:
       - task_name: "HKLManipulator"
         slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
-        next:
-        - task_name: "DimpleSolver"
-          slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
-          next: []
+        next: []
+        # Skipping the final solver for now
+        # - task_name: "DimpleSolver"
+        #   slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+        #   next: []
       - task_name: "HKLComparer"
         slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
         next: []

--- a/tests/functional/peakfinder8_lcls2_compression/dag.yaml
+++ b/tests/functional/peakfinder8_lcls2_compression/dag.yaml
@@ -1,0 +1,22 @@
+!LUTE_DAG
+task_name: "PeakFinderSFX"
+slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+next:
+- task_name: "CrystFELIndexer"
+  slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+  next:
+  - task_name: "StreamFileConcatenator"
+    slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=2"
+    next:
+    - task_name: "PartialatorMerger"
+      slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+      next:
+      - task_name: "HKLManipulator"
+        slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
+        next:
+        - task_name: "DimpleSolver"
+          slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=73 --exclusive"
+          next: []
+      - task_name: "HKLComparer"
+        slurm_params: "--account=lcls:data --partition=milano --nodes=1 --ntasks-per-node=8"
+        next: []

--- a/tests/run_functional.py
+++ b/tests/run_functional.py
@@ -642,6 +642,7 @@ def run_workflow_maestro(
     lute_location: str,
     config_file: str,
     workflow_file: str,
+    extra_args: List[str],
 ) -> bool:
     """Run a workflow using Maestro.
 
@@ -651,6 +652,9 @@ def run_workflow_maestro(
         config_file (str): Path to the configuration YAML.
 
         workflow_file (str): Path to the DAG definition YAML.
+
+        extra_args (List[str]): The set of additional arguments which should be
+            for SLURM.
 
     Returns:
         is_successful (bool): True if workflow returns successful. False otherwise.
@@ -909,6 +913,12 @@ if __name__ == "__main__":
                 True if os.path.exists(f"{test_dir}/SHOULD_FAIL") else False
             )
 
+            # Replace DAG SLURM account for account provided on command-line
+            for arg in extra_args:
+                if "--account=" in arg:
+                    sed_pattern = f"s|--account=[^[:space:]]*|{arg}|g"
+                    inplace_sed(wf_file, sed_pattern)
+
             # Retrieve the experiment and run from each test YAML
             experiment: str = parse_yaml_value(config_file, "experiment")
             run: str = parse_yaml_value(config_file, "run")
@@ -923,6 +933,7 @@ if __name__ == "__main__":
             run_workflow: Union[
                 Callable[[str, str, str, bool, bool], bool],
                 Callable[[str, str, str], bool],
+                Callable[[str, str, str, List[str]], bool],
             ]
             is_successful: bool
             if args.use_airflow:
@@ -947,6 +958,7 @@ if __name__ == "__main__":
                     lute_location=lute_location,
                     config_file=config_file,
                     workflow_file=wf_file,
+                    extra_args=extra_args,
                 )
 
             if is_successful:

--- a/tests/unit/test_env_bootstrap_mpi.py
+++ b/tests/unit/test_env_bootstrap_mpi.py
@@ -1,0 +1,81 @@
+import os
+from typing import Dict
+from unittest.mock import patch
+
+from subprocess_task import is_mpi_job
+
+
+def test_is_mpi_job_ompi():
+    """Test the MPI submission detection (OMPI flavor)."""
+    env: Dict[str, str] = {"OMPI_COMM_WORLD_RANK": "2", "OMPI_COMM_WORLD_SIZE": "4"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is True
+        assert rank == 2
+
+
+def test_is_mpi_job_pmi():
+    """Test the MPI submission detection (Intel flavor)."""
+    env: Dict[str, str] = {"PMI_RANK": "1", "PMI_SIZE": "2"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is True
+        assert rank == 1
+
+
+def test_is_mpi_job_slurm():
+    """Test the MPI submission detection (based on SLURM variables only)."""
+    env: Dict[str, str] = {"SLURM_PROCID": "1", "SLURM_NTASKS": "4"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is True
+        assert rank == 1
+
+
+def test_is_mpi_job_slurm_size_1():
+    """Test non-MPI submission for SLURM_NTASKS <= 2."""
+    env: Dict[str, str] = {"SLURM_PROCID": "0", "SLURM_NTASKS": "1"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is False
+        assert rank == 0
+
+
+def test_is_mpi_job_slurm_size_2():
+    """Test non-MPI submission for SLURM_NTASKS <= 2."""
+    env: Dict[str, str] = {"SLURM_PROCID": "0", "SLURM_NTASKS": "2"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is False
+        assert rank == 0
+
+
+def test_is_mpi_job_none():
+    """Test non-MPI submission for no relevant environment variables."""
+    with patch.dict(os.environ, {}, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is False
+        assert rank == -1
+
+
+def test_is_mpi_job_slurm_only_rank():
+    """Test non-MPI submission for SLURM environment variable only."""
+    env: Dict[str, str] = {"SLURM_PROCID": "0"}
+    with patch.dict(os.environ, env, clear=True):
+        is_mpi: bool
+        rank: int
+        is_mpi, rank = is_mpi_job()
+        assert is_mpi is False
+        assert rank == 0

--- a/utilities/activate_installation
+++ b/utilities/activate_installation
@@ -6,7 +6,8 @@
 LUTE_BIN_PATH="$(cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
 LUTE_INSTALL_PATH="$(echo $LUTE_BIN_PATH | sed s/bin//g)"
 echo "Using LUTE installation at $LUTE_INSTALL_PATH"
-LUTE_LIB_PATH=(${LUTE_INSTALL_PATH}lib/python*/site-packages)
+PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+LUTE_LIB_PATH=(${LUTE_INSTALL_PATH}lib/python${PY_VER}/site-packages)
 echo "Python libraries are available at: ${LUTE_LIB_PATH}"
 export PYTHONPATH="${LUTE_LIB_PATH}:${PYTHONPATH}"
 export PATH="${LUTE_BIN_PATH}:${PATH}"


### PR DESCRIPTION
# Description

This PR reworks `FindPeaksPyAlgos` to support using `peakfinder8`. It also adds the support for LCLS1 and LCLS2. The new `Task` is called `FindPeaksSFX`.

This also fixed some issues with the powder plot generation. NOTE: The powder HTML files are massive for the JF16M (>200 MB). This can be addressed later... For now there is a flag to turn off generation if needed. The raw (unassembled) powders are stored in the CXI files no matter what though.

## Disclaimers
**There is an issue in** `libpressio` **which requires a workaround in the** `Task`.

Due to out-of-bound access in some loops in the `libpressio` internals, the decompression process will seem to "hang" for ever if using array inputs that are of dimensionality 2. This is unfortunately the array requirement for using peakfinder8/CrystFEL (so called, "SLAB" geometry").

For the timebeing, there is a work-around in place which pads the arrays to 4-dimensions with empty axes along the first two. The arrays are then reshaped back to two dimensions afterwards. The centers/mask/peaks and so on that need to be passed to the compressor are also appropriately reshaped to 4D or whatever equivalent corresponding shape is required.

## Checklist
- [x] Add `peakfinder8` to `FindPeaksSFX`. (Also have nominal support for `peakfinder8_v2`, but not fully tested).
- [x] Add LCLS2 support to `FindPeaksSFX`.
- [x] Fix environment bootstrap for first-party MPI `Task`s that run in different environments
  - Previously the MPI context was destroyed on exec. Now, the context is not created at all until after the `exec`.
- [x] Tests for the new boostrap MPI detection in `tests/unit/test_env_bootstrap_mpi.py`
- [x] Functional/integration tests in `tests/functional/peakfinder8_lcls2` and `tests/functional/peakfinder8_lcls2_compression`
- [x] Support target `Task` environments that are different Python versions than the base environment
  - In general, this was always implicitly supported for Python-only code. C-extensions would break, however. The updates address this for C-extensions
  - This requires building `LUTE` twice (or more), once for each possible environment Python version that will be used.
- [x] `build.sh` updates for specifying an environment to source to get the base `python`
- [x] Add some additional documentation on `build.sh` changes, and add general cleanup to the docs.

## PR Type:
- [x] New feature/Enhancement

## Address issues:

# Testing
## Running the two `peakfinder8` tests (with and without compression)
```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data --run_tests peakfinder8_lcls2_compression
# ....
Submitted batch job 23085870
> tail slurm-23085870.out 
# ....
INFO:Launch_Func_Tests:Test workflow peakfinder8_lcls2_compression completed successfully.
INFO:Launch_Func_Tests:Ran 1 tests. 1 were successful.
INFO:Launch_Func_Tests:Ran 1 tests. 1 were successful.
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data --run_tests peakfinder8_lcls2
# ....
Submitted batch job 23087095
> tail -f slurm-23087095.out 
# ....
INFO:Launch_Func_Tests:Test workflow peakfinder8_lcls2 completed successfully.
INFO:Launch_Func_Tests:Ran 1 tests. 1 were successful.
INFO:Launch_Func_Tests:Ran 1 tests. 1 were successful.
```

## Double checking the rest of the tests
(Commented out the XSS analysis which is still known to be broken)
```diff
diff --git a/tests/functional/smd2_multi_node/dag.yaml b/tests/functional/smd2_multi_node/dag.yaml
index 3ac364f..bfd806e 100644
--- a/tests/functional/smd2_multi_node/dag.yaml
+++ b/tests/functional/smd2_multi_node/dag.yaml
@@ -1,7 +1,7 @@
 !LUTE_DAG
 task_name: SmallDataProducer2
 slurm_params: '--account=lcls:data --partition=milano --ntasks-per-node=50 --nodes=4 --exclusive'
-next:
-- task_name: SmallDataXSSAnalyzer
-  slurm_params: '--account=lcls:data --partition=milano'
-  next: []
+next: []
+#- task_name: SmallDataXSSAnalyzer
+#  slurm_params: '--account=lcls:data --partition=milano'
+#  next: []
```

```bash
> ./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:data --run_tests basic_tests,param_generation,smd2_mfx_prod,smd2_multi_node,smd_mfx_default,smd_xpp_default
# ....
Submitted batch job 23089951
> tail -f slurm-23089951.out 
# ....
INFO:Launch_Func_Tests:Test workflow smd_mfx_default completed successfully.
INFO:Launch_Func_Tests:Ran 6 tests. 6 were successful.
INFO:Launch_Func_Tests:Ran 6 tests. 6 were successful.
```
## Single Task Example
An example test YAML - a CrystFEL geometry is required:
```yaml
FindPeaksSFX:
    outdir: "{{ work_dir }}"
    det_name: "jungfrau"
    event_receiver: "evr0"
    tag: "test"
    event_logic: false
    psana_mask: false
    mask_file: null
    min_peaks: 10
    max_peaks: 2048
    npix_min: 2
    npix_max: 30
    amax_thr: 40
    atot_thr: 180
    son_min: 10.0
    peak_rank: 3
    r0: 3.0
    dr: 2.0
    nsigm: 10.0
    pv_camera_length: 100.0
    #pv_camera_length: "MFX:ROB:CONT:POS:Z"  # MFX epix10k2M
    #pv_camera_length: "MFX:DET:MMS:04.RBV" # MFX Rayonix
    n_events: 10
    geometry_file: "/sdf/scratch/users/d/dorlhiac/work/jf16mgeom.geom"
    make_powder_plots: false
```

Some output CXI:
```bash
> h5ls ../lute_output/mfx101343025_r0170_test.cxi/entry_1/data_1
data                     Dataset {8, 16384, 1024}
mask                     Dataset {16384, 1024}
powderHits               Dataset {16384, 1024}
powderMisses             Dataset {16384, 1024}
```

With the list file it generates:
```bash
> cat ../lute_output/mfx101343025_170_test.list 
/sdf/scratch/users/d/dorlhiac/work/lute_output/mfx101343025_r0170_test.cxi
```

## Unit Test Confirmation
```bash
> pytest tests/unit/
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/scratch/users/d/dorlhiac/work/lute_pf8
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 35 items                                                                                                                                                                                                                      

tests/unit/test_db_common.py .....                                                                                                                                                                                                [ 14%]
tests/unit/test_db_v1.py .                                                                                                                                                                                                        [ 17%]
tests/unit/test_db_v2.py .                                                                                                                                                                                                        [ 20%]
tests/unit/test_env_bootstrap_mpi.py .......                                                                                                                                                                                      [ 40%]
tests/unit/test_executor.py ......                                                                                                                                                                                                [ 57%]
tests/unit/test_ipc.py ..                                                                                                                                                                                                         [ 62%]
tests/unit/test_launch_utils.py ....                                                                                                                                                                                              [ 74%]
tests/unit/test_parsing.py ......                                                                                                                                                                                                 [ 91%]
tests/unit/test_task.py ...                                                                                                                                                                                                       [100%]

========================================================================================================== 35 passed in 1.54s ===========================================================================================================
> test_http
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
> test_server
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-03-05 13:49:11.173] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-03-05 13:49:11.173] [HTTP:Server] [info] Shutting down server...
[2026-03-05 13:49:11.173] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-03-05 13:49:11.173] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-03-05 13:49:11.274] [HTTP:Server] [info] Shutting down server...
[2026-03-05 13:49:11.274] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (101 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-03-05 13:49:11.275] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-03-05 13:49:11.375] [HTTP:Server] [info] Shutting down server...
[2026-03-05 13:49:11.375] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (202 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (202 ms total)
[  PASSED  ] 3 tests.
```

# Screenshots
<img width="742" height="964" alt="image" src="https://github.com/user-attachments/assets/cfb6269c-165a-49c8-9f0a-a41a2de834be" />
