### PR TITLE
ENH Refine XSS analysis task

### DIFF
--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -689,7 +689,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     scanned motors.
     """
 
-    class Thresholds(BaseModel):
+    class AnalysisParameters(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
@@ -721,7 +721,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     ccm_set: Optional[str] = Field(
         None, description="Name of the PV for the setpoint of the CCM."
     )
-    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
+    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0))
     element: Optional[str] = Field(
         None,
         description="Element under investigation. Currently unused. For future EXAFS.",
@@ -736,7 +736,7 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
     scanned motors.
     """
 
-    class Thresholds(BaseModel):
+    class AnalysisParameters(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
@@ -764,7 +764,7 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
+    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0))
     invert_xes_axes: bool = Field(
         False,
         description=(

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -640,15 +640,12 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             12, description="Size of median filter to apply to scattering profiles."
         )
         water_qs: Tuple[float, float] = Field(
-            (1.0, 1.93),
-            description="Q-range for water peak."
+            (1.0, 1.93), description="Q-range for water peak."
         )
         water_ratio: float = Field(
             1.25, description="Ratio of water peak intensity to use for analysis."
         )
-        water_sigma: float = Field(
-            2.0, description="Sigma for water peak."
-        )
+        water_sigma: float = Field(2.0, description="Sigma for water peak.")
         num_intensity_bins: int = Field(
             20, description="Number of bins for total intensity based subsampling."
         )
@@ -662,9 +659,8 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         None, description="Name of the detector with scattering data."
     )
     xss_event_codes: Optional[List[int]] = Field(
-        None,
-        description="List of event codes to use for XSS T-Jump analysis."
-    )   
+        None, description="List of event codes to use for XSS T-Jump analysis."
+    )
     ipm_var: str = Field(
         description="Name of the IPM to use for X-Ray intensity filtering."
     )
@@ -676,8 +672,7 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         ),
     )
     analysis_parameters: AnalysisParameters = Field(
-        AnalysisParameters(),
-        description="Parameters for XSS analysis."
+        AnalysisParameters(), description="Parameters for XSS analysis."
     )
 
 

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -634,8 +634,7 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         )
         q_norm: Tuple[float, float] = Field(
             (0.9, 3.5),
-            description=("Q-range to use for normalization of scattering signal."
-            ),
+            description=("Q-range to use for normalization of scattering signal."),
         )
         median_filter_size: int = Field(
             12, description="Size of median filter to apply to scattering profiles."
@@ -654,8 +653,8 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     )
     xss_event_codes: Optional[List[int]] = Field(
         None,
-        description="List of event codes to use for XSS analysis other than laser on/off."
-    )   
+        description="List of event codes to use for XSS analysis other than laser on/off.",
+    )
     ipm_var: str = Field(
         description="Name of the IPM to use for X-Ray intensity filtering."
     )
@@ -667,12 +666,17 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         ),
     )
     output_dir: Optional[str] = Field(
-        None, description=(
+        None,
+        description=(
             "Optional directory to save XSS analysis results. "
             "If None, no results will be saved."
+        ),
+    )
+    analysis_parameters: AnalysisParameters = Field(
+        AnalysisParameters(
+            min_Iscat=10.0, min_ipm=1000.0, q_range=(0.9, 3.5), q_norm=(0.9, 3.5)
         )
     )
-    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0, q_range=(0.9, 3.5), q_norm=(0.9, 3.5)))
 
 
 class AnalyzeSmallDataXASParameters(TaskParameters):

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -632,7 +632,7 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         min_ipm: float = Field(
             1000.0, description="Minimum X-ray intensity to use for filtering."
         )
-    
+
     class XSSProcessingParameters(BaseModel):
         q_norm: Tuple[float, float] = Field(
             (0.9, 3.5),
@@ -645,7 +645,8 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             (1.0, 1.93), description="Q-range for water peak."
         )
         water_ratio: float = Field(
-            1.25, description="Ratio of water peak intensity between low and high Q to filter bad water shots."
+            1.25,
+            description="Ratio of water peak intensity between low and high Q to filter bad water shots.",
         )
         water_sigma: float = Field(
             2.0, description="Standard deviation for filtering bad water shots."

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -716,7 +716,9 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     ccm_set: Optional[str] = Field(
         None, description="Name of the PV for the setpoint of the CCM."
     )
-    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0))
+    analysis_parameters: AnalysisParameters = Field(
+        AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0)
+    )
     element: Optional[str] = Field(
         None,
         description="Element under investigation. Currently unused. For future EXAFS.",
@@ -759,7 +761,9 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0))
+    analysis_parameters: AnalysisParameters = Field(
+        AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0)
+    )
     invert_xes_axes: bool = Field(
         False,
         description=(

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -625,13 +625,15 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     scanned motors.
     """
 
-    class AnalysisParameters(BaseModel):
+    class IntensityThresholds(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
         min_ipm: float = Field(
             1000.0, description="Minimum X-ray intensity to use for filtering."
         )
+    
+    class XSSProcessingParameters(BaseModel):
         q_norm: Tuple[float, float] = Field(
             (0.9, 3.5),
             description=("Q-range to use for normalization of scattering signal."),
@@ -643,9 +645,11 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             (1.0, 1.93), description="Q-range for water peak."
         )
         water_ratio: float = Field(
-            1.25, description="Ratio of water peak intensity to use for analysis."
+            1.25, description="Ratio of water peak intensity between low and high Q to filter bad water shots."
         )
-        water_sigma: float = Field(2.0, description="Sigma for water peak.")
+        water_sigma: float = Field(
+            2.0, description="Standard deviation for filtering bad water shots."
+        )
         num_intensity_bins: int = Field(
             20, description="Number of bins for total intensity based subsampling."
         )
@@ -671,8 +675,11 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    analysis_parameters: AnalysisParameters = Field(
-        AnalysisParameters(), description="Parameters for XSS analysis."
+    intensity_thresholds: IntensityThresholds = Field(
+        IntensityThresholds(), description="Intensity thresholds for XSS analysis."
+    )
+    xss_processing_parameters: XSSProcessingParameters = Field(
+        XSSProcessingParameters(), description="Parameters for processing XSS data."
     )
 
 
@@ -684,7 +691,7 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     scanned motors.
     """
 
-    class AnalysisParameters(BaseModel):
+    class IntensityThresholds(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
@@ -716,8 +723,9 @@ class AnalyzeSmallDataXASParameters(TaskParameters):
     ccm_set: Optional[str] = Field(
         None, description="Name of the PV for the setpoint of the CCM."
     )
-    analysis_parameters: AnalysisParameters = Field(
-        AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0)
+    intensity_thresholds: IntensityThresholds = Field(
+        IntensityThresholds(min_Iscat=10.0, min_ipm=1000.0),
+        description="Intensity thresholds for XAS analysis.",
     )
     element: Optional[str] = Field(
         None,
@@ -733,7 +741,7 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
     scanned motors.
     """
 
-    class AnalysisParameters(BaseModel):
+    class IntensityThresholds(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
@@ -761,8 +769,9 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    analysis_parameters: AnalysisParameters = Field(
-        AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0)
+    intensity_thresholds: IntensityThresholds = Field(
+        IntensityThresholds(min_Iscat=10.0, min_ipm=1000.0),
+        description="Intensity thresholds for XES analysis.",
     )
     invert_xes_axes: bool = Field(
         False,

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -640,8 +640,18 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
         median_filter_size: int = Field(
             12, description="Size of median filter to apply to scattering profiles."
         )
+        water_qs: Tuple[float, float] = Field(
+            (1.0, 1.93),
+            description="Q-range for water peak."
+        )
+        water_ratio: float = Field(
+            1.25, description="Ratio of water peak intensity to use for analysis."
+        )
+        water_sigma: float = Field(
+            2.0, description="Sigma for water peak."
+        )
         num_intensity_bins: int = Field(
-            100, description="Number of bins for total intensity based subsampling."
+            20, description="Number of bins for total intensity based subsampling."
         )
 
     _find_smd_path = validate_smd_path("smd_path")
@@ -654,7 +664,7 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     )
     xss_event_codes: Optional[List[int]] = Field(
         None,
-        description="List of event codes to use for XSS analysis other than laser on/off."
+        description="List of event codes to use for XSS T-Jump analysis."
     )   
     ipm_var: str = Field(
         description="Name of the IPM to use for X-Ray intensity filtering."
@@ -666,13 +676,10 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    output_dir: Optional[str] = Field(
-        None, description=(
-            "Optional directory to save XSS analysis results. "
-            "If None, no results will be saved."
-        )
+    analysis_parameters: AnalysisParameters = Field(
+        AnalysisParameters(),
+        description="Parameters for XSS analysis."
     )
-    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0, q_range=(0.9, 3.5), q_norm=(0.9, 3.5)))
 
 
 class AnalyzeSmallDataXASParameters(TaskParameters):

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -625,17 +625,24 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     scanned motors.
     """
 
-    class Thresholds(BaseModel):
+    class AnalysisParameters(BaseModel):
         min_Iscat: float = Field(
             10.0, description="Minimum scattering intensity to use for filtering."
         )
         min_ipm: float = Field(
             1000.0, description="Minimum X-ray intensity to use for filtering."
         )
-
-    class AnalysisFlags(BaseModel):
-        use_pyfai: bool = True
-        use_asymls: bool = False
+        q_norm: Tuple[float, float] = Field(
+            (0.9, 3.5),
+            description=("Q-range to use for normalization of scattering signal."
+            ),
+        )
+        median_filter_size: int = Field(
+            12, description="Size of median filter to apply to scattering profiles."
+        )
+        num_intensity_bins: int = Field(
+            100, description="Number of bins for total intensity based subsampling."
+        )
 
     _find_smd_path = validate_smd_path("smd_path")
 
@@ -645,6 +652,10 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
     xss_detname: Optional[str] = Field(
         None, description="Name of the detector with scattering data."
     )
+    xss_event_codes: Optional[List[int]] = Field(
+        None,
+        description="List of event codes to use for XSS analysis other than laser on/off."
+    )   
     ipm_var: str = Field(
         description="Name of the IPM to use for X-Ray intensity filtering."
     )
@@ -655,8 +666,13 @@ class AnalyzeSmallDataXSSParameters(TaskParameters):
             "E.g. lxt, lens_h, etc."
         ),
     )
-    thresholds: Thresholds = Field(Thresholds(min_Iscat=10.0, min_ipm=1000.0))
-    # analysis_flags: AnalysisFlags
+    output_dir: Optional[str] = Field(
+        None, description=(
+            "Optional directory to save XSS analysis results. "
+            "If None, no results will be saved."
+        )
+    )
+    analysis_parameters: AnalysisParameters = Field(AnalysisParameters(min_Iscat=10.0, min_ipm=1000.0, q_range=(0.9, 3.5), q_norm=(0.9, 3.5)))
 
 
 class AnalyzeSmallDataXASParameters(TaskParameters):

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -432,8 +432,9 @@ class AnalyzeSmallData(Task):
         Returns:
             processed_profiles (npt.NDArray[np.float64]): The processed water profiles.
         """
-        from scipy.stats import zscore  # type: ignore
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
 
+        from scipy.stats import zscore  # type: ignore
         medfilt_size: int = self._task_parameters.xss_processing_parameters.median_filter_size
         qs: Tuple[float, float] = self._task_parameters.xss_processing_parameters.water_qs
         ratio: float = self._task_parameters.xss_processing_parameters.water_ratio
@@ -639,20 +640,18 @@ class AnalyzeSmallData(Task):
 
     # XSS - Extraction and TR difference
     ############################################################################
-    def _extract_xss(self, event_codes: Optional[List[int]]) -> None:
+    def _extract_xss(self) -> None:
         """Extract XSS additional event codes other than laser on/off
         and setup event code filters.
 
         Sets up filters for each event code provided in the input list.
         Will search for both psana1 and psana2 formats of event code storage.
-
-        Args:
-            event_codes (Optional[List[int]]): A list of event codes to extract.
         """
         assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
+
         self._xss_event_codes = []
-        if event_codes:
-            xss_codes = np.sort(event_codes)
+        if self._task_parameters.xss_event_codes:
+            xss_codes = np.sort(self._task_parameters.xss_event_codes)
             for code in xss_codes:
                 try:  # psana1
                     self._filter_dict[f"code {code}"] = (
@@ -1090,6 +1089,8 @@ class AnalyzeSmallData(Task):
             laser_off (npt.NDArray[np.float64]): 2D laser off scattering profiles
                 of shape (n_events_laser_off, q_bins)
         """
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
+
         dark_mean: npt.NDArray[np.float64] = self._calc_xss_dark_mean()
         if len(np.unique(dark_mean)) > 1:
             # Can be len == 1 if all nan
@@ -1343,8 +1344,9 @@ class AnalyzeSmallData(Task):
             ("XSS Scan", scan_grid),
         )
 
-        overlap_grid = self.plot_xss_overlap_fit_hv(laser_on, bins, diff)
-        tabs.append(("XSS Overlap Fit", overlap_grid))
+        if len(bins) > 4:
+            overlap_grid = self.plot_xss_overlap_fit_hv(laser_on, bins, diff)
+            tabs.append(("XSS Overlap Fit", overlap_grid))
 
         tjump_grid: pn.GridSpec = self.plot_xss_tjump_hv(tjumps, processed_tjumps)
         tabs.append(("XSS T-Jump", tjump_grid))
@@ -1369,6 +1371,8 @@ class AnalyzeSmallData(Task):
         Returns:
             plot (pn.GridSpec): Plotted azimuthally integrated difference by scan variable.
         """
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
+
         scan_grid = pn.GridSpec(
             sizing_mode="stretch_both",
             max_width=1000,
@@ -1458,30 +1462,43 @@ class AnalyzeSmallData(Task):
             scan_grid[1, 1] = hv.Overlay(subsample_plots).opts(shared_axes=False)
 
         # Bottom left - 2D difference
-        xs_dim = hv.Dimension(("scan_bin", scan_var_name))
-        diff_dim = hv.Dimension(("diff", "dS"))
-        diff_img = hv.Image(
-            (bins, self._q_vals, diff), kdims=[xs_dim, q_dim], vdims=diff_dim
-        ).opts(cmap="viridis", colorbar=True, title="dS", shared_axes=False)
-        scan_grid[2, 0] = diff_img
+        if len(bins) > 1:
+            xs_dim = hv.Dimension(("scan_bin", scan_var_name))
+            diff_dim = hv.Dimension(("diff", "dS"))
+            diff_img = hv.Image(
+                (bins, self._q_vals, diff), kdims=[xs_dim, q_dim], vdims=diff_dim
+            ).opts(cmap="viridis", colorbar=True, title="dS", shared_axes=False)
+            scan_grid[2, 0] = diff_img
 
-        # Bottom right - difference slices
-        nth = max(1, len(bins) // 8)
-        every_nth = (np.arange(len(bins)) % nth) == 0
-        diff_slices = diff[:, every_nth]
-        spacing = np.nanmax(np.abs(diff_slices))
-        colors = [
-            to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
-        ]
-        diff_slice_plots = []
-        for i in range(diff_slices.shape[1]):
-            diff_slice_plot = hv.Curve(
-                (self._q_vals, diff_slices[:, i] + i * spacing),
+            # Bottom right - difference slices
+            nth = max(1, len(bins) // 8)
+            every_nth = (np.arange(len(bins)) % nth) == 0
+            diff_slices = diff[:, every_nth]
+            spacing = np.nanmax(np.abs(diff_slices))
+            colors = [
+                to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
+            ]
+            diff_slice_plots = []
+            for i in range(diff_slices.shape[1]):
+                diff_slice_plot = hv.Curve(
+                    (self._q_vals, diff_slices[:, i] + i * spacing),
+                    kdims=[q_dim],
+                    vdims=hv.Dimension(("diff", "dS")),
+                ).opts(color=colors[i], title="dS slices")
+                diff_slice_plots.append(diff_slice_plot)
+            scan_grid[2, 1] = hv.Overlay(diff_slice_plots).opts(shared_axes=False)
+        else:
+            diff_curve = hv.Curve(
+                (self._q_vals, diff[:, 0]),
                 kdims=[q_dim],
                 vdims=hv.Dimension(("diff", "dS")),
-            ).opts(color=colors[i], title="dS slices")
-            diff_slice_plots.append(diff_slice_plot)
-        scan_grid[2, 1] = hv.Overlay(diff_slice_plots).opts(shared_axes=False)
+            ).opts(
+                color="dodgerblue",
+                line_width=2,
+                title=f"dS — {scan_var_name} = {bins[0]:.3g}",
+                shared_axes=False,
+            )
+            scan_grid[2, 0:2] = diff_curve.opts(shared_axes=False)
 
         return scan_grid
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -22,7 +22,6 @@ import numpy.typing as npt
 import panel as pn
 import matplotlib.pyplot as plt  # type: ignore
 from matplotlib.colors import to_hex  # type: ignore
-from matplotlib.ticker import MaxNLocator  # type: ignore
 from mpi4py import MPI
 from scipy.signal import find_peaks  # type: ignore
 from scipy.optimize import curve_fit  # type: ignore
@@ -1584,7 +1583,7 @@ class AnalyzeSmallData(Task):
             ).opts(
                 cmap="coolwarm_r",
                 colorbar=True,
-                title=f"dS cross-talk to laser off",
+                title="dS cross-talk to laser off",
                 shared_axes=False,
             )
             tjump_grid[0, 1] = tjump_img
@@ -1601,7 +1600,7 @@ class AnalyzeSmallData(Task):
             ).opts(
                 cmap="coolwarm_r",
                 colorbar=True,
-                title=f"Processed dS cross-talk to laser off",
+                title="Processed dS cross-talk to laser off",
                 shared_axes=False,
             )
             tjump_grid[1, 1] = processed_tjump_img

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -434,8 +434,12 @@ class AnalyzeSmallData(Task):
         """
         from scipy.stats import zscore  # type: ignore
 
-        medfilt_size: int = self._task_parameters.xss_processing_parameters.median_filter_size
-        qs: Tuple[float, float] = self._task_parameters.xss_processing_parameters.water_qs
+        medfilt_size: int = (
+            self._task_parameters.xss_processing_parameters.median_filter_size
+        )
+        qs: Tuple[float, float] = (
+            self._task_parameters.xss_processing_parameters.water_qs
+        )
         ratio: float = self._task_parameters.xss_processing_parameters.water_ratio
         sigma: float = self._task_parameters.xss_processing_parameters.water_sigma
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -281,8 +281,8 @@ class AnalyzeSmallData(Task):
             ],
             self._task_parameters,
         )
-        scattering_thresh: float = self._task_parameters.analysis_parameters.min_Iscat
-        ipm_thresh: float = self._task_parameters.analysis_parameters.min_ipm
+        scattering_thresh: float = self._task_parameters.intensity_thresholds.min_Iscat
+        ipm_thresh: float = self._task_parameters.intensity_thresholds.min_ipm
         self._filter_dict["total scattering"] = (
             self._integrated_intensity > scattering_thresh
         )
@@ -423,10 +423,6 @@ class AnalyzeSmallData(Task):
     def _process_xss_water_signal(
         self,
         profiles: npt.NDArray[np.float64],
-        medfilt_size: int = 13,
-        qs: Tuple[float, float] = (1.0, 1.93),
-        ratio: float = 1.25,
-        sigma: float = 2.0,
     ) -> npt.NDArray[np.float64]:
         """Filter outliers and select strong enough water shots.
 
@@ -437,6 +433,11 @@ class AnalyzeSmallData(Task):
             processed_profiles (npt.NDArray[np.float64]): The processed water profiles.
         """
         from scipy.stats import zscore  # type: ignore
+
+        medfilt_size: int = self._task_parameters.xss_processing_parameters.median_filter_size
+        qs: Tuple[float, float] = self._task_parameters.xss_processing_parameters.water_qs
+        ratio: float = self._task_parameters.xss_processing_parameters.water_ratio
+        sigma: float = self._task_parameters.xss_processing_parameters.water_sigma
 
         profiles = self._apply_median_filter(profiles, medfilt_size)
         low_q, high_q = qs
@@ -675,10 +676,6 @@ class AnalyzeSmallData(Task):
 
     def _calc_tjump_xss(
         self,
-        medfilt_size: int = 13,
-        water_qs: Tuple[float, float] = (1.0, 1.93),
-        water_ratio: float = 1.25,
-        water_signal_sigma: float = 2.0,
     ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """Calculate the temperature jump traces for each event code.
 
@@ -706,10 +703,6 @@ class AnalyzeSmallData(Task):
         processed_las_off_profiles: npt.NDArray[np.float64] = (
             self._process_xss_water_signal(
                 las_off_profiles,
-                medfilt_size,
-                water_qs,
-                water_ratio,
-                water_signal_sigma,
             )
         )
         processed_las_off: npt.NDArray[np.float64] = np.nanmean(
@@ -726,7 +719,7 @@ class AnalyzeSmallData(Task):
             profiles = np.nanmean(self._norm_az_int[filter_code], axis=1)
             tjump = np.nanmean(profiles, axis=0) - las_off
             processed_profiles = self._process_xss_water_signal(
-                profiles, medfilt_size, water_qs, water_ratio, water_signal_sigma
+                profiles,
             )
             processed_tjump = np.nanmean(processed_profiles, axis=0) - processed_las_off
             tjumps[i, :] = tjump
@@ -846,7 +839,7 @@ class AnalyzeSmallData(Task):
     # XES - Extraction and TR difference
     ############################################################################
     def _extract_xes(self, detname: str) -> None:
-        """Extract XAS specific data.
+        """Extract XES specific data.
 
         Extracts individual ROIs and applys projections to extract the XES
         spectra. Depending on input TaskParameters, it will optionally rotate
@@ -1101,7 +1094,7 @@ class AnalyzeSmallData(Task):
         if len(np.unique(dark_mean)) > 1:
             # Can be len == 1 if all nan
             self._az_int -= dark_mean
-        q_limits = self._task_parameters.analysis_parameters.q_norm
+        q_limits = self._task_parameters.xss_processing_parameters.q_norm
         norm: npt.NDArray[np.float64] = self._calc_norm_by_qrange(q_limits)
         self._norm_az_int = (
             self._az_int / norm[:, :, np.newaxis]
@@ -1445,7 +1438,7 @@ class AnalyzeSmallData(Task):
         scan_grid[1, 0] = cake_on_img
 
         # Mid right - 1D subsample unnormalized laser on shots
-        num_bins = self._task_parameters.analysis_parameters.num_intensity_bins
+        num_bins = self._task_parameters.xss_processing_parameters.num_intensity_bins
         az_av_laser_on = self._az_int[filter_las_on]
         total_intensity = np.nansum(az_av_laser_on, axis=(1, 2))
         sorted_indices = np.argsort(total_intensity)

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -331,7 +331,8 @@ class AnalyzeSmallData(Task):
         # )
         return np.nanmean(self._calc_norm_by_qrange((1.5, 3.5)), axis=-1)
 
-    def _apply_median_filter(self,
+    def _apply_median_filter(
+        self,
         profiles: npt.NDArray[np.float64],
         kernel_size: int = 13,
     ) -> npt.NDArray[np.float64]:
@@ -346,7 +347,7 @@ class AnalyzeSmallData(Task):
             filtered_profiles (npt.NDArray[np.float64]): The filtered profiles.
         """
         from scipy.signal import medfilt  # type: ignore
-    
+
         if kernel_size % 2 == 0:
             kernel_size += 1
 
@@ -419,13 +420,14 @@ class AnalyzeSmallData(Task):
             )
             dark_mean = np.zeros([self._num_events])
         return dark_mean
-    
-    def _process_xss_water_signal(self, 
+
+    def _process_xss_water_signal(
+        self,
         profiles: npt.NDArray[np.float64],
         medfilt_size: int = 13,
         qs: Tuple[float, float] = (1.0, 1.93),
         ratio: float = 1.25,
-        sigma: float = 2.0
+        sigma: float = 2.0,
     ) -> npt.NDArray[np.float64]:
         """Filter outliers and select strong enough water shots.
 
@@ -446,9 +448,11 @@ class AnalyzeSmallData(Task):
         filter = high_q_vals > low_q_vals
 
         signal_peak = np.abs(zscore(profiles[:, high_q_idx]))
-        filter &= (signal_peak <= sigma)
+        filter &= signal_peak <= sigma
         if np.sum(filter) == 0:
-            logger.warning("No good water shots found. Try loosening the criteria. Defaulting to all shots.")
+            logger.warning(
+                "No good water shots found. Try loosening the criteria. Defaulting to all shots."
+            )
             filter = np.ones_like(filter, dtype=bool)
         return profiles[filter]
 
@@ -650,7 +654,7 @@ class AnalyzeSmallData(Task):
         if event_codes:
             xss_codes = np.sort(event_codes)
             for code in xss_codes:
-                try: # psana1
+                try:  # psana1
                     self._filter_dict[f"code {code}"] = (
                         self._smd_h5["evr"][f"code_{code}"][
                             self._start_idx : self._stop_idx
@@ -669,13 +673,13 @@ class AnalyzeSmallData(Task):
                         self._xss_event_codes.append(code)
                     except Exception:
                         logger.error(f"No event code {code} found.")
-        
+
     def _calc_tjump_xss(
         self,
         medfilt_size: int = 13,
         water_qs: Tuple[float, float] = (1.0, 1.93),
         water_ratio: float = 1.25,
-        water_signal_sigma: float = 2.0
+        water_signal_sigma: float = 2.0,
     ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """Calculate the temperature jump traces for each event code.
 
@@ -685,7 +689,7 @@ class AnalyzeSmallData(Task):
         Returns:
             tjumps (npt.NDArray[np.float64]): A 2D array of shape (event_codes, q_bins)
                 containing the raw and processed temperature jump traces for each event code.
-            
+
             processed_tjumps (npt.NDArray[np.float64]): A 2D array of shape (event_codes, q_bins)
                 containing the processed temperature jump traces for each event code.
         """
@@ -696,17 +700,23 @@ class AnalyzeSmallData(Task):
             filter_vars="xray on, laser off, ipm, total scattering"
         )
 
-        las_off_profiles: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_off], axis=1)
-        las_off: npt.NDArray[np.float64] = np.nanmean(las_off_profiles, axis=0)
-        processed_las_off_profiles: npt.NDArray[np.float64] = self._process_xss_water_signal(
-            las_off_profiles,
-            medfilt_size,
-            water_qs, 
-            water_ratio, 
-            water_signal_sigma,
+        las_off_profiles: npt.NDArray[np.float64] = np.nanmean(
+            self._norm_az_int[filter_las_off], axis=1
         )
-        processed_las_off: npt.NDArray[np.float64] = np.nanmean(processed_las_off_profiles, axis=0)
-    
+        las_off: npt.NDArray[np.float64] = np.nanmean(las_off_profiles, axis=0)
+        processed_las_off_profiles: npt.NDArray[np.float64] = (
+            self._process_xss_water_signal(
+                las_off_profiles,
+                medfilt_size,
+                water_qs,
+                water_ratio,
+                water_signal_sigma,
+            )
+        )
+        processed_las_off: npt.NDArray[np.float64] = np.nanmean(
+            processed_las_off_profiles, axis=0
+        )
+
         for i, code in enumerate(self._xss_event_codes):
             filter_code: npt.NDArray[np.bool_] = self._aggregate_filters(
                 filter_vars=f"xray on, code {code}, ipm, total scattering"
@@ -716,7 +726,9 @@ class AnalyzeSmallData(Task):
 
             profiles = np.nanmean(self._norm_az_int[filter_code], axis=1)
             tjump = np.nanmean(profiles, axis=0) - las_off
-            processed_profiles = self._process_xss_water_signal(profiles, medfilt_size, water_qs, water_ratio, water_signal_sigma)
+            processed_profiles = self._process_xss_water_signal(
+                profiles, medfilt_size, water_qs, water_ratio, water_signal_sigma
+            )
             processed_tjump = np.nanmean(processed_profiles, axis=0) - processed_las_off
             tjumps[i, :] = tjump
             processed_tjumps[i, :] = processed_tjump
@@ -1120,9 +1132,15 @@ class AnalyzeSmallData(Task):
         )
 
         bins: npt.NDArray[np.float64] = self._calc_scan_bins()
-        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        xss_las_on: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_on, axis=(0, 1))       # [q_bins]
-        xss_las_off: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_off, axis=(0, 1))       # [q_bins]
+        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros(
+            (len(self._q_vals), len(bins))
+        )
+        xss_las_on: npt.NDArray[np.float64] = np.nanmean(
+            normed_xss_las_on, axis=(0, 1)
+        )  # [q_bins]
+        xss_las_off: npt.NDArray[np.float64] = np.nanmean(
+            normed_xss_las_off, axis=(0, 1)
+        )  # [q_bins]
         for idx, scan_bin in enumerate(bins):
             if lxt_fast_scan:
                 if idx == len(bins) - 1:
@@ -1138,7 +1156,9 @@ class AnalyzeSmallData(Task):
                     normed_xss_las_on[mask], axis=(0, 1)
                 )
 
-        diff: npt.NDArray[np.float64] = np.nan_to_num(binned_xss_las_on) - np.nan_to_num(xss_las_off[:, np.newaxis])
+        diff: npt.NDArray[np.float64] = np.nan_to_num(
+            binned_xss_las_on
+        ) - np.nan_to_num(xss_las_off[:, np.newaxis])
 
         return bins, diff, xss_las_on, xss_las_off
 
@@ -1354,39 +1374,58 @@ class AnalyzeSmallData(Task):
 
             diff (npt.NDArray[np.float64]): 2D binned difference scattering of shape
                 (q_bins, scan_bins)
-            
+
             scan_var_name (str): Name of the scan variable.
 
         Returns:
             plot (pn.GridSpec): Plotted azimuthally integrated difference by scan variable.
         """
         scan_grid = pn.GridSpec(
-            sizing_mode="stretch_both", max_width=1000, max_height=1200,
+            sizing_mode="stretch_both",
+            max_width=1000,
+            max_height=1200,
         )
-        
+
         # Top left - 2D cake laser off
         filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        cake_off: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_off], axis=0)
+        cake_off: npt.NDArray[np.float64] = np.nanmean(
+            self._norm_az_int[filter_las_off], axis=0
+        )
         phi_dim = hv.Dimension(("phi", "Phi (deg)"))
         q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
-        cake_off_img = hv.Image((self._phi_vals, self._q_vals, cake_off.T), kdims=[phi_dim, q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
-            cmap="viridis", colorbar=True, title="2D Az Int - dS laser off", shared_axes=False
+        cake_off_img = hv.Image(
+            (self._phi_vals, self._q_vals, cake_off.T),
+            kdims=[phi_dim, q_dim],
+            vdims=hv.Dimension(("intensity", "Intensity (a.u.)")),
+        ).opts(
+            cmap="viridis",
+            colorbar=True,
+            title="2D Az Int - dS laser off",
+            shared_axes=False,
         )
         scan_grid[0, 0] = cake_off_img
 
         # Top right - 1D phi - average laser off
         azav_avg = np.nanmean(cake_off, axis=0)
         q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
-        azav_plot = hv.Curve((self._q_vals, azav_avg), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
-            title="1D Az Int - phi-slices laser off normalized", color="dodgerblue", line_width=3
+        azav_plot = hv.Curve(
+            (self._q_vals, azav_avg),
+            kdims=[q_dim],
+            vdims=hv.Dimension(("intensity", "Intensity (a.u.)")),
+        ).opts(
+            title="1D Az Int - phi-slices laser off normalized",
+            color="dodgerblue",
+            line_width=3,
         )
         for i in range(cake_off.shape[0]):
             phi_slice = cake_off[i, :]
-            phi_slice_plot = hv.Curve((self._q_vals, phi_slice), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
-                color="gray", alpha=0.5, line_dash="dashed", line_width=0.8
-            )
+            phi_slice_plot = hv.Curve(
+                (self._q_vals, phi_slice),
+                kdims=[q_dim],
+                vdims=hv.Dimension(("intensity", "Intensity (a.u.)")),
+            ).opts(color="gray", alpha=0.5, line_dash="dashed", line_width=0.8)
             azav_plot *= phi_slice_plot
         scan_grid[0, 1] = azav_plot.opts(shared_axes=False)
 
@@ -1394,9 +1433,18 @@ class AnalyzeSmallData(Task):
         filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser on, ipm, total scattering"
         )
-        cake_on: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_on], axis=0)
-        cake_on_img = hv.Image((self._phi_vals, self._q_vals, cake_on.T), kdims=[phi_dim, q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
-            cmap="viridis", colorbar=True, title="2D Az Int - laser on", shared_axes=False
+        cake_on: npt.NDArray[np.float64] = np.nanmean(
+            self._norm_az_int[filter_las_on], axis=0
+        )
+        cake_on_img = hv.Image(
+            (self._phi_vals, self._q_vals, cake_on.T),
+            kdims=[phi_dim, q_dim],
+            vdims=hv.Dimension(("intensity", "Intensity (a.u.)")),
+        ).opts(
+            cmap="viridis",
+            colorbar=True,
+            title="2D Az Int - laser on",
+            shared_axes=False,
         )
         scan_grid[1, 0] = cake_on_img
 
@@ -1411,9 +1459,11 @@ class AnalyzeSmallData(Task):
         subsample_plots = []
         for i, pct in enumerate(percentages):
             idx = sorted_indices[int(np.ceil(pct * n_events)) - 1]
-            laser_on_subsample_plot = hv.Curve((self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0)), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
-                color=colors[i], title="1D Az Int - laser on", shared_axes=False
-            )
+            laser_on_subsample_plot = hv.Curve(
+                (self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0)),
+                kdims=[q_dim],
+                vdims=hv.Dimension(("intensity", "Intensity (a.u.)")),
+            ).opts(color=colors[i], title="1D Az Int - laser on", shared_axes=False)
             subsample_plots.append(laser_on_subsample_plot)
         if subsample_plots:
             scan_grid[1, 1] = hv.Overlay(subsample_plots).opts(shared_axes=False)
@@ -1421,9 +1471,9 @@ class AnalyzeSmallData(Task):
         # Bottom left - 2D difference
         xs_dim = hv.Dimension(("scan_bin", scan_var_name))
         diff_dim = hv.Dimension(("diff", "dS"))
-        diff_img = hv.Image((bins, self._q_vals, diff), kdims=[xs_dim, q_dim], vdims=diff_dim).opts(
-            cmap="viridis", colorbar=True, title="dS", shared_axes=False
-        )
+        diff_img = hv.Image(
+            (bins, self._q_vals, diff), kdims=[xs_dim, q_dim], vdims=diff_dim
+        ).opts(cmap="viridis", colorbar=True, title="dS", shared_axes=False)
         scan_grid[2, 0] = diff_img
 
         # Bottom right - difference slices
@@ -1431,12 +1481,16 @@ class AnalyzeSmallData(Task):
         every_nth = (np.arange(len(bins)) % nth) == 0
         diff_slices = diff[:, every_nth]
         spacing = np.nanmax(np.abs(diff_slices))
-        colors = [to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))]
+        colors = [
+            to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
+        ]
         diff_slice_plots = []
         for i in range(diff_slices.shape[1]):
-            diff_slice_plot = hv.Curve((self._q_vals, diff_slices[:, i] + i*spacing), kdims=[q_dim], vdims=hv.Dimension(("diff", "dS"))).opts(
-                color=colors[i], title="dS slices"
-            )
+            diff_slice_plot = hv.Curve(
+                (self._q_vals, diff_slices[:, i] + i * spacing),
+                kdims=[q_dim],
+                vdims=hv.Dimension(("diff", "dS")),
+            ).opts(color=colors[i], title="dS slices")
             diff_slice_plots.append(diff_slice_plot)
         scan_grid[2, 1] = hv.Overlay(diff_slice_plots).opts(shared_axes=False)
 
@@ -1459,7 +1513,9 @@ class AnalyzeSmallData(Task):
         """
 
         tjump_grid = pn.GridSpec(
-            sizing_mode="stretch_both", max_width=1000, max_height=800,
+            sizing_mode="stretch_both",
+            max_width=1000,
+            max_height=800,
         )
 
         if len(self._xss_event_codes) > 0:
@@ -1470,41 +1526,86 @@ class AnalyzeSmallData(Task):
             processed_tjump_curves = []
             q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
 
-            colors = [to_hex(c) for c in plt.cm.coolwarm_r(np.linspace(0, 1, len(self._xss_event_codes)))]
+            colors = [
+                to_hex(c)
+                for c in plt.cm.coolwarm_r(
+                    np.linspace(0, 1, len(self._xss_event_codes))
+                )
+            ]
             for i, code in enumerate(self._xss_event_codes):
                 if np.all(tjumps[i] == 0):
                     continue
                 valid_codes.append(code)
                 valid_tjumps.append(tjumps[i])
-                tjump_plot = hv.Curve((self._q_vals, tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
-                    color=colors[i], title=f"dS to laser off"
-                )
+                tjump_plot = hv.Curve(
+                    (self._q_vals, tjumps[i]),
+                    kdims=[q_dim],
+                    vdims=hv.Dimension(("diff", f"dS code")),
+                    label=f"{code}",
+                ).opts(color=colors[i], title=f"dS to laser off")
                 tjump_curves.append(tjump_plot)
                 valid_processed_tjumps.append(processed_tjumps[i])
-                processed_tjump_plot = hv.Curve((self._q_vals, processed_tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
-                    color=colors[i], title=f"Processed dS to laser off"
-                )
+                processed_tjump_plot = hv.Curve(
+                    (self._q_vals, processed_tjumps[i]),
+                    kdims=[q_dim],
+                    vdims=hv.Dimension(("diff", f"dS code")),
+                    label=f"{code}",
+                ).opts(color=colors[i], title=f"Processed dS to laser off")
                 processed_tjump_curves.append(processed_tjump_plot)
 
             if tjump_curves:
-                tjump_grid[0, 0] = hv.Overlay(tjump_curves).opts(
-                    hv.opts.NdOverlay(legend_position="top_right", fontsize={"legend": 6})
-                ).opts(shared_axes=False)
+                tjump_grid[0, 0] = (
+                    hv.Overlay(tjump_curves)
+                    .opts(
+                        hv.opts.NdOverlay(
+                            legend_position="top_right", fontsize={"legend": 6}
+                        )
+                    )
+                    .opts(shared_axes=False)
+                )
             if processed_tjump_curves:
-                tjump_grid[1, 0] = hv.Overlay(processed_tjump_curves).opts(
-                    hv.opts.NdOverlay(legend_position="top_right", fontsize={"legend": 6})
-                ).opts(shared_axes=False)
+                tjump_grid[1, 0] = (
+                    hv.Overlay(processed_tjump_curves)
+                    .opts(
+                        hv.opts.NdOverlay(
+                            legend_position="top_right", fontsize={"legend": 6}
+                        )
+                    )
+                    .opts(shared_axes=False)
+                )
 
             labels = [f"{code}" for code in valid_codes]
-            tjump_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_tjumps[i]))]
-            tjump_img = hv.HeatMap(tjump_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
-                cmap='coolwarm_r', colorbar=True, title=f"dS cross-talk to laser off", shared_axes=False
+            tjump_heatmap_data = [
+                (q, code, v)
+                for i, code in enumerate(labels)
+                for _, (q, v) in enumerate(zip(self._q_vals, valid_tjumps[i]))
+            ]
+            tjump_img = hv.HeatMap(
+                tjump_heatmap_data,
+                kdims=[q_dim, hv.Dimension(("code", "Event code"))],
+                vdims=hv.Dimension(("diff", f"dS cross-talk to laser off")),
+            ).opts(
+                cmap="coolwarm_r",
+                colorbar=True,
+                title=f"dS cross-talk to laser off",
+                shared_axes=False,
             )
             tjump_grid[0, 1] = tjump_img
 
-            processed_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_processed_tjumps[i]))]
-            processed_tjump_img = hv.HeatMap(processed_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
-                cmap='coolwarm_r', colorbar=True, title=f"Processed dS cross-talk to laser off", shared_axes=False
+            processed_heatmap_data = [
+                (q, code, v)
+                for i, code in enumerate(labels)
+                for _, (q, v) in enumerate(zip(self._q_vals, valid_processed_tjumps[i]))
+            ]
+            processed_tjump_img = hv.HeatMap(
+                processed_heatmap_data,
+                kdims=[q_dim, hv.Dimension(("code", "Event code"))],
+                vdims=hv.Dimension(("diff", f"dS cross-talk to laser off")),
+            ).opts(
+                cmap="coolwarm_r",
+                colorbar=True,
+                title=f"Processed dS cross-talk to laser off",
+                shared_axes=False,
             )
             tjump_grid[1, 1] = processed_tjump_img
 
@@ -1531,7 +1632,9 @@ class AnalyzeSmallData(Task):
         Returns:
             pn.GridSpec: Plotted overlap fit.
         """
-        overlap_grid: pn.GridSpec = pn.GridSpec(sizing_mode="stretch_both", max_width=1000, max_height=400)
+        overlap_grid: pn.GridSpec = pn.GridSpec(
+            sizing_mode="stretch_both", max_width=1000, max_height=400
+        )
         raw_curve: npt.NDArray[np.float64]
         msg: str
         if self._scan_var_name is not None and "lxt" in self._scan_var_name:
@@ -1545,8 +1648,26 @@ class AnalyzeSmallData(Task):
                 f"FWHM: {fwhm}"
             )
             logger.info(msg)
-            overlap_grid[0, 0] = hv.Curve((bins, raw_curve), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="blue", title=msg, xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
-            overlap_grid[0, 1] = hv.Curve((bins, trace), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="orange", title="Convolution", xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+            overlap_grid[0, 0] = hv.Curve(
+                (bins, raw_curve),
+                kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))],
+                vdims=hv.Dimension(("diff", "dS")),
+            ).opts(
+                color="blue",
+                title=msg,
+                xlabel=f"Scan Variable ({self._scan_var_name})",
+                ylabel="dS",
+            )
+            overlap_grid[0, 1] = hv.Curve(
+                (bins, trace),
+                kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))],
+                vdims=hv.Dimension(("diff", "dS")),
+            ).opts(
+                color="orange",
+                title="Convolution",
+                xlabel=f"Scan Variable ({self._scan_var_name})",
+                ylabel="dS",
+            )
         else:
             opt: npt.NDArray[np.float64]
             raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
@@ -1556,8 +1677,26 @@ class AnalyzeSmallData(Task):
                 f"FWHM: {sigma_to_fwhm(opt[2])}"
             )
             logger.info(msg)
-            overlap_grid[0, 0] = hv.Curve((bins, raw_curve), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="blue", title=msg, xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
-            overlap_grid[0, 1] = hv.Curve((bins, gaussian(bins, *opt)), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="orange", title="Gaussian Fit", xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+            overlap_grid[0, 0] = hv.Curve(
+                (bins, raw_curve),
+                kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))],
+                vdims=hv.Dimension(("diff", "dS")),
+            ).opts(
+                color="blue",
+                title=msg,
+                xlabel=f"Scan Variable ({self._scan_var_name})",
+                ylabel="dS",
+            )
+            overlap_grid[0, 1] = hv.Curve(
+                (bins, gaussian(bins, *opt)),
+                kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))],
+                vdims=hv.Dimension(("diff", "dS")),
+            ).opts(
+                color="orange",
+                title="Gaussian Fit",
+                xlabel=f"Scan Variable ({self._scan_var_name})",
+                ylabel="dS",
+            )
 
         return overlap_grid
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -435,6 +435,7 @@ class AnalyzeSmallData(Task):
         assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
 
         from scipy.stats import zscore  # type: ignore
+
         medfilt_size: int = (
             self._task_parameters.xss_processing_parameters.median_filter_size
         )
@@ -1480,7 +1481,8 @@ class AnalyzeSmallData(Task):
             diff_slices = diff[:, every_nth]
             spacing = np.nanmax(np.abs(diff_slices))
             colors = [
-                to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
+                to_hex(c)
+                for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
             ]
             diff_slice_plots = []
             for i in range(diff_slices.shape[1]):

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -21,6 +21,7 @@ import numpy as np
 import numpy.typing as npt
 import panel as pn
 import matplotlib.pyplot as plt  # type: ignore
+from matplotlib.colors import to_hex  # type: ignore
 from matplotlib.ticker import MaxNLocator  # type: ignore
 from mpi4py import MPI
 from scipy.signal import find_peaks  # type: ignore
@@ -186,6 +187,7 @@ class AnalyzeSmallData(Task):
                 self._scan_values = np.linspace(
                     self._start_idx, self._stop_idx, self._num_events
                 )
+                self._scan_var_name = "linear"
                 logger.debug(
                     "No scans found, using linearly spaced data for _scan_values."
                 )
@@ -329,6 +331,28 @@ class AnalyzeSmallData(Task):
         # )
         return np.nanmean(self._calc_norm_by_qrange((1.5, 3.5)), axis=-1)
 
+    def _apply_median_filter(self,
+        profiles: npt.NDArray[np.float64],
+        kernel_size: int = 13,
+    ) -> npt.NDArray[np.float64]:
+        """Apply a median filter to a set of profiles.
+
+        Args:
+            profiles (npt.NDArray[np.float64]): The input profiles to filter.
+
+            kernel_size (int): The size of the median filter kernel.
+
+        Returns:
+            filtered_profiles (npt.NDArray[np.float64]): The filtered profiles.
+        """
+        from scipy.signal import medfilt  # type: ignore
+    
+        if kernel_size % 2 == 0:
+            kernel_size += 1
+
+        profiles = medfilt(profiles, (1, kernel_size))
+        return profiles
+
     def _aggregate_filters(
         self, filter_vars: str = ("xray on, laser on, total scattering, ipm")
     ) -> npt.NDArray[np.bool_]:
@@ -395,6 +419,38 @@ class AnalyzeSmallData(Task):
             )
             dark_mean = np.zeros([self._num_events])
         return dark_mean
+    
+    def _process_xss_water_signal(self, 
+        profiles: npt.NDArray[np.float64],
+        medfilt_size: int = 13,
+        qs: Tuple[float, float] = (1.0, 1.93),
+        ratio: float = 1.25,
+        sigma: float = 2.0
+    ) -> npt.NDArray[np.float64]:
+        """Filter outliers and select strong enough water shots.
+
+        Args:
+            profiles (npt.NDArray[np.float64]): The input profiles to filter.
+
+        Returns:
+            processed_profiles (npt.NDArray[np.float64]): The processed water profiles.
+        """
+        from scipy.stats import zscore  # type: ignore
+
+        profiles = self._apply_median_filter(profiles, medfilt_size)
+        low_q, high_q = qs
+        low_q_idx: int = np.argmin(np.abs(self._q_vals - low_q))
+        high_q_idx: int = np.argmin(np.abs(self._q_vals - high_q))
+        high_q_vals = np.abs(profiles[:, high_q_idx])
+        low_q_vals = np.abs(profiles[:, low_q_idx]) * ratio
+        filter = high_q_vals > low_q_vals
+
+        signal_peak = np.abs(zscore(profiles[:, high_q_idx]))
+        filter &= (signal_peak <= sigma)
+        if np.sum(filter) == 0:
+            logger.warning("No good water shots found. Try loosening the criteria. Defaulting to all shots.")
+            filter = np.ones_like(filter, dtype=bool)
+        return profiles[filter]
 
     def _find_solvent_argmax(self, corrected_profile: npt.NDArray) -> int:
         """Find the index of the solvent ring maximum.
@@ -409,7 +465,7 @@ class AnalyzeSmallData(Task):
             peak_idx (int): The index where the solvent maximum is located.
         """
         res: Tuple[npt.NDArray[np.int64], Dict[str, npt.NDArray[np.float64]]] = (
-            find_peaks(corrected_profile, 1)
+            find_peaks(corrected_profile, height=1)
         )
         try:
             peak_indices: npt.NDArray = res[0]
@@ -418,9 +474,14 @@ class AnalyzeSmallData(Task):
             logger.debug("No peaks found")
             return cast(int, np.argmax(corrected_profile))
 
-        peak_idx: int = peak_indices[
-            np.argmax(peak_heights)
-        ]  # peak_indices[0]  # peak_indices[peak_select - 1]
+        try:
+            peak_idx: int = peak_indices[
+                np.argmax(peak_heights)
+            ]  # peak_indices[0]  # peak_indices[peak_select - 1]
+        except ValueError:
+            logger.debug("No valid peaks found")
+            return cast(int, np.argmax(corrected_profile))
+
         self._solvent_peak_idx = peak_idx
         return peak_idx
 
@@ -572,7 +633,7 @@ class AnalyzeSmallData(Task):
         fwhm: float = self._fit_convolution_fwhm(trace, bins)
         return raw_curve, trace, center, fwhm
 
-    # XSS - Extraction and filter by event code
+    # XSS - Extraction and TR difference
     ############################################################################
     def _extract_xss(self, event_codes: Optional[List[int]]) -> None:
         """Extract XSS additional event codes other than laser on/off 
@@ -587,7 +648,8 @@ class AnalyzeSmallData(Task):
         assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
         self._xss_event_codes = []
         if event_codes:
-            for code in event_codes:
+            xss_codes = np.sort(event_codes)
+            for code in xss_codes:
                 try: # psana1
                     self._filter_dict[f"code {code}"] = (
                         self._smd_h5["evr"][f"code_{code}"][self._start_idx : self._stop_idx] == 1
@@ -601,6 +663,58 @@ class AnalyzeSmallData(Task):
                         self._xss_event_codes.append(code)
                     except Exception:
                         logger.error(f"No event code {code} found.")
+        
+    def _calc_tjump_xss(
+        self,
+        medfilt_size: int = 13,
+        water_qs: Tuple[float, float] = (1.0, 1.93),
+        water_ratio: float = 1.25,
+        water_signal_sigma: float = 2.0
+    ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Calculate the temperature jump traces for each event code.
+
+        The temperature jump traces are calculated by summing the normalized azimuthal intensities
+        for each event code and then applying a water signal filter to obtain the processed trace.
+
+        Returns:
+            tjumps (npt.NDArray[np.float64]): A 2D array of shape (event_codes, q_bins)
+                containing the raw and processed temperature jump traces for each event code.
+            
+            processed_tjumps (npt.NDArray[np.float64]): A 2D array of shape (event_codes, q_bins)
+                containing the processed temperature jump traces for each event code.
+        """
+        tjumps = np.zeros((len(self._xss_event_codes), len(self._q_vals)))
+        processed_tjumps = np.zeros((len(self._xss_event_codes), len(self._q_vals)))
+
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+
+        las_off_profiles: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_off], axis=1)
+        las_off: npt.NDArray[np.float64] = np.nanmean(las_off_profiles, axis=0)
+        processed_las_off_profiles: npt.NDArray[np.float64] = self._process_xss_water_signal(
+            las_off_profiles,
+            medfilt_size,
+            water_qs, 
+            water_ratio, 
+            water_signal_sigma,
+        )
+        processed_las_off: npt.NDArray[np.float64] = np.nanmean(processed_las_off_profiles, axis=0)
+    
+        for i, code in enumerate(self._xss_event_codes):
+            filter_code: npt.NDArray[np.bool_] = self._aggregate_filters(
+                filter_vars=f"xray on, code {code}, ipm, total scattering"
+            )
+            if np.sum(filter_code) == 0:
+                continue
+
+            profiles = np.nanmean(self._norm_az_int[filter_code], axis=1)
+            tjump = np.nanmean(profiles, axis=0) - las_off
+            processed_profiles = self._process_xss_water_signal(profiles, medfilt_size, water_qs, water_ratio, water_signal_sigma)
+            processed_tjump = np.nanmean(processed_profiles, axis=0) - processed_las_off
+            tjumps[i, :] = tjump
+            processed_tjumps[i, :] = processed_tjump
+        return tjumps, processed_tjumps
 
     # XAS - Extraction and TR difference
     ############################################################################
@@ -992,7 +1106,8 @@ class AnalyzeSmallData(Task):
         )
 
         bins: npt.NDArray[np.float64] = self._calc_scan_bins()
-        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))    # [q_bins, scan_bins]
+        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
+        xss_las_on: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_on, axis=(0, 1))       # [q_bins]
         xss_las_off: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_off, axis=(0, 1))       # [q_bins]
         for idx, scan_bin in enumerate(bins):
             if lxt_fast_scan:
@@ -1006,7 +1121,8 @@ class AnalyzeSmallData(Task):
                 binned_xss_las_on[:, idx] = np.nanmean(normed_xss_las_on[mask], axis=(0, 1))
 
         diff: npt.NDArray[np.float64] = np.nan_to_num(binned_xss_las_on) - np.nan_to_num(xss_las_off[:, np.newaxis])
-        return bins, diff, normed_xss_las_on, normed_xss_las_off
+
+        return bins, diff, xss_las_on, xss_las_off
 
     def _calc_scan_binned_difference_xas(
         self,
@@ -1167,9 +1283,12 @@ class AnalyzeSmallData(Task):
     # XSS
     def plot_all_xss(
         self,
+        laser_on: npt.NDArray[np.float64],
         bins: npt.NDArray[np.float64],
         diff: npt.NDArray[np.float64],
         scan_var_name: str,
+        tjumps: npt.NDArray[np.float64],
+        processed_tjumps: npt.NDArray[np.float64],
     ) -> plt.Figure:
         """Plot the azimuthally integrated difference scattering.
 
@@ -1181,104 +1300,248 @@ class AnalyzeSmallData(Task):
             
             scan_var_name (str): Name of the scan variable.
 
+            tjumps (npt.NDArray[np.float64]): T-jump traces for each event code.
+
+            processed_tjumps (npt.NDArray[np.float64]): Processed T-jump traces for each event code.
+
         Returns:
             plot (plt.Figure): Plotted azimuthally integrated difference.
         """
-        if len(self._xss_event_codes) > 0:
-            fig, ax = plt.subplots(3, 2, figsize=(9, 9), dpi=200)
-        else:
-            fig, ax = plt.subplots(2, 2, figsize=(9, 6), dpi=200)
-
         exp: str = self._task_parameters.lute_config.experiment
         run: int = self._task_parameters.lute_config.run
-        fig.suptitle(f"{exp} r{run:04d} - XSS Analysis summary")
 
-        # Plot 2D mean azimuthal integration
-        cake: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int, axis=0)
-        phis, qs = np.meshgrid(self._phi_vals, self._q_vals)
-        ax[0, 0].pcolormesh(phis, qs, cake.T, shading="nearest", cmap="viridis", vmin=np.nanpercentile(cake, 5), vmax=np.nanpercentile(cake, 95))
-        ax[0, 0].set_title(f"Run {run} - 2D Az Int")
-        ax[0, 0].set_xlabel("$\phi$ (deg)")
-        ax[0, 0].set_ylabel("Q ($\AA^{-1}$)")
-        ax2 = ax[0, 0].twinx()
-        phi_avgs = np.nanmean(cake, axis=1)
-        ax2.plot(self._phi_vals, phi_avgs, '-o', markerfacecolor='white', markeredgecolor='black', color='black')
-        ax2.set_ylim([0, np.nanmax(phi_avgs)])
-        ax2.set_ylabel("Avg $\phi$-Intensity")
+        scan_grid: pn.GridSpec = self.plot_xss_scan_hv(bins, diff, scan_var_name)
 
-        # Plot subsample of laser on
-        num_bins = self._task_parameters.analysis_parameters.num_intensity_bins
+        tabs = pn.Tabs(
+            ("XSS Scan", scan_grid),
+        )
+
+        overlap_grid = self.plot_xss_overlap_fit_hv(laser_on, bins, diff)
+        tabs.append(("XSS Overlap Fit", overlap_grid))
+
+        tjump_grid: pn.GridSpec = self.plot_xss_tjump_hv(tjumps, processed_tjumps)
+        tabs.append(("XSS T-Jump", tjump_grid))
+        return tabs
+
+    def plot_xss_scan_hv(
+        self,
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
+        scan_var_name: str,
+    ) -> pn.GridSpec:
+        """Plot the azimuthally integrated difference scattering by scan variable.
+
+        Args:
+            bins (npt.NDArray[np.float64]): 1D array of scan bins
+
+            diff (npt.NDArray[np.float64]): 2D binned difference scattering of shape
+                (q_bins, scan_bins)
+            
+            scan_var_name (str): Name of the scan variable.
+
+        Returns:
+            plot (pn.GridSpec): Plotted azimuthally integrated difference by scan variable.
+        """
+        scan_grid = pn.GridSpec(
+            sizing_mode="stretch_both", max_width=1000, max_height=1200,
+        )
+        
+        # Top left - 2D cake laser off
+        filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser off, ipm, total scattering"
+        )
+        cake_off: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_off], axis=0)
+        phi_dim = hv.Dimension(("phi", "Phi (deg)"))
+        q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
+        cake_off_img = hv.Image((self._phi_vals, self._q_vals, cake_off.T), kdims=[phi_dim, q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
+            cmap="viridis", colorbar=True, title="2D Az Int - dS laser off", shared_axes=False
+        )
+        scan_grid[0, 0] = cake_off_img
+
+        # Top right - 1D phi - average laser off
+        azav_avg = np.nanmean(cake_off, axis=0)
+        q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
+        azav_plot = hv.Curve((self._q_vals, azav_avg), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
+            title="1D Az Int - phi-slices laser off normalized", color="dodgerblue", line_width=3
+        )
+        for i in range(cake_off.shape[0]):
+            phi_slice = cake_off[i, :]
+            phi_slice_plot = hv.Curve((self._q_vals, phi_slice), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
+                color="gray", alpha=0.5, line_dash="dashed", line_width=0.8
+            )
+            azav_plot *= phi_slice_plot
+        scan_grid[0, 1] = azav_plot.opts(shared_axes=False)
+
+        # Mid left - 2D cake laser on
         filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser on, ipm, total scattering"
         )
+        cake_on: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int[filter_las_on], axis=0)
+        cake_on_img = hv.Image((self._phi_vals, self._q_vals, cake_on.T), kdims=[phi_dim, q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
+            cmap="viridis", colorbar=True, title="2D Az Int - laser on", shared_axes=False
+        )
+        scan_grid[1, 0] = cake_on_img
+
+        # Mid right - 1D subsample unnormalized laser on shots
+        num_bins = self._task_parameters.analysis_parameters.num_intensity_bins
         az_av_laser_on = self._az_int[filter_las_on]
         total_intensity = np.nansum(az_av_laser_on, axis=(1, 2))
         sorted_indices = np.argsort(total_intensity)
         n_events = az_av_laser_on.shape[0]
         percentages = np.arange(1, num_bins + 1) / num_bins
-        colors = plt.cm.viridis(percentages)
+        colors = [to_hex(c) for c in plt.cm.viridis(percentages)]
+        subsample_plots = []
         for i, pct in enumerate(percentages):
             idx = sorted_indices[int(np.ceil(pct * n_events)) - 1]
-            ax[0, 1].plot(self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0), color=colors[i])
-        ax[0, 1].set_title("$S_{on}$ 1D Az Int")
-        ax[0, 1].set_xlabel("Q ($\AA^{-1}$)")
-        ax[0, 1].set_ylabel("Intensity (a.u.)")
+            laser_on_subsample_plot = hv.Curve((self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0)), kdims=[q_dim], vdims=hv.Dimension(("intensity", "Intensity (a.u.)"))).opts(
+                color=colors[i], title="1D Az Int - laser on", shared_axes=False
+            )
+            subsample_plots.append(laser_on_subsample_plot)
+        if subsample_plots:
+            scan_grid[1, 1] = hv.Overlay(subsample_plots).opts(shared_axes=False)
 
-        # Plot difference Q vs Scan
-        xs, qs = np.meshgrid(bins, self._q_vals)
-        ax[1, 0].pcolormesh(xs, qs, diff, shading="nearest", cmap="viridis")
-        ax[1, 0].xaxis.set_major_locator(MaxNLocator(nbins=4))
-        ax[1, 0].set_title("$\Delta S$")
-        ax[1, 0].set_xlabel(scan_var_name)
-        ax[1, 0].set_ylabel("Q ($\AA^{-1}$)")
+        # Bottom left - 2D difference
+        xs_dim = hv.Dimension(("scan_bin", scan_var_name))
+        diff_dim = hv.Dimension(("diff", "dS"))
+        diff_img = hv.Image((bins, self._q_vals, diff), kdims=[xs_dim, q_dim], vdims=diff_dim).opts(
+            cmap="viridis", colorbar=True, title="dS", shared_axes=False
+        )
+        scan_grid[2, 0] = diff_img
 
-        # Plot difference slices
+        # Bottom right - difference slices
         nth = max(1, len(bins) // 8)
         every_nth = (np.arange(len(bins)) % nth) == 0
         diff_slices = diff[:, every_nth]
         spacing = np.nanmax(np.abs(diff_slices))
-        colors = plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
+        colors = [to_hex(c) for c in plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))]
+        diff_slice_plots = []
         for i in range(diff_slices.shape[1]):
-            ax[1, 1].axhline(i*spacing, color='gray', linestyle='--', linewidth=0.3)
-            ax[1, 1].plot(self._q_vals, diff_slices[:, i] + i*spacing, color=colors[i])
-        ax[1, 1].set_title("$\Delta S$ slices")
-        ax[1, 1].set_xlabel("Q ($\AA^{-1}$)")
-        ax[1, 1].set_yticks([])
+            diff_slice_plot = hv.Curve((self._q_vals, diff_slices[:, i] + i*spacing), kdims=[q_dim], vdims=hv.Dimension(("diff", "dS"))).opts(
+                color=colors[i], title="dS slices"
+            )
+            diff_slice_plots.append(diff_slice_plot)
+        scan_grid[2, 1] = hv.Overlay(diff_slice_plots).opts(shared_axes=False)
+
+        return scan_grid
+
+    def plot_xss_tjump_hv(
+        self,
+        tjumps: npt.NDArray[np.float64],
+        processed_tjumps: npt.NDArray[np.float64],
+    ) -> pn.Tabs:
+        """Plot the temperature jump analysis for XSS.
+
+        Args:
+            tjumps (npt.NDArray[np.float64]): Temperature jump azimuthal averages for each event code.
+
+            processed_tjumps (npt.NDArray[np.float64]): Processed temperature jump azimuthal averages for each event code.
+
+        Returns:
+            plot (pn.GridSpec): Plotted temperature jump analysis.
+        """
+
+        tjump_grid = pn.GridSpec(
+            sizing_mode="stretch_both", max_width=1000, max_height=800,
+        )
 
         if len(self._xss_event_codes) > 0:
-            diff_traces = []
+            valid_tjumps = []
+            valid_processed_tjumps = []
             valid_codes = []
-            filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
-                filter_vars="xray on, laser off, ipm, total scattering"
-            )
-            laser_off = np.nanmean(self._norm_az_int[filter_las_off], axis=(0, 1))
-            colors = plt.cm.jet(np.linspace(0, 1, len(self._xss_event_codes)))
+            tjump_curves = []
+            processed_tjump_curves = []
+            q_dim = hv.Dimension(("q", "Q (Å⁻¹)"))
+
+            colors = [to_hex(c) for c in plt.cm.coolwarm_r(np.linspace(0, 1, len(self._xss_event_codes)))]
             for i, code in enumerate(self._xss_event_codes):
-                filter_code: npt.NDArray[np.bool_] = self._aggregate_filters(
-                    filter_vars=f"xray on, code {code}, ipm, total scattering"
-                )
-                if np.sum(filter_code) == 0:
+                if np.all(tjumps[i] == 0):
                     continue
-                diff_trace = np.nanmean(self._norm_az_int[filter_code], axis=(0, 1)) - laser_off
-                diff_traces.append(diff_trace)
                 valid_codes.append(code)
-                ax[2, 0].plot(self._q_vals, diff_trace, color=colors[i], label=f"{code}")
-            ax[2, 0].set_title(f"$\Delta S$ relative to laser off")
-            ax[2, 0].set_xlabel("Q ($\AA^{-1}$)")
-            ax[2, 0].set_ylabel("Normalized intensity (a.u.)")
-            ax[2, 0].legend(fontsize='small')
+                valid_tjumps.append(tjumps[i])
+                tjump_plot = hv.Curve((self._q_vals, tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
+                    color=colors[i], title=f"dS to laser off"
+                )
+                tjump_curves.append(tjump_plot)
+                valid_processed_tjumps.append(processed_tjumps[i])
+                processed_tjump_plot = hv.Curve((self._q_vals, processed_tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
+                    color=colors[i], title=f"Processed dS to laser off"
+                )
+                processed_tjump_curves.append(processed_tjump_plot)
+
+            if tjump_curves:
+                tjump_grid[0, 0] = hv.Overlay(tjump_curves).opts(
+                    hv.opts.NdOverlay(legend_position="top_right", fontsize={"legend": 6})
+                ).opts(shared_axes=False)
+            if processed_tjump_curves:
+                tjump_grid[1, 0] = hv.Overlay(processed_tjump_curves).opts(
+                    hv.opts.NdOverlay(legend_position="top_right", fontsize={"legend": 6})
+                ).opts(shared_axes=False)
 
             labels = [f"{code}" for code in valid_codes]
-            ax[2, 1].imshow(diff_traces, aspect='auto', cmap='coolwarm_r')
-            ax[2, 1].set_title(f"$\Delta S$ cross-talk relative to laser off")
-            ax[2, 1].set_xlabel("Q ($\AA^{-1}$)")
-            ax[2, 1].set_xticks([])
-            ax[2, 1].set_yticks(ticks=np.arange(len(labels)), labels=labels)
+            tjump_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_tjumps[i]))]
+            tjump_img = hv.HeatMap(tjump_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
+                cmap='coolwarm_r', colorbar=True, title=f"dS cross-talk to laser off", shared_axes=False
+            )
+            tjump_grid[0, 1] = tjump_img
 
-        plt.tight_layout()
-        if self._task_parameters.output_dir:
-            fig.savefig(f"{self._task_parameters.output_dir}/{exp}_r{run:04d}_xss_summary.png")
-        return fig
+            processed_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_processed_tjumps[i]))]
+            processed_tjump_img = hv.HeatMap(processed_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
+                cmap='coolwarm_r', colorbar=True, title=f"Processed dS cross-talk to laser off", shared_axes=False
+            )
+            tjump_grid[1, 1] = processed_tjump_img
+
+        return tjump_grid
+
+    def plot_xss_overlap_fit_hv(
+        self,
+        laser_on: npt.NDArray[np.float64],
+        bins: npt.NDArray[np.float64],
+        diff: npt.NDArray[np.float64],
+    ) -> pn.GridSpec:
+        """Plot the overlap fit to a slice of the binned difference.
+
+        Args:
+            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
+                scattering profile.
+
+            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
+                signal.
+
+            diff (npt.NDArray[np.float64]): 2D difference signal of shape
+                (q_bins, scan_bins).
+
+        Returns:
+            pn.GridSpec: Plotted overlap fit.
+        """
+        overlap_grid: pn.GridSpec = pn.GridSpec(sizing_mode="stretch_both", max_width=1000, max_height=400)
+        raw_curve: npt.NDArray[np.float64]
+        msg: str
+        if self._scan_var_name is not None and "lxt" in self._scan_var_name:
+            trace: npt.NDArray[np.float64]
+            center: int
+            fwhm: float
+            raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
+            msg = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {bins[center]}\n"
+                f"FWHM: {fwhm}"
+            )
+            logger.info(msg)
+            overlap_grid[0, 0] = hv.Curve((bins, raw_curve), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="blue", title=msg, xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+            overlap_grid[0, 1] = hv.Curve((bins, trace), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="orange", title="Convolution", xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+        else:
+            opt: npt.NDArray[np.float64]
+            raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
+            msg = (
+                f"Scan Var: {self._scan_var_name}\n"
+                f"Overlap Position: {opt[1]}\n"
+                f"FWHM: {sigma_to_fwhm(opt[2])}"
+            )
+            logger.info(msg)
+            overlap_grid[0, 0] = hv.Curve((bins, raw_curve), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="blue", title=msg, xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+            overlap_grid[0, 1] = hv.Curve((bins, gaussian(bins, *opt)), kdims=[hv.Dimension((f"{self._scan_var_name}", "Scan Variable"))], vdims=hv.Dimension(("diff", "dS"))).opts(color="orange", title="Gaussian Fit", xlabel=f"Scan Variable ({self._scan_var_name})", ylabel="dS")
+
+        return overlap_grid
 
 
     # XAS

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -374,18 +374,18 @@ class AnalyzeSmallData(Task):
 
         return total_filter
 
-    def _calc_xss_dark_mean(
-        self
-    ) -> npt.NDArray[np.float64]:
+    def _calc_xss_dark_mean(self) -> npt.NDArray[np.float64]:
         """Calculate the dark (X-ray off) mean of a set of XSS 2D profiles.
-    
+
         Returns:
             dark_mean (npt.NDArray[np.float64]): The calculated dark mean.
                 Shape: (phi_bins, q_bins)
         """
         dark_mean: npt.NDArray[np.float64]
         try:
-            dark_mean = np.nanmean(self._az_int[self._filter_dict["xray off"], :, :], axis=0)
+            dark_mean = np.nanmean(
+                self._az_int[self._filter_dict["xray off"], :, :], axis=0
+            )
             dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
             dark_mean /= self._mpi_size
         except KeyError:
@@ -575,10 +575,10 @@ class AnalyzeSmallData(Task):
     # XSS - Extraction and filter by event code
     ############################################################################
     def _extract_xss(self, event_codes: Optional[List[int]]) -> None:
-        """Extract XSS additional event codes other than laser on/off 
+        """Extract XSS additional event codes other than laser on/off
         and setup event code filters.
 
-        Sets up filters for each event code provided in the input list. 
+        Sets up filters for each event code provided in the input list.
         Will search for both psana1 and psana2 formats of event code storage.
 
         Args:
@@ -588,15 +588,21 @@ class AnalyzeSmallData(Task):
         self._xss_event_codes = []
         if event_codes:
             for code in event_codes:
-                try: # psana1
+                try:  # psana1
                     self._filter_dict[f"code {code}"] = (
-                        self._smd_h5["evr"][f"code_{code}"][self._start_idx : self._stop_idx] == 1
+                        self._smd_h5["evr"][f"code_{code}"][
+                            self._start_idx : self._stop_idx
+                        ]
+                        == 1
                     )
                     self._xss_event_codes.append(code)
                 except Exception:
-                    try: # psana2
+                    try:  # psana2
                         self._filter_dict[f"code {code}"] = (
-                            self._smd_h5["timing"]["eventcodes"][self._start_idx : self._stop_idx][:, code] == 1
+                            self._smd_h5["timing"]["eventcodes"][
+                                self._start_idx : self._stop_idx
+                            ][:, code]
+                            == 1
                         )
                         self._xss_event_codes.append(code)
                     except Exception:
@@ -944,9 +950,9 @@ class AnalyzeSmallData(Task):
         self,
     ) -> Tuple[
         npt.NDArray[np.float64],
-        npt.NDArray[np.float64], 
-        npt.NDArray[np.float64], 
-        npt.NDArray[np.float64]
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
     ]:
         """Calculate the binned difference scattering.
 
@@ -972,7 +978,9 @@ class AnalyzeSmallData(Task):
             self._az_int -= dark_mean
         q_limits = self._task_parameters.analysis_parameters.q_norm
         norm: npt.NDArray[np.float64] = self._calc_norm_by_qrange(q_limits)
-        self._norm_az_int = self._az_int / norm[:, :, np.newaxis]                                # [events, phi_bins, q_bins]
+        self._norm_az_int = (
+            self._az_int / norm[:, :, np.newaxis]
+        )  # [events, phi_bins, q_bins]
         del dark_mean
         del norm
 
@@ -982,30 +990,46 @@ class AnalyzeSmallData(Task):
         filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        normed_xss_las_on: npt.NDArray[np.float64] = self._norm_az_int[filter_las_on]            # [events_las_on, phi_bins, q_bins]
-        normed_xss_las_off: npt.NDArray[np.float64] = self._norm_az_int[filter_las_off]          # [events_las_off, phi_bins, q_bins]
+        normed_xss_las_on: npt.NDArray[np.float64] = self._norm_az_int[
+            filter_las_on
+        ]  # [events_las_on, phi_bins, q_bins]
+        normed_xss_las_off: npt.NDArray[np.float64] = self._norm_az_int[
+            filter_las_off
+        ]  # [events_las_off, phi_bins, q_bins]
 
-        scanvals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]              # [events_las_on]
+        scanvals_las_on: npt.NDArray[np.float64] = self._scan_values[
+            filter_las_on
+        ]  # [events_las_on]
 
         lxt_fast_scan: bool = (
             self._scan_var_name is not None and "lxt_fast" in self._scan_var_name
         )
 
         bins: npt.NDArray[np.float64] = self._calc_scan_bins()
-        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))    # [q_bins, scan_bins]
-        xss_las_off: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_off, axis=(0, 1))       # [q_bins]
+        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros(
+            (len(self._q_vals), len(bins))
+        )  # [q_bins, scan_bins]
+        xss_las_off: npt.NDArray[np.float64] = np.nanmean(
+            normed_xss_las_off, axis=(0, 1)
+        )  # [q_bins]
         for idx, scan_bin in enumerate(bins):
             if lxt_fast_scan:
                 if idx == len(bins) - 1:
                     continue
                 mask = (scanvals_las_on >= scan_bin) * (scanvals_las_on < bins[idx + 1])
-                binned_xss_las_on[:, idx] = np.nanmean(normed_xss_las_on[mask], axis=(0, 1))
+                binned_xss_las_on[:, idx] = np.nanmean(
+                    normed_xss_las_on[mask], axis=(0, 1)
+                )
 
             else:
                 mask = scanvals_las_on == scan_bin
-                binned_xss_las_on[:, idx] = np.nanmean(normed_xss_las_on[mask], axis=(0, 1))
+                binned_xss_las_on[:, idx] = np.nanmean(
+                    normed_xss_las_on[mask], axis=(0, 1)
+                )
 
-        diff: npt.NDArray[np.float64] = np.nan_to_num(binned_xss_las_on) - np.nan_to_num(xss_las_off[:, np.newaxis])
+        diff: npt.NDArray[np.float64] = np.nan_to_num(
+            binned_xss_las_on
+        ) - np.nan_to_num(xss_las_off[:, np.newaxis])
         return bins, diff, normed_xss_las_on, normed_xss_las_off
 
     def _calc_scan_binned_difference_xas(
@@ -1178,7 +1202,7 @@ class AnalyzeSmallData(Task):
 
             diff (npt.NDArray[np.float64]): 2D binned difference scattering of shape
                 (q_bins, scan_bins)
-            
+
             scan_var_name (str): Name of the scan variable.
 
         Returns:
@@ -1196,13 +1220,28 @@ class AnalyzeSmallData(Task):
         # Plot 2D mean azimuthal integration
         cake: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int, axis=0)
         phis, qs = np.meshgrid(self._phi_vals, self._q_vals)
-        ax[0, 0].pcolormesh(phis, qs, cake.T, shading="nearest", cmap="viridis", vmin=np.nanpercentile(cake, 5), vmax=np.nanpercentile(cake, 95))
+        ax[0, 0].pcolormesh(
+            phis,
+            qs,
+            cake.T,
+            shading="nearest",
+            cmap="viridis",
+            vmin=np.nanpercentile(cake, 5),
+            vmax=np.nanpercentile(cake, 95),
+        )
         ax[0, 0].set_title(f"Run {run} - 2D Az Int")
         ax[0, 0].set_xlabel("$\phi$ (deg)")
         ax[0, 0].set_ylabel("Q ($\AA^{-1}$)")
         ax2 = ax[0, 0].twinx()
         phi_avgs = np.nanmean(cake, axis=1)
-        ax2.plot(self._phi_vals, phi_avgs, '-o', markerfacecolor='white', markeredgecolor='black', color='black')
+        ax2.plot(
+            self._phi_vals,
+            phi_avgs,
+            "-o",
+            markerfacecolor="white",
+            markeredgecolor="black",
+            color="black",
+        )
         ax2.set_ylim([0, np.nanmax(phi_avgs)])
         ax2.set_ylabel("Avg $\phi$-Intensity")
 
@@ -1219,7 +1258,9 @@ class AnalyzeSmallData(Task):
         colors = plt.cm.viridis(percentages)
         for i, pct in enumerate(percentages):
             idx = sorted_indices[int(np.ceil(pct * n_events)) - 1]
-            ax[0, 1].plot(self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0), color=colors[i])
+            ax[0, 1].plot(
+                self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0), color=colors[i]
+            )
         ax[0, 1].set_title("$S_{on}$ 1D Az Int")
         ax[0, 1].set_xlabel("Q ($\AA^{-1}$)")
         ax[0, 1].set_ylabel("Intensity (a.u.)")
@@ -1239,8 +1280,10 @@ class AnalyzeSmallData(Task):
         spacing = np.nanmax(np.abs(diff_slices))
         colors = plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
         for i in range(diff_slices.shape[1]):
-            ax[1, 1].axhline(i*spacing, color='gray', linestyle='--', linewidth=0.3)
-            ax[1, 1].plot(self._q_vals, diff_slices[:, i] + i*spacing, color=colors[i])
+            ax[1, 1].axhline(i * spacing, color="gray", linestyle="--", linewidth=0.3)
+            ax[1, 1].plot(
+                self._q_vals, diff_slices[:, i] + i * spacing, color=colors[i]
+            )
         ax[1, 1].set_title("$\Delta S$ slices")
         ax[1, 1].set_xlabel("Q ($\AA^{-1}$)")
         ax[1, 1].set_yticks([])
@@ -1259,17 +1302,21 @@ class AnalyzeSmallData(Task):
                 )
                 if np.sum(filter_code) == 0:
                     continue
-                diff_trace = np.nanmean(self._norm_az_int[filter_code], axis=(0, 1)) - laser_off
+                diff_trace = (
+                    np.nanmean(self._norm_az_int[filter_code], axis=(0, 1)) - laser_off
+                )
                 diff_traces.append(diff_trace)
                 valid_codes.append(code)
-                ax[2, 0].plot(self._q_vals, diff_trace, color=colors[i], label=f"{code}")
+                ax[2, 0].plot(
+                    self._q_vals, diff_trace, color=colors[i], label=f"{code}"
+                )
             ax[2, 0].set_title(f"$\Delta S$ relative to laser off")
             ax[2, 0].set_xlabel("Q ($\AA^{-1}$)")
             ax[2, 0].set_ylabel("Normalized intensity (a.u.)")
-            ax[2, 0].legend(fontsize='small')
+            ax[2, 0].legend(fontsize="small")
 
             labels = [f"{code}" for code in valid_codes]
-            ax[2, 1].imshow(diff_traces, aspect='auto', cmap='coolwarm_r')
+            ax[2, 1].imshow(diff_traces, aspect="auto", cmap="coolwarm_r")
             ax[2, 1].set_title(f"$\Delta S$ cross-talk relative to laser off")
             ax[2, 1].set_xlabel("Q ($\AA^{-1}$)")
             ax[2, 1].set_xticks([])
@@ -1277,9 +1324,10 @@ class AnalyzeSmallData(Task):
 
         plt.tight_layout()
         if self._task_parameters.output_dir:
-            fig.savefig(f"{self._task_parameters.output_dir}/{exp}_r{run:04d}_xss_summary.png")
+            fig.savefig(
+                f"{self._task_parameters.output_dir}/{exp}_r{run:04d}_xss_summary.png"
+            )
         return fig
-
 
     # XAS
     def plot_all_xas(

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -439,8 +439,8 @@ class AnalyzeSmallData(Task):
 
         profiles = self._apply_median_filter(profiles, medfilt_size)
         low_q, high_q = qs
-        low_q_idx: int = np.argmin(np.abs(self._q_vals - low_q))
-        high_q_idx: int = np.argmin(np.abs(self._q_vals - high_q))
+        low_q_idx = np.argmin(np.abs(self._q_vals - low_q))
+        high_q_idx = np.argmin(np.abs(self._q_vals - high_q))
         high_q_vals = np.abs(profiles[:, high_q_idx])
         low_q_vals = np.abs(profiles[:, low_q_idx]) * ratio
         filter = high_q_vals > low_q_vals
@@ -1325,9 +1325,6 @@ class AnalyzeSmallData(Task):
         Returns:
             plot (plt.Figure): Plotted azimuthally integrated difference.
         """
-        exp: str = self._task_parameters.lute_config.experiment
-        run: int = self._task_parameters.lute_config.run
-
         scan_grid: pn.GridSpec = self.plot_xss_scan_hv(bins, diff, scan_var_name)
 
         tabs = pn.Tabs(
@@ -1477,12 +1474,12 @@ class AnalyzeSmallData(Task):
                 valid_codes.append(code)
                 valid_tjumps.append(tjumps[i])
                 tjump_plot = hv.Curve((self._q_vals, tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
-                    color=colors[i], title=f"dS to laser off"
+                    color=colors[i], title="dS to laser off"
                 )
                 tjump_curves.append(tjump_plot)
                 valid_processed_tjumps.append(processed_tjumps[i])
                 processed_tjump_plot = hv.Curve((self._q_vals, processed_tjumps[i]), kdims=[q_dim], vdims=hv.Dimension(("diff", f"dS code")), label=f"{code}").opts(
-                    color=colors[i], title=f"Processed dS to laser off"
+                    color=colors[i], title="Processed dS to laser off"
                 )
                 processed_tjump_curves.append(processed_tjump_plot)
 
@@ -1498,13 +1495,13 @@ class AnalyzeSmallData(Task):
             labels = [f"{code}" for code in valid_codes]
             tjump_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_tjumps[i]))]
             tjump_img = hv.HeatMap(tjump_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
-                cmap='coolwarm_r', colorbar=True, title=f"dS cross-talk to laser off", shared_axes=False
+                cmap='coolwarm_r', colorbar=True, title="dS cross-talk to laser off", shared_axes=False
             )
             tjump_grid[0, 1] = tjump_img
 
             processed_heatmap_data = [(q, code, v) for i, code in enumerate(labels) for _, (q, v) in enumerate(zip(self._q_vals, valid_processed_tjumps[i]))]
             processed_tjump_img = hv.HeatMap(processed_heatmap_data, kdims=[q_dim, hv.Dimension(("code", "Event code"))], vdims=hv.Dimension(("diff", f"dS cross-talk to laser off"))).opts(
-                cmap='coolwarm_r', colorbar=True, title=f"Processed dS cross-talk to laser off", shared_axes=False
+                cmap='coolwarm_r', colorbar=True, title="Processed dS cross-talk to laser off", shared_axes=False
             )
             tjump_grid[1, 1] = processed_tjump_img
 

--- a/lute/tasks/_smalldata.py
+++ b/lute/tasks/_smalldata.py
@@ -21,6 +21,7 @@ import numpy as np
 import numpy.typing as npt
 import panel as pn
 import matplotlib.pyplot as plt  # type: ignore
+from matplotlib.ticker import MaxNLocator  # type: ignore
 from mpi4py import MPI
 from scipy.signal import find_peaks  # type: ignore
 from scipy.optimize import curve_fit  # type: ignore
@@ -279,8 +280,8 @@ class AnalyzeSmallData(Task):
             ],
             self._task_parameters,
         )
-        scattering_thresh: float = self._task_parameters.thresholds.min_Iscat
-        ipm_thresh: float = self._task_parameters.thresholds.min_ipm
+        scattering_thresh: float = self._task_parameters.analysis_parameters.min_Iscat
+        ipm_thresh: float = self._task_parameters.analysis_parameters.min_ipm
         self._filter_dict["total scattering"] = (
             self._integrated_intensity > scattering_thresh
         )
@@ -304,7 +305,7 @@ class AnalyzeSmallData(Task):
         """
         norm_range: npt.NDArray[np.bool_] = self._q_vals > q_limits[0]
         norm_range &= self._q_vals < q_limits[1]
-        return np.nanmean(self._az_int[..., norm_range], axis=-1)
+        return np.nanmean(self._az_int[..., norm_range], axis=2)
 
     def _calc_norm_by_max(self) -> npt.NDArray[np.float64]:
         """Calculate a normalization factor by taking the maximum of each profile.
@@ -374,20 +375,17 @@ class AnalyzeSmallData(Task):
         return total_filter
 
     def _calc_xss_dark_mean(
-        self, profiles: npt.NDArray[np.float64]
+        self
     ) -> npt.NDArray[np.float64]:
-        """Calculate the dark (X-ray off) mean of a set of XSS profiles.
-
-        Args:
-            profiles (npt.NDArray[np.float64]): Set of profiles to calculate the
-                dark mean from. Shape: (n_events, q_bins)
+        """Calculate the dark (X-ray off) mean of a set of XSS 2D profiles.
+    
         Returns:
             dark_mean (npt.NDArray[np.float64]): The calculated dark mean.
-                Shape: (q_bins)
+                Shape: (phi_bins, q_bins)
         """
         dark_mean: npt.NDArray[np.float64]
         try:
-            dark_mean = np.nanmean(profiles[self._filter_dict["xray off"]], axis=0)
+            dark_mean = np.nanmean(self._az_int[self._filter_dict["xray off"], :, :], axis=0)
             dark_mean = self._mpi_comm.allreduce(dark_mean, op=MPI.SUM)
             dark_mean /= self._mpi_size
         except KeyError:
@@ -573,6 +571,36 @@ class AnalyzeSmallData(Task):
         center: int = cast(int, trace.argmax())
         fwhm: float = self._fit_convolution_fwhm(trace, bins)
         return raw_curve, trace, center, fwhm
+
+    # XSS - Extraction and filter by event code
+    ############################################################################
+    def _extract_xss(self, event_codes: Optional[List[int]]) -> None:
+        """Extract XSS additional event codes other than laser on/off 
+        and setup event code filters.
+
+        Sets up filters for each event code provided in the input list. 
+        Will search for both psana1 and psana2 formats of event code storage.
+
+        Args:
+            event_codes (Optional[List[int]]): A list of event codes to extract.
+        """
+        assert isinstance(self._task_parameters, AnalyzeSmallDataXSSParameters)
+        self._xss_event_codes = []
+        if event_codes:
+            for code in event_codes:
+                try: # psana1
+                    self._filter_dict[f"code {code}"] = (
+                        self._smd_h5["evr"][f"code_{code}"][self._start_idx : self._stop_idx] == 1
+                    )
+                    self._xss_event_codes.append(code)
+                except Exception:
+                    try: # psana2
+                        self._filter_dict[f"code {code}"] = (
+                            self._smd_h5["timing"]["eventcodes"][self._start_idx : self._stop_idx][:, code] == 1
+                        )
+                        self._xss_event_codes.append(code)
+                    except Exception:
+                        logger.error(f"No event code {code} found.")
 
     # XAS - Extraction and TR difference
     ############################################################################
@@ -915,13 +943,16 @@ class AnalyzeSmallData(Task):
     def _calc_scan_binned_difference_xss(
         self,
     ) -> Tuple[
-        npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64], 
+        npt.NDArray[np.float64], 
+        npt.NDArray[np.float64]
     ]:
         """Calculate the binned difference scattering.
 
         Calculates the 1D difference scattering for each bin of a scan variable.
         Final difference shape is 2D: (q_bins, scan_bins). Also returns bins and
-        the laser on profiles.
+        the laser on/off profiles.
 
         Returns:
             bins (npt.NDArray[np.float64]): 1D array of scan bins used.
@@ -930,56 +961,52 @@ class AnalyzeSmallData(Task):
                 (q_bins, scan_bins)
 
             laser_on (npt.NDArray[np.float64]): 2D laser on scattering profiles
-                of shape (n_events_las_on, q_bins)
+                of shape (n_events_laser_on, q_bins)
+
+            laser_off (npt.NDArray[np.float64]): 2D laser off scattering profiles
+                of shape (n_events_laser_off, q_bins)
         """
-        profiles: npt.NDArray[np.float64] = np.nansum(self._az_int, axis=1)
-        dark_mean: npt.NDArray[np.float64] = self._calc_xss_dark_mean(profiles)
+        dark_mean: npt.NDArray[np.float64] = self._calc_xss_dark_mean()
         if len(np.unique(dark_mean)) > 1:
             # Can be len == 1 if all nan
-            profiles -= dark_mean
-        norm: npt.NDArray[np.float64] = self._calc_norm_by_qrange()
-        profiles = (profiles.T / np.nanmean(norm, axis=-1).T).T
+            self._az_int -= dark_mean
+        q_limits = self._task_parameters.analysis_parameters.q_norm
+        norm: npt.NDArray[np.float64] = self._calc_norm_by_qrange(q_limits)
+        self._norm_az_int = self._az_int / norm[:, :, np.newaxis]                                # [events, phi_bins, q_bins]
         del dark_mean
         del norm
 
-        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser on, ipm, total scattering"
+        )
         filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
-        normed_xss_las_on: npt.NDArray[np.float64] = profiles[filter_las_on]
-        normed_xss_las_off: npt.NDArray[np.float64] = profiles[filter_las_off]
+        normed_xss_las_on: npt.NDArray[np.float64] = self._norm_az_int[filter_las_on]            # [events_las_on, phi_bins, q_bins]
+        normed_xss_las_off: npt.NDArray[np.float64] = self._norm_az_int[filter_las_off]          # [events_las_off, phi_bins, q_bins]
+
+        scanvals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]              # [events_las_on]
+
+        lxt_fast_scan: bool = (
+            self._scan_var_name is not None and "lxt_fast" in self._scan_var_name
+        )
 
         bins: npt.NDArray[np.float64] = self._calc_scan_bins()
-        binned_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        binned_off: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))
-        scanvals_las_on: npt.NDArray[np.float64] = self._scan_values[filter_las_on]
-        scanvals_las_off: npt.NDArray[np.float64] = self._scan_values[filter_las_off]
-
-        idx: int
-        scan_bin: float
+        binned_xss_las_on: npt.NDArray[np.float64] = np.zeros((len(self._q_vals), len(bins)))    # [q_bins, scan_bins]
+        xss_las_off: npt.NDArray[np.float64] = np.nanmean(normed_xss_las_off, axis=(0, 1))       # [q_bins]
         for idx, scan_bin in enumerate(bins):
-            if self._scan_var_name is not None and "lxt_fast" in self._scan_var_name:
+            if lxt_fast_scan:
                 if idx == len(bins) - 1:
                     continue
-                mask_on: npt.NDArray[np.bool_] = (scanvals_las_on >= scan_bin) * (
-                    scanvals_las_on < bins[idx + 1]
-                )
-                mask_off: npt.NDArray[np.bool_] = (scanvals_las_off >= scan_bin) * (
-                    scanvals_las_off < bins[idx + 1]
-                )
-                binned_on[:, idx] = np.nanmean(normed_xss_las_on[mask_on], axis=0)
-                binned_off[:, idx] = np.nanmean(normed_xss_las_off[mask_off], axis=0)
+                mask = (scanvals_las_on >= scan_bin) * (scanvals_las_on < bins[idx + 1])
+                binned_xss_las_on[:, idx] = np.nanmean(normed_xss_las_on[mask], axis=(0, 1))
+
             else:
-                binned_on[:, idx] = np.nanmean(
-                    normed_xss_las_on[(scanvals_las_on == scan_bin)], axis=0
-                )
-                binned_off[:, idx] = np.nanmean(
-                    normed_xss_las_off[(scanvals_las_off == scan_bin)], axis=0
-                )
-        diff: npt.NDArray[np.float64] = np.nan_to_num(binned_on) - np.nan_to_num(
-            binned_off
-        )
-        return bins, diff, normed_xss_las_on
+                mask = scanvals_las_on == scan_bin
+                binned_xss_las_on[:, idx] = np.nanmean(normed_xss_las_on[mask], axis=(0, 1))
+
+        diff: npt.NDArray[np.float64] = np.nan_to_num(binned_xss_las_on) - np.nan_to_num(xss_las_off[:, np.newaxis])
+        return bins, diff, normed_xss_las_on, normed_xss_las_off
 
     def _calc_scan_binned_difference_xas(
         self,
@@ -1001,14 +1028,16 @@ class AnalyzeSmallData(Task):
 
             diff (Optional[npt.NDArray[np.float64]]): 1D difference absorption.
 
-            laser_off (Optional[npt.NDArray[np.float64]]): 1D laser on absorption.
+            laser_on (Optional[npt.NDArray[np.float64]]): 1D laser on absorption.
 
             laser_off (Optional[npt.NDArray[np.float64]]): 1D laser off absorption.
         """
         bins: npt.NDArray[np.float64] = self._calc_scan_bins()
         if len(bins) <= 2:
             return None, None, None, None
-        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser on, ipm, total scattering"
+        )
         filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
@@ -1074,11 +1103,13 @@ class AnalyzeSmallData(Task):
 
             diff (npt.NDArray[np.float64]): 2D difference emission.
 
-            laser_off (npt.NDArray[np.float64]): 2D laser on emission.
+            laser_on (npt.NDArray[np.float64]): 2D laser on emission.
 
             laser_off (npt.NDArray[np.float64]): 2D laser off emission.
         """
-        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters()
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser on, ipm, total scattering"
+        )
         filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
             filter_vars="xray on, laser off, ipm, total scattering"
         )
@@ -1134,166 +1165,121 @@ class AnalyzeSmallData(Task):
     ############################################################################
 
     # XSS
-    def plot_avg_xss(
-        self,
-        laser_on: npt.NDArray[np.float64],
-        q_vals: npt.NDArray[np.float64],
-        phis: npt.NDArray[np.float64],
-    ) -> plt.Figure: ...
-
-    def plot_difference_xss_hv(
-        self,
-        bins: npt.NDArray[np.float64],
-        q_vals: npt.NDArray[np.float64],
-        diff: npt.NDArray[np.float64],
-        scan_var_name: str,
-    ) -> pn.GridSpec:
-        """Plot the binned difference scattering.
-
-        Args:
-            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            q_vals (npt.NDArray[np.float64]): 1D set of Q bins.
-
-            diff (npt.NDArray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-            scan_var_name (str): Name of the scan variable (for titles, etc.).
-
-        Returns:
-            plot (pn.GridSpec): Plotted binned difference.
-        """
-        grid: pn.GridSpec = pn.GridSpec(name="Difference Profiles")
-        xdim: hv.core.dimension.Dimension = hv.Dimension(
-            ("scan_var", f"Scan Var {scan_var_name}")
-        )
-        ydim: hv.core.dimension.Dimension = hv.Dimension(("Q", "Q"))
-        diff_img: hv.Image = hv.Image(
-            (bins, q_vals, diff),
-            kdims=[xdim, ydim],
-        ).opts(shared_axes=False)
-        contours = diff_img + hv.operation.contours(diff_img, levels=5)
-        contours.opts(
-            hv.opts.Contours(cmap="fire", colorbar=True, tools=["hover"], width=325)
-        ).opts(shared_axes=False)
-        grid[:2, :2] = contours
-        xdim = hv.Dimension(("Q", "Q"))
-        ydim = hv.Dimension(("dS", "dS"))
-        diff_curves: hv.Overlay
-        diff_curves = hv.Curve((q_vals, diff[:, 0]))
-        for i, _ in enumerate(bins):
-            if i == 0:
-                continue
-            else:
-                diff_curves *= hv.Curve(
-                    (
-                        q_vals,
-                        diff[:, i],
-                    )
-                ).opts(xlabel=xdim.label, ylabel=ydim.label)
-
-        grid[2:4, :] = diff_curves.opts(shared_axes=False)
-        return grid
-
-    def plot_xss_overlap_fit(
-        self,
-        laser_on: npt.NDArray[np.float64],
-        bins: npt.NDArray[np.float64],
-        diff: npt.NDArray[np.float64],
-    ) -> plt.Figure:
-        """Plot the overlap fit to a slice of the binned difference.
-
-        Args:
-            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
-                scattering profile.
-
-            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (npt.NDArray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-        Returns:
-            plot (plt.Figure): Plotted overlap fit.
-        """
-        fig, ax = plt.subplots(1, 1, figsize=(6, 3), dpi=200)
-        raw_curve: npt.NDArray[np.float64]
-        msg: str
-        if self._scan_var_name is not None and "lxt" in self._scan_var_name:
-            trace: npt.NDArray[np.float64]
-            center: int
-            fwhm: float
-            raw_curve, trace, center, fwhm = self._convolution_fit(laser_on, bins, diff)
-            msg = (
-                f"Scan Var: {self._scan_var_name}\n"
-                f"Overlap Position: {bins[center]}\n"
-                f"FWHM: {fwhm}"
-            )
-            logger.info(msg)
-            ax.plot(bins, raw_curve, label="Raw")
-            ax2 = ax.twinx()
-            ax2.plot(bins, trace, color="orange", label="Convolution")
-            ax.set_title(msg)
-            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
-            ax.set_ylabel(r"$\Delta$S")
-            plt.legend(loc=0, frameon=False)
-        else:
-            opt: npt.NDArray[np.float64]
-            raw_curve, opt, _ = self._fit_overlap(laser_on, bins, diff)
-            msg = (
-                f"Scan Var: {self._scan_var_name}\n"
-                f"Overlap Position: {opt[1]}\n"
-                f"FWHM: {sigma_to_fwhm(opt[2])}"
-            )
-            logger.info(msg)
-            ax.plot(bins, raw_curve)
-            ax.plot(bins, gaussian(bins, *opt))
-            ax.set_title(msg)
-            ax.set_xlabel(f"Scan Variable ({self._scan_var_name})")
-            ax.set_ylabel(r"$\Delta$S")
-        fig.tight_layout()
-        return fig
-
     def plot_all_xss(
         self,
-        laser_on: npt.NDArray[np.float64],
         bins: npt.NDArray[np.float64],
         diff: npt.NDArray[np.float64],
         scan_var_name: str,
-    ) -> pn.Tabs:
-        """Plot all relevant scattering plots.
+    ) -> plt.Figure:
+        """Plot the azimuthally integrated difference scattering.
 
         Args:
-            laser_on (npt.NDArray[np.float64]): 1D corrected average laser on
-                scattering profile.
+            bins (npt.NDArray[np.float64]): 1D array of scan bins
 
-            bins (npt.NDArray[np.float64]): 1D set of bins used for difference
-                signal.
-
-            diff (npt.NDArray[np.float64]): 2D difference signal of shape
-                (q_bins, scan_bins).
-
-            scan_var_name (str): Name of the scan variable (for titles, etc.).
+            diff (npt.NDArray[np.float64]): 2D binned difference scattering of shape
+                (q_bins, scan_bins)
+            
+            scan_var_name (str): Name of the scan variable.
 
         Returns:
-            plot (pn.Tabs): All plots in separated tabs in a pn.Tabs object.
+            plot (plt.Figure): Plotted azimuthally integrated difference.
         """
-        # avg_fig = self.plot_avg_xss()
-        overlap_fig = self.plot_xss_overlap_fit(laser_on, bins, diff)
+        if len(self._xss_event_codes) > 0:
+            fig, ax = plt.subplots(3, 2, figsize=(9, 9), dpi=200)
+        else:
+            fig, ax = plt.subplots(2, 2, figsize=(9, 6), dpi=200)
 
-        # avg_grid = pn.GridSpec(name="TR X-ray Scattering")
-        # avg_grid[:2, :2] = avg_fig
+        exp: str = self._task_parameters.lute_config.experiment
+        run: int = self._task_parameters.lute_config.run
+        fig.suptitle(f"{exp} r{run:04d} - XSS Analysis summary")
 
-        diff_grid = self.plot_difference_xss_hv(bins, self._q_vals, diff, scan_var_name)
-        overlap_grid = pn.GridSpec(name="Overlap Fit")
-        overlap_grid[:2, :2] = overlap_fig
+        # Plot 2D mean azimuthal integration
+        cake: npt.NDArray[np.float64] = np.nanmean(self._norm_az_int, axis=0)
+        phis, qs = np.meshgrid(self._phi_vals, self._q_vals)
+        ax[0, 0].pcolormesh(phis, qs, cake.T, shading="nearest", cmap="viridis", vmin=np.nanpercentile(cake, 5), vmax=np.nanpercentile(cake, 95))
+        ax[0, 0].set_title(f"Run {run} - 2D Az Int")
+        ax[0, 0].set_xlabel("$\phi$ (deg)")
+        ax[0, 0].set_ylabel("Q ($\AA^{-1}$)")
+        ax2 = ax[0, 0].twinx()
+        phi_avgs = np.nanmean(cake, axis=1)
+        ax2.plot(self._phi_vals, phi_avgs, '-o', markerfacecolor='white', markeredgecolor='black', color='black')
+        ax2.set_ylim([0, np.nanmax(phi_avgs)])
+        ax2.set_ylabel("Avg $\phi$-Intensity")
 
-        tabbed_display = pn.Tabs(diff_grid)
-        tabbed_display.append(overlap_grid)
-        # tabbed_display.append(avg_grid)
+        # Plot subsample of laser on
+        num_bins = self._task_parameters.analysis_parameters.num_intensity_bins
+        filter_las_on: npt.NDArray[np.bool_] = self._aggregate_filters(
+            filter_vars="xray on, laser on, ipm, total scattering"
+        )
+        az_av_laser_on = self._az_int[filter_las_on]
+        total_intensity = np.nansum(az_av_laser_on, axis=(1, 2))
+        sorted_indices = np.argsort(total_intensity)
+        n_events = az_av_laser_on.shape[0]
+        percentages = np.arange(1, num_bins + 1) / num_bins
+        colors = plt.cm.viridis(percentages)
+        for i, pct in enumerate(percentages):
+            idx = sorted_indices[int(np.ceil(pct * n_events)) - 1]
+            ax[0, 1].plot(self._q_vals, np.nanmean(az_av_laser_on[idx], axis=0), color=colors[i])
+        ax[0, 1].set_title("$S_{on}$ 1D Az Int")
+        ax[0, 1].set_xlabel("Q ($\AA^{-1}$)")
+        ax[0, 1].set_ylabel("Intensity (a.u.)")
 
-        return tabbed_display
+        # Plot difference Q vs Scan
+        xs, qs = np.meshgrid(bins, self._q_vals)
+        ax[1, 0].pcolormesh(xs, qs, diff, shading="nearest", cmap="viridis")
+        ax[1, 0].xaxis.set_major_locator(MaxNLocator(nbins=4))
+        ax[1, 0].set_title("$\Delta S$")
+        ax[1, 0].set_xlabel(scan_var_name)
+        ax[1, 0].set_ylabel("Q ($\AA^{-1}$)")
+
+        # Plot difference slices
+        nth = max(1, len(bins) // 8)
+        every_nth = (np.arange(len(bins)) % nth) == 0
+        diff_slices = diff[:, every_nth]
+        spacing = np.nanmax(np.abs(diff_slices))
+        colors = plt.cm.viridis(np.linspace(0, 1, diff_slices.shape[1]))
+        for i in range(diff_slices.shape[1]):
+            ax[1, 1].axhline(i*spacing, color='gray', linestyle='--', linewidth=0.3)
+            ax[1, 1].plot(self._q_vals, diff_slices[:, i] + i*spacing, color=colors[i])
+        ax[1, 1].set_title("$\Delta S$ slices")
+        ax[1, 1].set_xlabel("Q ($\AA^{-1}$)")
+        ax[1, 1].set_yticks([])
+
+        if len(self._xss_event_codes) > 0:
+            diff_traces = []
+            valid_codes = []
+            filter_las_off: npt.NDArray[np.bool_] = self._aggregate_filters(
+                filter_vars="xray on, laser off, ipm, total scattering"
+            )
+            laser_off = np.nanmean(self._norm_az_int[filter_las_off], axis=(0, 1))
+            colors = plt.cm.jet(np.linspace(0, 1, len(self._xss_event_codes)))
+            for i, code in enumerate(self._xss_event_codes):
+                filter_code: npt.NDArray[np.bool_] = self._aggregate_filters(
+                    filter_vars=f"xray on, code {code}, ipm, total scattering"
+                )
+                if np.sum(filter_code) == 0:
+                    continue
+                diff_trace = np.nanmean(self._norm_az_int[filter_code], axis=(0, 1)) - laser_off
+                diff_traces.append(diff_trace)
+                valid_codes.append(code)
+                ax[2, 0].plot(self._q_vals, diff_trace, color=colors[i], label=f"{code}")
+            ax[2, 0].set_title(f"$\Delta S$ relative to laser off")
+            ax[2, 0].set_xlabel("Q ($\AA^{-1}$)")
+            ax[2, 0].set_ylabel("Normalized intensity (a.u.)")
+            ax[2, 0].legend(fontsize='small')
+
+            labels = [f"{code}" for code in valid_codes]
+            ax[2, 1].imshow(diff_traces, aspect='auto', cmap='coolwarm_r')
+            ax[2, 1].set_title(f"$\Delta S$ cross-talk relative to laser off")
+            ax[2, 1].set_xlabel("Q ($\AA^{-1}$)")
+            ax[2, 1].set_xticks([])
+            ax[2, 1].set_yticks(ticks=np.arange(len(labels)), labels=labels)
+
+        plt.tight_layout()
+        if self._task_parameters.output_dir:
+            fig.savefig(f"{self._task_parameters.output_dir}/{exp}_r{run:04d}_xss_summary.png")
+        return fig
+
 
     # XAS
     def plot_all_xas(

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -72,13 +72,15 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         # Currently scattering data is extracted as standard since its used
         # for all analysis types (XSS, XAS, XES,...)
         self._extract_standard_data()
-        self._extract_xss(self._task_parameters.xss_event_codes)
+        self._extract_xss()
 
     def _run(self) -> None:
         diff: Optional[npt.NDArray[np.float64]]
         bins: npt.NDArray[np.float64]
-        laser_on: npt.NDArray[np.float64]
-        laser_off: npt.NDArray[np.float64]
+        laser_on: Optional[npt.NDArray[np.float64]]
+        laser_off: Optional[npt.NDArray[np.float64]]
+        tjumps: Optional[npt.NDArray[np.float64]]
+        processed_tjumps: Optional[npt.NDArray[np.float64]]
         bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xss()
         tjumps, processed_tjumps = self._calc_tjump_xss()
 

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -50,6 +50,13 @@ def laser_off_mean(
 ) -> npt.NDArray[np.float64]:
     return laser_off0.sum(axis=0) + laser_off1.sum(axis=0)
 
+
+def sum_tjump(
+    tjumps0: npt.NDArray[np.float64], tjumps1: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    return tjumps0 + tjumps1
+
+
 class AnalyzeSmallDataXSS(AnalyzeSmallData):
     """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
 
@@ -73,22 +80,34 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         laser_on: npt.NDArray[np.float64]
         laser_off: npt.NDArray[np.float64]
         bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xss()
+        tjumps, processed_tjumps = self._calc_tjump_xss(
+            self._task_parameters.analysis_parameters.median_filter_size,
+            self._task_parameters.analysis_parameters.water_qs,
+            self._task_parameters.analysis_parameters.water_ratio,
+            self._task_parameters.analysis_parameters.water_sigma
+        )
 
         if self._mpi_size > 1:
             diff = self._mpi_comm.reduce(diff, op=sum_diff)
             laser_on = self._mpi_comm.reduce(laser_on, op=laser_on_mean)
             laser_off = self._mpi_comm.reduce(laser_off, op=laser_off_mean)
+            tjumps = self._mpi_comm.reduce(tjumps, op=sum_tjump)
+            processed_tjumps = self._mpi_comm.reduce(processed_tjumps, op=sum_tjump)
         if (
             self._mpi_rank == 0
             and diff is not None
             and laser_on is not None
             and laser_off is not None
+            and tjumps is not None
+            and processed_tjumps is not None
         ):
             diff /= self._mpi_size
-            laser_on /= self._num_events
-            laser_off /= self._num_events
+            laser_on /= self._total_num_events
+            laser_off /= self._total_num_events
+            tjumps /= self._mpi_size
+            processed_tjumps /= self._mpi_size
             name: str = self._scan_var_name if self._scan_var_name else "by_event"
-            plots = self.plot_all_xss(bins, diff, name)
+            plots = self.plot_all_xss(laser_on, bins, diff, name, tjumps, processed_tjumps)
             plot_display_name: str
             run: int
             try:

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -253,7 +253,6 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
         except ValueError:
             run = 0
         plot_display_name: str
-        exp_run: str
         plots: Optional[pn.Tabs]
         if (
             self._mpi_rank == 0

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -80,12 +80,7 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         laser_on: npt.NDArray[np.float64]
         laser_off: npt.NDArray[np.float64]
         bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xss()
-        tjumps, processed_tjumps = self._calc_tjump_xss(
-            self._task_parameters.analysis_parameters.median_filter_size,
-            self._task_parameters.analysis_parameters.water_qs,
-            self._task_parameters.analysis_parameters.water_ratio,
-            self._task_parameters.analysis_parameters.water_sigma,
-        )
+        tjumps, processed_tjumps = self._calc_tjump_xss()
 
         if self._mpi_size > 1:
             diff = self._mpi_comm.reduce(diff, op=sum_diff)
@@ -116,13 +111,10 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
                 run = int(self._task_parameters.lute_config.run)
             except ValueError:
                 run = 0
-
-            if "lens" in name:
-                plot_display_name = f"XSS/{run:04d}/lens_scans/{name}"
-            elif name == "by_event":
-                plot_display_name = f"XSS/{run:04d}/event_scans/by_event"
+            if name == "by_event":
+                plot_display_name = f"XSS/{run:04d}_by_event"
             else:
-                plot_display_name = f"XSS/{run:04d}/time_scans/{name}"
+                plot_display_name = f"XSS/{run:04d}_{name}"
 
             self._result.payload = ElogSummaryPlots(plot_display_name, plots)
 
@@ -201,14 +193,10 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
             plots = self.plot_xas_scan_hv(laser_on, laser_off, scan_bins, diff)
             if plots is not None:
                 name: str = self._scan_var_name if self._scan_var_name else "by_event"
-                if "lens" in name:
-                    plot_display_name = f"XAS/{run:04d}/lens_scans/{name}"
-                elif "lxe_opa" in name:
-                    plot_display_name = f"XAS/{run:04d}/power_scans/{name}"
-                elif name == "by_event":
-                    plot_display_name = f"XAS/{run:04d}/event_scans/by_event"
+                if name == "by_event":
+                    plot_display_name = f"XAS/{run:04d}_by_event"
                 else:
-                    plot_display_name = f"XAS/{run:04d}/time_scans/{name}"
+                    plot_display_name = f"XAS/{run:04d}_{name}"
 
                 all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots
@@ -284,14 +272,10 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
             plots = self.plot_xes_scan_hv(laser_on, laser_off, scan_bins, diff)
             if plots is not None:
                 name: str = self._scan_var_name if self._scan_var_name else "by_event"
-                if "lens" in name:
-                    plot_display_name = f"XES/{run:04d}/lens_scans/{name}"
-                elif "lxe_opa" in name:
-                    plot_display_name = f"XES/{run:04d}/power_scans/{name}"
-                elif "by_event" in name:
-                    plot_display_name = f"XES/{run:04d}/event_scans/{name}"
+                if name == "by_event":
+                    plot_display_name = f"XES/{run:04d}_by_event"
                 else:
-                    plot_display_name = f"XES/{run:04d}/time_scans/{name}"
+                    plot_display_name = f"XES/{run:04d}_{name}"
 
                 all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -168,7 +168,6 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
         except ValueError:
             run = 0
         plot_display_name: str
-        exp_run: str
         plots: Optional[pn.Tabs]
         if (
             self._mpi_rank == 0
@@ -286,7 +285,6 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
             plots = self.plot_xes_scan_hv(laser_on, laser_off, scan_bins, diff)
             if plots is not None:
                 name: str = self._scan_var_name if self._scan_var_name else "by_event"
-                exp_run = f"{run:04d}_{name}_XES"
                 if "lens" in name:
                     plot_display_name = f"XES/{run:04d}/lens_scans/{name}"
                 elif "lxe_opa" in name:

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -50,6 +50,7 @@ def laser_off_mean(
 ) -> npt.NDArray[np.float64]:
     return laser_off0.sum(axis=0) + laser_off1.sum(axis=0)
 
+
 class AnalyzeSmallDataXSS(AnalyzeSmallData):
     """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
 
@@ -95,7 +96,7 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
                 run = int(self._task_parameters.lute_config.run)
             except ValueError:
                 run = 0
-            
+
             if "lens" in name:
                 plot_display_name = f"XSS/{run:04d}/lens_scans/{name}"
             elif name == "by_event":

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -45,6 +45,11 @@ def laser_on_mean(
     return laser_on0.sum(axis=0) + laser_on1.sum(axis=0)
 
 
+def laser_off_mean(
+    laser_off0: npt.NDArray[np.float64], laser_off1: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    return laser_off0.sum(axis=0) + laser_off1.sum(axis=0)
+
 class AnalyzeSmallDataXSS(AnalyzeSmallData):
     """Task to analyze XSS profiles stored in a SmallData HDF5 file."""
 
@@ -60,35 +65,43 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
         # Currently scattering data is extracted as standard since its used
         # for all analysis types (XSS, XAS, XES,...)
         self._extract_standard_data()
+        self._extract_xss(self._task_parameters.xss_event_codes)
 
     def _run(self) -> None:
         diff: Optional[npt.NDArray[np.float64]]
         bins: npt.NDArray[np.float64]
-        laser_on: Optional[npt.NDArray[np.float64]]
-        bins, diff, laser_on = self._calc_scan_binned_difference_xss()
+        laser_on: npt.NDArray[np.float64]
+        laser_off: npt.NDArray[np.float64]
+        bins, diff, laser_on, laser_off = self._calc_scan_binned_difference_xss()
 
         if self._mpi_size > 1:
             diff = self._mpi_comm.reduce(diff, op=sum_diff)
             laser_on = self._mpi_comm.reduce(laser_on, op=laser_on_mean)
-        else:
-            laser_on = np.nansum(laser_on, axis=0)
-
-        if self._mpi_rank == 0 and diff is not None and laser_on is not None:
+            laser_off = self._mpi_comm.reduce(laser_off, op=laser_off_mean)
+        if (
+            self._mpi_rank == 0
+            and diff is not None
+            and laser_on is not None
+            and laser_off is not None
+        ):
             diff /= self._mpi_size
-            laser_on /= self._total_num_events
-            name: str = self._scan_var_name if self._scan_var_name else "By_Event"
-            plots: pn.Tabs = self.plot_all_xss(laser_on, bins, diff, name)
+            laser_on /= self._num_events
+            laser_off /= self._num_events
+            name: str = self._scan_var_name if self._scan_var_name else "by_event"
+            plots = self.plot_all_xss(bins, diff, name)
             plot_display_name: str
             run: int
             try:
                 run = int(self._task_parameters.lute_config.run)
             except ValueError:
                 run = 0
-            exp_run: str = f"{run:04d}_{name}_XSS"
+            
             if "lens" in name:
-                plot_display_name = f"lens_scans/{exp_run}"
+                plot_display_name = f"XSS/{run:04d}/lens_scans/{name}"
+            elif name == "by_event":
+                plot_display_name = f"XSS/{run:04d}/event_scans/by_event"
             else:
-                plot_display_name = f"time_scans/{exp_run}"
+                plot_display_name = f"XSS/{run:04d}/time_scans/{name}"
 
             self._result.payload = ElogSummaryPlots(plot_display_name, plots)
 
@@ -148,8 +161,7 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
             laser_on /= self._mpi_size
             laser_off /= self._mpi_size
             plots = self.plot_all_xas(laser_on, laser_off, ccm_bins, diff)
-            exp_run = f"{run:04d}_XAS"
-            plot_display_name = f"XAS/{exp_run}"
+            plot_display_name = f"XAS/{run:04d}"
             all_plots.append(ElogSummaryPlots(plot_display_name, plots))
 
         scan_bins: Optional[npt.NDArray[np.float64]]
@@ -168,14 +180,15 @@ class AnalyzeSmallDataXAS(AnalyzeSmallData):
         ):
             plots = self.plot_xas_scan_hv(laser_on, laser_off, scan_bins, diff)
             if plots is not None:
-                name: str = self._scan_var_name if self._scan_var_name else "By_Event"
-                exp_run = f"{run:04d}_{name}_XAS"
+                name: str = self._scan_var_name if self._scan_var_name else "by_event"
                 if "lens" in name:
-                    plot_display_name = f"lens_scans/{exp_run}"
+                    plot_display_name = f"XAS/{run:04d}/lens_scans/{name}"
                 elif "lxe_opa" in name:
-                    plot_display_name = f"power_scans/{exp_run}"
+                    plot_display_name = f"XAS/{run:04d}/power_scans/{name}"
+                elif name == "by_event":
+                    plot_display_name = f"XAS/{run:04d}/event_scans/by_event"
                 else:
-                    plot_display_name = f"time_scans/{exp_run}"
+                    plot_display_name = f"XAS/{run:04d}/time_scans/{name}"
 
                 all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots
@@ -233,8 +246,7 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
             laser_off /= self._mpi_size
             energy_bins: Optional[npt.NDArray[np.float64]] = None
             plots = self.plot_xes_hv(laser_on, laser_off, energy_bins, diff)
-            exp_run = f"{run:04d}_XES"
-            plot_display_name = f"XES/{exp_run}"
+            plot_display_name = f"XES/{run:04d}"
             all_plots.append(ElogSummaryPlots(plot_display_name, plots))
 
         scan_bins: npt.NDArray[np.float64]
@@ -252,14 +264,16 @@ class AnalyzeSmallDataXES(AnalyzeSmallData):
         ):
             plots = self.plot_xes_scan_hv(laser_on, laser_off, scan_bins, diff)
             if plots is not None:
-                name: str = self._scan_var_name if self._scan_var_name else "By_Event"
+                name: str = self._scan_var_name if self._scan_var_name else "by_event"
                 exp_run = f"{run:04d}_{name}_XES"
                 if "lens" in name:
-                    plot_display_name = f"lens_scans/{exp_run}"
+                    plot_display_name = f"XES/{run:04d}/lens_scans/{name}"
                 elif "lxe_opa" in name:
-                    plot_display_name = f"power_scans/{exp_run}"
+                    plot_display_name = f"XES/{run:04d}/power_scans/{name}"
+                elif "by_event" in name:
+                    plot_display_name = f"XES/{run:04d}/event_scans/{name}"
                 else:
-                    plot_display_name = f"time_scans/{exp_run}"
+                    plot_display_name = f"XES/{run:04d}/time_scans/{name}"
 
                 all_plots.append(ElogSummaryPlots(plot_display_name, plots))
         self._result.payload = all_plots

--- a/lute/tasks/smalldata.py
+++ b/lute/tasks/smalldata.py
@@ -84,7 +84,7 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
             self._task_parameters.analysis_parameters.median_filter_size,
             self._task_parameters.analysis_parameters.water_qs,
             self._task_parameters.analysis_parameters.water_ratio,
-            self._task_parameters.analysis_parameters.water_sigma
+            self._task_parameters.analysis_parameters.water_sigma,
         )
 
         if self._mpi_size > 1:
@@ -107,7 +107,9 @@ class AnalyzeSmallDataXSS(AnalyzeSmallData):
             tjumps /= self._mpi_size
             processed_tjumps /= self._mpi_size
             name: str = self._scan_var_name if self._scan_var_name else "by_event"
-            plots = self.plot_all_xss(laser_on, bins, diff, name, tjumps, processed_tjumps)
+            plots = self.plot_all_xss(
+                laser_on, bins, diff, name, tjumps, processed_tjumps
+            )
             plot_display_name: str
             run: int
             try:

--- a/tests/functional/smd2_multi_node/config.yaml
+++ b/tests/functional/smd2_multi_node/config.yaml
@@ -83,7 +83,7 @@ AnalyzeSmallDataXSS:
     - "lens_h"
     - "lens_g"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
 ...


### PR DESCRIPTION
# Description 

This PR aims to centralize all the XSS analysis in one single task as well as fixing some XSS calculations. This PR adds the analysis scripts of both ReduceScatt (difference signal between laser on and off for scan runs) and TJump (temperature jump between laser on and off for different event codes). This PR in the meantime is fixing the calculation of the difference signal of scan runs to match the ouput of ReduceScatt. 

## Checklist 

- [x] Fix `_calc_scan_binned_difference_xss` following ReduceScatt's cookbook
- [x] Add ReduceScatt laser off and difference signal plots (all in holoviews)
- [x] Add Beamline laser on plots to check sample hitting (all in holoviews)
- [x] Add T-Jump analysis to the task: 
  - [x] `_extract_xss` to add event code filters (psana1 and psana2)
  - [x] `_calc_tjump_xss` to process azimuthal averages
- [x] Add PumpProbe event code contour plots (all in holoviews) 

## PR Type: 

- [x] New Feature/Enhancement 

## Address Issues

AnalyzeSmallDataXSS was underused, beamline scientists preferred to use their own scripts/notebooks (ReduceScatt). Doris aimed to deliver a first scripting attempt with a temporary lute third-party task calling lcls-mlcv/PumpProbe repository. This PR aims to centralize all the XSS analysis in one single task in effort to simplify the analysis done at the beamline.

## Example of analysis

### XSS Scan

For the EXAFS `mfx101344525` beamtime, it was reported that the difference analysis was not showing any signal although `ReduceScatt` was clearly showing some signal. Link to eLog: https://pswww.slac.stanford.edu/lgbk/lgbk/mfx101344525/eLog

Quote for run 82:
"XSS analysis of overlap scan using small data azimuthal integration. Can see clear difference signal but run summary does not show any difference signal."
<img width="2654" height="1346" alt="image" src="https://github.com/user-attachments/assets/eb0c38aa-b273-49a1-b1e8-2d2163a31c67" />
<img width="2540" height="1430" alt="image" src="https://github.com/user-attachments/assets/62d473ef-7165-460a-9371-43520df61533" />

I was able to reproduce the `ReduceScatt` analysis with the proposed new `AnalyzeSmallDataXSS` task:
<img width="1470" height="1316" alt="Screenshot 2026-04-21 at 3 11 12 PM" src="https://github.com/user-attachments/assets/757b969d-0a90-4c9d-bc44-7deaab4c5f2f" />

The overlap fit was also left unchanged:
<img width="1277" height="567" alt="Screenshot 2026-04-22 at 8 56 16 AM" src="https://github.com/user-attachments/assets/c9089431-3a59-4043-a50d-923beb60b4ee" />

### XSS T-Jump

The T-Jump analysis was added to the task allowing more thorough analysis of pump-probe experiments.
If a list of event codes is provided under the yaml key `xss_event_codes`, this will launch this analysis. If no event codes provided, the XSS T-Jump will remain blank.

For the Follmer `mfx101262725`, Doris set up the `PumpProbe` third-party task to show this analysis to the eLog:
<img width="1051" height="384" alt="Screenshot 2026-04-21 at 11 37 19 AM" src="https://github.com/user-attachments/assets/c7977e32-d62e-4592-89b3-79ffdb3f58c5" />
<img width="1051" height="384" alt="Screenshot 2026-04-21 at 11 37 24 AM" src="https://github.com/user-attachments/assets/22d8d8dc-2c10-498e-aaee-52499889802b" />


I was able to reproduce the `PumpProbe` analysis with the proposed new `AnalyzeSmallDataXSS` task:
<img width="1523" height="1080" alt="Screenshot 2026-04-21 at 3 17 53 PM" src="https://github.com/user-attachments/assets/7b21a2ec-959b-4368-bd1c-01f8ec05e678" />

# Testing 

## Functional 

```bash
>./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok
Sourced latest psconda.sh
python -B /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/run_functional.py --no_clone --run_dir /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok
Running python -B /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/run_functional.py --no_clone --run_dir /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok with --partition=milano --account=lcls:prjlute22 --ntasks=1
Submitted batch job 27902488
```
```bash
>tail -f slurm-27902488.out 

Time Tester spent: 
- Pending: 24 s
- Running: 13 s
[2026-05-15 15:05:30.794] [HTTP:Server] [info] Shutting down server...
[2026-05-15 15:05:30.794] [HTTP:Server] [info] All server threads exited.
[2026-05-15 15:05:30.795] [LWM:Manager] [info] Exiting after workflow completed successfully.
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Maestro workflow exited: COMPLETED
INFO:Launch_Func_Tests:Test workflow basic_rest completed successfully.
INFO:Launch_Func_Tests:Test workflow basic_rest completed successfully.
INFO:Launch_Func_Tests:Ran 9 tests. 6 were successful.
INFO:Launch_Func_Tests:Ran 9 tests. 6 were successful.
```

This is best I can do so far:
- `BinaryErrTester` is failing but it is expected (?).
- Both `SmallDataProducer` are failing because of `psplot` not being found
  - LCLS2 environment is leaking into current environment which makes the `psana1` task fails 
- One of the `CrystFELIndexer` is failing because cannot 
```Refusing to overwrite stream '/sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute_output/mfx101343025_r0170_test.stream'!
Failed to open stream '/sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute_output/mfx101343025_r0170_test.stream'
)
```

## Unit

```bash
>pytest unit
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 36 items                                                                                                                                                                                                   

unit/test_db_common.py .....                                                                                                                                                                                   [ 13%]
unit/test_db_v1.py .                                                                                                                                                                                           [ 16%]
unit/test_db_v2.py .                                                                                                                                                                                           [ 19%]
unit/test_env_bootstrap_mpi.py .......                                                                                                                                                                         [ 38%]
unit/test_executor.py ......                                                                                                                                                                                   [ 55%]
unit/test_ipc.py ..                                                                                                                                                                                            [ 61%]
unit/test_ipc_bidirectional.py .                                                                                                                                                                               [ 63%]
unit/test_launch_utils.py ....                                                                                                                                                                                 [ 75%]
unit/test_parsing.py ......                                                                                                                                                                                    [ 91%]
unit/test_task.py ...                                                                                                                                                                                          [100%]

================================================================================================= 36 passed in 1.88s =================================================================================================
```

```bash
>test_http 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
```

```bash
test_server
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-04-22 09:14:19.679] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-04-22 09:14:19.679] [HTTP:Server] [info] Shutting down server...
[2026-04-22 09:14:19.679] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-04-22 09:14:19.679] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-04-22 09:14:19.780] [HTTP:Server] [info] Shutting down server...
[2026-04-22 09:14:19.780] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-04-22 09:14:19.780] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-04-22 09:14:19.881] [HTTP:Server] [info] Shutting down server...
[2026-04-22 09:14:19.881] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (202 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (202 ms total)
[  PASSED  ] 3 tests.
```