### PR TITLE
ENH Faster LUTE setup through setup_lute script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -135,9 +135,9 @@ if [[ $SOURCE_PYENV ]]; then
     print_banner "${LINES[@]}"
     source "${SOURCE_PYENV}"
 elif [[ $HOSTNAME =~ "sdf" ]]; then
-    LINES=("Sourcing the Psana1 environment (for Python3)")
+    LINES=("Sourcing the Psana2 environment (for Python3)")
     print_banner "${LINES[@]}"
-    source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
+    source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh
 fi
 
 # We will append Python Version info to the build directories for side-by-side builds

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -17,6 +17,25 @@ from krtc import KerberosTicket  # type: ignore
 logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger(__name__)
 
+DEFAULT_CONFIG = {
+    "SmallDataProducer": {
+        "nodes": 4,
+        "ntasks_per_node": 50,
+    },
+    "SmallDataProducer2": {
+        "nodes": 4,
+        "ntasks_per_node": 50,
+    },
+    "BayFAIOptimizer": {
+        "nodes": 1,
+        "ntasks_per_node": 120,
+    },
+    "BayFAIOptimizer2": {
+        "nodes": 1,
+        "ntasks_per_node": 120,
+    },
+}
+
 
 def _run_subprocess_log(cmd: List[str], env: Optional[Dict[str, str]] = None) -> None:
     """Run a subprocess with logging."""
@@ -105,7 +124,8 @@ def run_build_script(lute_path: str) -> None:
 
     cwd: str = os.getcwd()
     os.chdir(lute_path)
-    cmd: List[str] = ["./build.sh"]
+    cmd: List[str] = ["./build.sh", "-e"]
+    logger.info(f"Building LUTE at {lute_path}. This may take a few minutes...")
     _run_subprocess_log(cmd)
     os.chdir(cwd)
 
@@ -132,7 +152,7 @@ def pip_install(src_dir: str, install_dir: Optional[str] = None) -> None:
         src_dir,
         f'--prefix="{install_dir}"',
     ]
-    logging.info(f"Attempting to install from: {src_dir} to: {install_dir}")
+    logger.info(f"Attempting to install from: {src_dir} to: {install_dir}")
     env: Dict[str, str] = os.environ.copy()
     env["PATH"] = (
         f"/sdf/group/lcls/ds/ana/sw/conda1/inst/envs/ana-4.0.63-py3/bin:{env['PATH']}"
@@ -167,6 +187,64 @@ def modify_permissions(lute_path: str):
         for f in files:
             os.chmod(os.path.join(root, f), 0o765)
 
+def update_dag_params(dag_path: str, partition: str, account: str, nodes: int, ntasks_per_node: int) -> None:
+    """Update slurm_params in a DAG file in place.
+
+    For tasks listed in DEFAULT_CONFIG, use the task-specific nodes/ntasks_per_node.
+    For all other tasks, use the user-provided values.
+
+    Args:
+        dag_path (str): Path to the DAG file.
+
+        partition (str): SLURM partition.
+
+        account (str): SLURM account.
+
+        nodes (int): Number of nodes (used for tasks not in DEFAULT_CONFIG).
+
+        ntasks_per_node (int): Tasks per node (used for tasks not in DEFAULT_CONFIG).
+    """
+    with open(dag_path, "r") as f:
+        lines: List[str] = f.readlines()
+
+    result: List[str] = []
+    current_task: Optional[str] = None
+
+    for line in lines:
+        stripped = line.lstrip()
+        task_name = None
+        if stripped.startswith("task_name:"):
+            task_name = stripped
+        elif stripped.startswith("- task_name:"):
+            task_name = stripped[2:]  # Strip the "- " prefix
+        if task_name is not None:
+            # Extract task name (handles both quoted and unquoted)
+            task_value = task_name.split(":", 1)[1].strip().strip("\"'")
+            current_task = task_value
+
+        if stripped.startswith("slurm_params:"):
+            indent = line[: len(line) - len(stripped)]
+            if current_task and current_task in DEFAULT_CONFIG:
+                cfg = DEFAULT_CONFIG[current_task]
+                params = (
+                    f"--account={account} --partition={partition} "
+                    f"--ntasks-per-node={cfg['ntasks_per_node']} "
+                    f"--nodes={cfg['nodes']} --exclusive"
+                )
+            else:
+                params = (
+                    f"--account={account} --partition={partition} "
+                    f"--ntasks-per-node={ntasks_per_node} "
+                    f"--nodes={nodes}"
+                )
+            result.append(f"{indent}slurm_params: '{params}'\n")
+        else:
+            result.append(line)
+
+    with open(dag_path, "w") as f:
+        f.writelines(result)
+
+    logger.info(f"Updated slurm_params in DAG file: {dag_path}")
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -195,6 +273,7 @@ def main() -> None:
         action="store_true",
     )
     parser.add_argument(
+        "-D",
         "--directory",
         type=str,
         help=(
@@ -221,14 +300,17 @@ def main() -> None:
         "-W",
         "--workflow",
         type=str,
-        help=("Which analysis workflow to run. Defaults to smd_summaries."),
-        default="smd",
+        nargs="+",
+        action="extend",
+        help="Which analysis workflow(s) to run. E.g. -W smd bayfai.",
     )
     args: argparse.Namespace
     extra_args: List[str]  # May have additional SLURM arguments
     args, extra_args = parser.parse_known_args()
 
     hutch: str = args.experiment[:3]
+
+    workflow_names: List[str] = args.workflow if args.workflow else ["smd"]
 
     results_dir: str = f"/sdf/data/lcls/ds/{hutch}/{args.experiment}/results"
     if args.directory != "":
@@ -282,34 +364,24 @@ def main() -> None:
     inplace_sed(config_path, sed_pattern)
 
     database_setup(f"{lute_output_dir}/lute.db")  # Setup permissions on database
-    full_workflow_path: str = f"{lute_output_dir}/{args.workflow}.dag"
-    if not os.path.exists(full_workflow_path):
-        included_wf_defn: str = f"{lute_path}/workflows/common/{args.workflow}.dag"
-        shutil.copy(included_wf_defn, full_workflow_path)
-    os.chmod(full_workflow_path, 0o666)
-
-    param_string: str = f"{launch_executable} -c {config_path} -W {full_workflow_path}"
-
-    if args.debug:
-        param_string = f"{param_string} --debug"
-    if args.test:
-        param_string = f"{param_string} --test"
-
+    
     extra_args_str: str = " ".join(extra_args)
     # Check for partition, account and ntasks. ntasks has defaults by workflow
+    partition: str = "milano"
     if "partition" not in extra_args_str:
         logger.warning(
-            "No queue/partition provided. Defaulting to milano. Any key to continue. "
+            f"No queue/partition provided. Defaulting to {partition}. Any key to continue. "
             "Ctrl-C to exit."
         )
         try:
             _: str = input()
-            extra_args_str = f"{extra_args_str} --partition=milano"
+            extra_args_str = f"{extra_args_str} --partition={partition}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
+
+    account: str = f"lcls:{args.experiment}"
     if "account" not in extra_args_str:
-        account: str = f"lcls:{args.experiment}"
         logger.warning(
             f"No account provided. Defaulting to {account}. Any key to continue. "
             "Ctrl-C to exit."
@@ -320,72 +392,91 @@ def main() -> None:
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
-    if "ntasks" not in extra_args_str:
-        ncores: int = 120
-        # if args.workflow in ("smd_xas", "smd_xss", "test"):
-        #     ncores = 2
-        # elif args.workflow in ("smd_summaries", "smd_xes"):
-        #     ncores = 5
-        # else:
-        #     ncores = 120
+
+    nodes: int = 1
+    if "nodes" not in extra_args_str:
         logger.warning(
-            f"No tasks/cores provided. Defaulting to {ncores}. Any key to continue. "
+            f"No nodes provided. Defaulting to {nodes}. Any key to continue. "
             "Ctrl-C to exit."
         )
         try:
             _ = input()
-            extra_args_str = f"{extra_args_str} --ntasks={ncores}"
+            extra_args_str = f"{extra_args_str} --nodes={nodes}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
 
-    param_string = f"{param_string} {extra_args_str}"
-
-    main_workflow: Dict[str, str]
-    # if args.workflow in ("smd_summaries", "smd_xss", "smd_xes", "smd_xss"):
-    if args.workflow in ("smd_summaries", "smd_xss", "smd_xes", "smd_xss"):
-        main_workflow = {
-            "name": "lute_smd_summaries",
-            "executable": arp_executable,
-            "trigger": "RUN_PARAM_IS_VALUE",
-            "run_param_name": "SmallData",
-            "run_param_value": "done",
-            "location": "S3DF",
-            "parameters": param_string,
-        }
-    elif args.workflow == "bayfai":
-        main_workflow = {
-            "name": "lute_bayfai",
-            "executable": arp_executable,
-            "trigger": "MANUAL",
-            "location": "S3DF",
-            "parameters": param_string,
-        }
-    elif 0:
-        # Replace eventually with workflows which use START_OF_RUN
-        main_workflow = {
-            "name": f"lute_{args.workflow}",
-            "executable": arp_executable,
-            "trigger": "START_OF_RUN",
-            "location": "S3DF",
-            "parameters": param_string,
-        }
-    else:
-        main_workflow = {
-            "name": f"lute_{args.workflow}",
-            "executable": arp_executable,
-            "trigger": "END_OF_RUN",
-            "location": "S3DF",
-            "parameters": param_string,
-        }
+    ntasks_per_node: int = 1
+    if "ntasks-per-node" not in extra_args_str:
+        logger.warning(
+            f"No ntasks-per-node provided. Defaulting to {ntasks_per_node}. Any key to continue. "
+            "Ctrl-C to exit."
+        )
+        try:
+            _ = input()
+            extra_args_str = f"{extra_args_str} --ntasks-per-node={ntasks_per_node}"
+        except KeyboardInterrupt:
+            logger.info("Exiting.")
+            sys.exit(0)
+    
+    if "exclusive" not in extra_args_str:
+        logger.warning(
+            f"No exclusivity provided. Defaulting to no exclusive access. Any key to continue. "
+            "Ctrl-C to exit."
+        )
+        try:
+            _ = input()
+        except KeyboardInterrupt:
+            logger.info("Exiting.")
+            sys.exit(0)
 
     workflows: List[Dict[str, str]] = []
-    workflows.append(main_workflow)
-    # Will want to append additional auxiliary workflows eventually
+    for wf_name in workflow_names:
+        full_workflow_path: str = f"{lute_output_dir}/{wf_name}.dag"
+        if not os.path.exists(full_workflow_path):
+            included_wf_defn: str = f"{lute_path}/workflows/common/{wf_name}.dag"
+            if not os.path.exists(included_wf_defn):
+                logger.error(
+                    f"Workflow definition not found for workflow: {wf_name}. Skipping workflow."
+                )
+                continue
+            shutil.copy(included_wf_defn, full_workflow_path)
+        os.chmod(full_workflow_path, 0o666)
+
+        param_string: str = f"{launch_executable} -c {config_path} -W {full_workflow_path} --partition={partition} --account={account}"
+        if args.debug:
+            param_string = f"{param_string} --debug"
+        if args.test:
+            param_string = f"{param_string} --test"
+
+        # Update the DAG file in place with collected SLURM params
+        update_dag_params(full_workflow_path, partition, account, nodes, ntasks_per_node)
+
+        # Build workflow dict with appropriate trigger
+        if wf_name in ("smd_summaries", "smd_xss", "smd_xes", "smd_xas"):
+            trigger: Dict[str, str] = {
+                "trigger": "RUN_PARAM_IS_VALUE",
+                "run_param_name": "SmallData",
+                "run_param_value": "done",
+            }
+        elif wf_name == "bayfai":
+            trigger = {"trigger": "MANUAL"}
+        elif 0:
+            trigger = {"trigger": "START_OF_RUN"}
+        else:
+            trigger = {"trigger": "END_OF_RUN"}
+
+        workflows.append({
+            "name": f"lute_{wf_name}",
+            "executable": arp_executable,
+            "location": "S3DF",
+            "parameters": param_string,
+            **trigger,
+        })
 
     for workflow in workflows:
         logger.info(
-            f"Creating eLog workflow named {workflow['name']} with parameters: {workflow['parameters']}"
+            f"Creating eLog workflow for {workflow['name']}"
         )
         krbticket: Any = KerberosTicket("HTTP@pswww.slac.stanford.edu")
         krbheaders: dict = krbticket.getAuthHeaders()

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -133,7 +133,7 @@ def run_build_script(lute_path: str) -> None:
         lute_path (str): The path to the LUTE installation to build.
     """
 
-    cmd: List[str] = ["./build.sh", "-e"]
+    cmd: List[str] = ["./build.sh", "-e", "-r"]
     logger.info(f"Building LUTE at {lute_path}. This may take a few minutes...")
     _run_subprocess_log(cmd, cwd=lute_path)
 
@@ -187,13 +187,13 @@ def inplace_sed(in_file: str, pattern: str) -> None:
 
 def modify_permissions(lute_path: str):
     """Recursively set permissions for a LUTE installation."""
-    os.chmod(lute_path, 0o765)
+    os.chmod(lute_path, 0o775)
     for root, dirs, files in os.walk(lute_path):
         for d in dirs:
-            os.chmod(os.path.join(root, d), 0o765)
+            os.chmod(os.path.join(root, d), 0o775)
 
         for f in files:
-            os.chmod(os.path.join(root, f), 0o765)
+            os.chmod(os.path.join(root, f), 0o775)
 
 def update_dag_params(dag_path: str, partition: str, account: str, extra_slurm_params: str) -> None:
     """Update slurm_params in a DAG file in place.

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -459,16 +459,10 @@ def main() -> None:
         update_dag_params(full_workflow_path, partition, account, extra_slurm_params)
 
         # Build workflow dict with appropriate trigger
-        if wf_name in ("smd_summaries", "smd_xss", "smd_xes", "smd_xas"):
-            trigger: Dict[str, str] = {
-                "trigger": "RUN_PARAM_IS_VALUE",
-                "run_param_name": "SmallData",
-                "run_param_value": "done",
-            }
+        if wf_name in ("smd", "smd_summaries", "smd_xss", "smd_xes", "smd_xas"):
+            trigger = {"trigger": "START_OF_RUN"}
         elif wf_name == "bayfai":
             trigger = {"trigger": "MANUAL"}
-        elif 0:
-            trigger = {"trigger": "START_OF_RUN"}
         else:
             trigger = {"trigger": "END_OF_RUN"}
 

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -37,8 +37,21 @@ DEFAULT_CONFIG = {
 }
 
 
-def _run_subprocess_log(cmd: List[str], env: Optional[Dict[str, str]] = None) -> None:
-    """Run a subprocess with logging."""
+def _run_subprocess_log(
+    cmd: List[str],
+    env: Optional[Dict[str, str]] = None,
+    cwd: Optional[str] = None,
+) -> None:
+    """Run a subprocess with logging.
+
+    Args:
+        cmd (List[str]): The command to run.
+
+        env (Optional[Dict[str, str]]): Environment to run the command in.
+
+        cwd (Optional[str]): Working directory to run the command in. If not
+            provided, the current working directory is used.
+    """
     global logger
 
     out: str
@@ -49,6 +62,7 @@ def _run_subprocess_log(cmd: List[str], env: Optional[Dict[str, str]] = None) ->
         stderr=subprocess.PIPE,
         universal_newlines=True,
         env=env,
+        cwd=cwd,
     ).communicate()
     if out:
         logger.info(out)
@@ -104,15 +118,12 @@ def git_clone(repo: str, location: str, tag: str) -> None:
         "git",
         "clone",
         f"https://github.com/{repo}.git",
-        location,
+        location,   
     ]
     _run_subprocess_log(cmd)
 
-    cwd: str = os.getcwd()
-    os.chdir(location)
     cmd = ["git", "checkout", tag]
-    _run_subprocess_log(cmd)
-    os.chdir(cwd)
+    _run_subprocess_log(cmd, cwd=location)
 
 
 def run_build_script(lute_path: str) -> None:
@@ -122,12 +133,9 @@ def run_build_script(lute_path: str) -> None:
         lute_path (str): The path to the LUTE installation to build.
     """
 
-    cwd: str = os.getcwd()
-    os.chdir(lute_path)
     cmd: List[str] = ["./build.sh", "-e"]
     logger.info(f"Building LUTE at {lute_path}. This may take a few minutes...")
-    _run_subprocess_log(cmd)
-    os.chdir(cwd)
+    _run_subprocess_log(cmd, cwd=lute_path)
 
 
 def pip_install(src_dir: str, install_dir: Optional[str] = None) -> None:
@@ -162,7 +170,7 @@ def pip_install(src_dir: str, install_dir: Optional[str] = None) -> None:
         if not os.path.exists(install_dir):
             mkdir_cmd: List[str] = ["mkdir", "-p", install_dir]
             _run_subprocess_log(mkdir_cmd)
-    _run_subprocess_log(cmd, env)
+    _run_subprocess_log(cmd, env=env)
 
 
 def inplace_sed(in_file: str, pattern: str) -> None:
@@ -187,11 +195,11 @@ def modify_permissions(lute_path: str):
         for f in files:
             os.chmod(os.path.join(root, f), 0o765)
 
-def update_dag_params(dag_path: str, partition: str, account: str, nodes: int, ntasks_per_node: int) -> None:
+def update_dag_params(dag_path: str, partition: str, account: str, extra_slurm_params: str) -> None:
     """Update slurm_params in a DAG file in place.
 
     For tasks listed in DEFAULT_CONFIG, use the task-specific nodes/ntasks_per_node.
-    For all other tasks, use the user-provided values.
+    For all other tasks, forward the user-provided SLURM parameters verbatim.
 
     Args:
         dag_path (str): Path to the DAG file.
@@ -200,9 +208,7 @@ def update_dag_params(dag_path: str, partition: str, account: str, nodes: int, n
 
         account (str): SLURM account.
 
-        nodes (int): Number of nodes (used for tasks not in DEFAULT_CONFIG).
-
-        ntasks_per_node (int): Tasks per node (used for tasks not in DEFAULT_CONFIG).
+        extra_slurm_params (str): Additional SLURM parameters, forwarded as-is.
     """
     with open(dag_path, "r") as f:
         lines: List[str] = f.readlines()
@@ -229,13 +235,12 @@ def update_dag_params(dag_path: str, partition: str, account: str, nodes: int, n
                 params = (
                     f"--account={account} --partition={partition} "
                     f"--ntasks-per-node={cfg['ntasks_per_node']} "
-                    f"--nodes={cfg['nodes']} --exclusive"
+                    f"--nodes={cfg['nodes']}"
                 )
             else:
                 params = (
                     f"--account={account} --partition={partition} "
-                    f"--ntasks-per-node={ntasks_per_node} "
-                    f"--nodes={nodes}"
+                    f"{extra_slurm_params}"
                 )
             result.append(f"{indent}slurm_params: '{params}'\n")
         else:
@@ -365,67 +370,68 @@ def main() -> None:
 
     database_setup(f"{lute_output_dir}/lute.db")  # Setup permissions on database
     
-    extra_args_str: str = " ".join(extra_args)
-    # Check for partition, account and ntasks. ntasks has defaults by workflow
+    # Check for partition and account. If not provided, prompt the user to use defaults.
     partition: str = "milano"
-    if "partition" not in extra_args_str:
+    account: str = f"lcls:{args.experiment}"
+    has_partition: bool = False
+    has_account: bool = False
+    extra_slurm_args: List[str] = []
+    for arg in extra_args:
+        if arg.startswith("--partition="):
+            partition = arg.split("=", 1)[1]
+            has_partition = True
+        elif arg.startswith("--account="):
+            account = arg.split("=", 1)[1]
+            has_account = True
+        else:
+            extra_slurm_args.append(arg)
+
+    if not has_partition:
         logger.warning(
-            f"No queue/partition provided. Defaulting to {partition}. Any key to continue. "
-            "Ctrl-C to exit."
+            f"No queue/partition provided. Defaulting to {partition}. Any key to "
+            "continue. Ctrl-C to exit."
         )
         try:
             _: str = input()
-            extra_args_str = f"{extra_args_str} --partition={partition}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
 
-    account: str = f"lcls:{args.experiment}"
-    if "account" not in extra_args_str:
+    if not has_account:
         logger.warning(
             f"No account provided. Defaulting to {account}. Any key to continue. "
             "Ctrl-C to exit."
         )
         try:
             _ = input()
-            extra_args_str = f"{extra_args_str} --account={account}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
 
+    extra_slurm_params: str = " ".join(extra_slurm_args)
+    # Check for at least nodes and ntasks, and if not provided, prompt the user to use defaults.
     nodes: int = 1
-    if "nodes" not in extra_args_str:
+    if "nodes" not in extra_slurm_params:
         logger.warning(
             f"No nodes provided. Defaulting to {nodes}. Any key to continue. "
             "Ctrl-C to exit."
         )
         try:
             _ = input()
-            extra_args_str = f"{extra_args_str} --nodes={nodes}"
+            extra_slurm_params = f"{extra_slurm_params} --nodes={nodes}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
 
-    ntasks_per_node: int = 1
-    if "ntasks-per-node" not in extra_args_str:
+    ntasks: int = 1
+    if "ntasks" not in extra_slurm_params:
         logger.warning(
-            f"No ntasks-per-node provided. Defaulting to {ntasks_per_node}. Any key to continue. "
+            f"No ntasks provided. Defaulting to {ntasks}. Any key to continue. "
             "Ctrl-C to exit."
         )
         try:
             _ = input()
-            extra_args_str = f"{extra_args_str} --ntasks-per-node={ntasks_per_node}"
-        except KeyboardInterrupt:
-            logger.info("Exiting.")
-            sys.exit(0)
-    
-    if "exclusive" not in extra_args_str:
-        logger.warning(
-            f"No exclusivity provided. Defaulting to no exclusive access. Any key to continue. "
-            "Ctrl-C to exit."
-        )
-        try:
-            _ = input()
+            extra_slurm_params = f"{extra_slurm_params} --ntasks={ntasks}"
         except KeyboardInterrupt:
             logger.info("Exiting.")
             sys.exit(0)
@@ -450,7 +456,7 @@ def main() -> None:
             param_string = f"{param_string} --test"
 
         # Update the DAG file in place with collected SLURM params
-        update_dag_params(full_workflow_path, partition, account, nodes, ntasks_per_node)
+        update_dag_params(full_workflow_path, partition, account, extra_slurm_params)
 
         # Build workflow dict with appropriate trigger
         if wf_name in ("smd_summaries", "smd_xss", "smd_xes", "smd_xas"):

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -118,7 +118,7 @@ def git_clone(repo: str, location: str, tag: str) -> None:
         "git",
         "clone",
         f"https://github.com/{repo}.git",
-        location,   
+        location,
     ]
     _run_subprocess_log(cmd)
 

--- a/workflows/common/bayfai.dag
+++ b/workflows/common/bayfai.dag
@@ -1,16 +1,16 @@
 !LUTE_DAG
-!branch_daq2
-daq2:
-  task_name: "SmallDataProducer2"
-  slurm_params: ""
-  next:
-  - task_name: "BayFAIOptimizer2"
+- !branch_daq2
+  daq2:
+    task_name: SmallDataProducer2
     slurm_params: ""
-    next: []
-daq1:
-  task_name: "SmallDataProducer"
-  slurm_params: ""
-  next:
-  - task_name: "BayFAIOptimizer"
+    next:
+    - task_name: BayFAIOptimizer2
+      slurm_params: ""
+      next: []
+  daq1:
+    task_name: SmallDataProducer
     slurm_params: ""
-    next: []
+    next:
+    - task_name: BayFAIOptimizer
+      slurm_params: ""
+      next: []

--- a/workflows/common/smd.dag
+++ b/workflows/common/smd.dag
@@ -1,28 +1,28 @@
 !LUTE_DAG
-!branch_daq2
-daq2:
-  task_name: "SmallDataProducer2"
-  slurm_params: ""
-  next:
-  - task_name: "SmallDataXSSAnalyzer"
+- !branch_daq2
+  daq2:
+    task_name: SmallDataProducer2
     slurm_params: ""
-    next: []
-  - task_name: "SmallDataXASAnalyzer"
+    next:
+    - task_name: "SmallDataXSSAnalyzer"
+      slurm_params: ""
+      next: []
+    - task_name: "SmallDataXASAnalyzer"
+      slurm_params: ""
+      next: []
+    - task_name: "SmallDataXESAnalyzer"
+      slurm_params: ""
+      next: []
+  daq1:
+    task_name: "SmallDataProducer"
     slurm_params: ""
-    next: []
-  - task_name: "SmallDataXESAnalyzer"
-    slurm_params: ""
-    next: []
-daq1:
-  task_name: "SmallDataProducer"
-  slurm_params: ""
-  next:
-  - task_name: "SmallDataXSSAnalyzer"
-    slurm_params: ""
-    next: []
-  - task_name: "SmallDataXASAnalyzer"
-    slurm_params: ""
-    next: []
-  - task_name: "SmallDataXESAnalyzer"
-    slurm_params: ""
-    next: []
+    next:
+    - task_name: "SmallDataXSSAnalyzer"
+      slurm_params: ""
+      next: []
+    - task_name: "SmallDataXASAnalyzer"
+      slurm_params: ""
+      next: []
+    - task_name: "SmallDataXESAnalyzer"
+      slurm_params: ""
+      next: []

--- a/workflows/maestro/src/maestro/launch_maestro.py
+++ b/workflows/maestro/src/maestro/launch_maestro.py
@@ -8,7 +8,7 @@ import os
 import random
 import socket
 import sys
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from lute.execution.launch import (
     get_base_launch_parser,
@@ -73,6 +73,10 @@ def main():
     run_type, is_daq2 = retrieve_run_info(
         experiment, run_num, jid_authorization, args.type
     )
+    branch_conditions: Dict[str, bool] = {
+        "is_daq2": is_daq2 if is_daq2 is not None else True,
+        run_type: True,
+    }
 
     bin_dir: str = os.path.dirname(os.path.realpath(sys.argv[0]))
     lute_location: str = os.path.abspath(f"{bin_dir}/..")
@@ -84,6 +88,7 @@ def main():
         config_file=args.config,
         debug=args.debug,
         default_slurm_params=" ".join(extra_args),
+        branch_conditions=branch_conditions,
     )
 
     num_concurrent_steps: int = get_concurrent_job_steps(wf_defn)


### PR DESCRIPTION
# Description

This PR updates the `lute/utilities/setup_lute.py` script that allows to clone fresh `lute` install, build the package, and push workflows to the eLog. The modifications brought to this script now allows the building of entry points scripts too, as well as settting up more than one workflow on the eLog if needed. This PR also fixes the DAQ branching in `maestro` workflows.

# Checklist

- [x] Pass `is_daq2` correctly to `load_lute_dag`
- [x] Fix branching-parsing indentation issues in `workflows/common` DAGs
- [x] Change argparse in `setup_lute.py` to handle more than one workflow (example: `-W bayfai smd smd_summaries`)
- [x] Update DAG slurm params within the `setup_lute.py` script

# PR Type

- [x] New feature/Enhancement

# Example of use

To setup `lute` for example for `xcs101591326`:
- `kinit` first
- `source psana`
- `source lute/install/bin/activate_installation`
- Then running: `setup_lute -e xcs101591326 -f -D lconreux -W smd bayfai`
  - This will clone the `lute` under `results/xcs101591326/lconreux`
  - Set up config and fully-specified DAG YAMLs
  - Push `smd` and `bayfai` workflows to the eLog

### `cxi101620426` example

```bash
>setup_lute -e cxi101620426 -f -D lconreux -W bayfai smd
INFO:lute_utilities.setup.setup_lute:Cloning into '/sdf/data/lcls/ds/cxi/cxi101620426/results/lconreux/lute'...
Updating files:  61% (212/346)
Updating files:  62% (215/346)
Updating files:  63% (218/346)
Updating files:  64% (222/346)
Updating files:  65% (225/346)
Updating files:  66% (229/346)
Updating files:  67% (232/346)
Updating files:  68% (236/346)
Updating files:  69% (239/346)
Updating files:  70% (243/346)
Updating files:  71% (246/346)
Updating files:  72% (250/346)
Updating files:  73% (253/346)
Updating files:  74% (257/346)
Updating files:  75% (260/346)
Updating files:  76% (263/346)
Updating files:  77% (267/346)
Updating files:  78% (270/346)
Updating files:  79% (274/346)
Updating files:  80% (277/346)
Updating files:  81% (281/346)
Updating files:  82% (284/346)
Updating files:  83% (288/346)
Updating files:  84% (291/346)
Updating files:  85% (295/346)
Updating files:  86% (298/346)
Updating files:  87% (302/346)
Updating files:  88% (305/346)
Updating files:  89% (308/346)
Updating files:  90% (312/346)
Updating files:  91% (315/346)
Updating files:  92% (319/346)
Updating files:  93% (322/346)
Updating files:  94% (326/346)
Updating files:  95% (329/346)
Updating files:  96% (333/346)
Updating files:  97% (336/346)
Updating files:  98% (340/346)
Updating files:  99% (343/346)
Updating files: 100% (346/346)
Updating files: 100% (346/346), done.

INFO:lute_utilities.setup.setup_lute:Your branch is up to date with 'origin/dev'.

INFO:lute_utilities.setup.setup_lute:Already on 'dev'

INFO:lute_utilities.setup.setup_lute:Building LUTE at /sdf/data/lcls/ds/cxi/cxi101620426/results/lconreux/lute. This may take a few minutes...
```

After building entry points:
```bash
WARNING:lute_utilities.setup.setup_lute:No queue/partition provided. Defaulting to milano. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No account provided. Defaulting to lcls:cxi101620426. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No nodes provided. Defaulting to 1. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No ntasks provided. Defaulting to 1. Any key to continue. Ctrl-C to exit.

INFO:lute_utilities.setup.setup_lute:Updated slurm_params in DAG file: /sdf/data/lcls/ds/cxi/cxi101620426/results/lconreux/lute_output/bayfai.dag
INFO:lute_utilities.setup.setup_lute:Updated slurm_params in DAG file: /sdf/data/lcls/ds/cxi/cxi101620426/results/lconreux/lute_output/smd.dag
INFO:lute_utilities.setup.setup_lute:Creating eLog workflow for lute_bayfai
INFO:lute_utilities.setup.setup_lute:Creating eLog workflow for lute_smd
```

Check on eLog:
<img width="2556" height="326" alt="image" src="https://github.com/user-attachments/assets/11bb2f4d-b1a6-4993-af77-0ed7a0041aa8" />

