### PR TITLE
MNT Resolve SMD templating 

### DIFF
--- a/config/cxi.yaml
+++ b/config/cxi.yaml
@@ -45,78 +45,80 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau4M"]
-  #epicsPV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  detSumAlgos:
-    all:
-      - "calib"
-      - "calib_dropped"
-      - "calib_dropped_square"
-      - "calib_thresADU1"
-      - "calib_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
-  #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #    thresADU: None
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    detnames: ["jungfrau4M"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      all:
+        - "calib"
+        - "calib_dropped"
+        - "calib_dropped_square"
+        - "calib_thresADU1"
+        - "calib_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
+    #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #    thresADU: None
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 
 ###########
 # BayFAI

--- a/config/mec.yaml
+++ b/config/mec.yaml
@@ -45,78 +45,80 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: ["Epix10kaQuad0", "Epix10kaQuad1", "Epix10kaQuad2", "Epix10kaQuad3"]
-  #epicsPV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  detSumAlgos:
-    all:
-      - "calib"
-      - "calib_dropped"
-      - "calib_dropped_square"
-      - "calib_thresADU1"
-      - "calib_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
-  #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #    thresADU: None
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    detnames: ["Epix10kaQuad0", "Epix10kaQuad1", "Epix10kaQuad2", "Epix10kaQuad3"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      all:
+        - "calib"
+        - "calib_dropped"
+        - "calib_dropped_square"
+        - "calib_thresADU1"
+        - "calib_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
+    #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #    thresADU: None
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 
 ###########
 # BayFAI

--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -230,7 +230,7 @@ AnalyzeSmallDataXSS:
     - "lens_v"
     - "lens_h"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
 
@@ -251,7 +251,7 @@ AnalyzeSmallDataXAS:
   ccm: "epics/ccm_E"
   ccm_set: "epicsUser/ccm_E_setpoint" # Requested CCM setpoint PV. Makes binning better but not required.
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
   #element: null       # For EXAFS -- currently unused
@@ -270,7 +270,7 @@ AnalyzeSmallDataXES:
     - "lxt"
     - "lxt_fast"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 1000           # Minimum x-ray intensity at selected ipm
   # Optional settings.

--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -129,90 +129,94 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: []
-  #xdetectors: []
-  #epicsPV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  detSumAlgos:
-    all:
-      - "calib"
-      - "calib_dropped"
-      - "calib_dropped_square"
-      - "calib_thresADU1"
-      - "calib_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
-  #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
-  #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #      thresADU: None
-  #      calcPars: True
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #    ADU_per_Photon: 1.0
-  #    phiBins: 1
-  #    qbin: 5e-3
-  #    thresRms: null
-  #    thresADUhigh: null
-  #    geomCorr: true
-  #    polCorr: true
-  #    userMask: "/path/to/numpy_array.
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #    relabel: true
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    detnames: ["jungfrau"]
+    #xdetectors: []
+    #epicsPV: []
+    #epicsOncePV: []
+    #epicsArchFilePV:
+    #  - ["pv", "alias"]
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      all:
+        - "calib"
+        - "calib_dropped"
+        - "calib_dropped_square"
+        - "calib_thresADU1"
+        - "calib_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
+    #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
+    #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #      thresADU: None
+    #      calcPars: True
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #    ADU_per_Photon: 1.0
+    #    phiBins: 1
+    #    qbin: 5e-3
+    #    thresRms: null
+    #    thresADUhigh: null
+    #    geomCorr: true
+    #    polCorr: true
+    #    userMask: "/path/to/numpy_array.
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #    relabel: true
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 
 # TR-Scattering analysis - produces scan plots (t0/spatial overlap, etc.)
 AnalyzeSmallDataXSS:

--- a/config/templates/cheetah_template.yaml
+++ b/config/templates/cheetah_template.yaml
@@ -1,13 +1,4 @@
-{%- macro step_pydantic_model(data) %}
-{%- for field, sub_fields in data.items() %}
-{%- if sub_fields is mapping %}
-{{ field }}:
-{{- step_pydantic_model(sub_fields)|indent(loop.depth*2, True) }}
-{%- else %}
-{{ field }}: {{ sub_fields | tojson }}
-{%- endif %}
-{%- endfor %}
-{%- endmacro -%}
+{%- from "macros.jinja" import step_pydantic_model -%}
 
 {%- if data_retrieval_layer is defined and data_retrieval_layer %}
 om:

--- a/config/templates/macros.jinja
+++ b/config/templates/macros.jinja
@@ -1,7 +1,7 @@
 # Smalldata producer configuration macro
-{%- macro step_parameters(dict_name, detector, data, add_to_ret=True) %}
+{%- macro step_parameters(dict_name, detector, data, add_to_ret=True, skip_keys=[]) %}
 {%- if data is mapping %}
-{%- for param_name, param_value in data.items() %}
+{%- for param_name, param_value in data.items() if param_name not in skip_keys %}
         {% if param_value is none -%}
         {{ dict_name }}["{{ param_name }}"] = None
         {% else -%}

--- a/config/templates/macros.jinja
+++ b/config/templates/macros.jinja
@@ -1,0 +1,49 @@
+# Smalldata producer configuration macro
+{%- macro step_parameters(dict_name, detector, data, add_to_ret=True) %}
+{%- if data is mapping %}
+{%- for param_name, param_value in data.items() %}
+        {% if param_value is none -%}
+        {{ dict_name }}["{{ param_name }}"] = None
+        {% else -%}
+        {{ dict_name }}["{{ param_name }}"] = {{ param_value | pprint }}
+        {% endif %}
+{%- endfor %}
+        {% if add_to_ret -%}
+        ret_dict["{{ detector }}"] = {{ dict_name }}
+        {% endif %}
+{%- else %}
+        # Create list of dicts for {{ detector }}
+        {{ dict_name }}s = []
+
+{%- for data_dict in data %}
+        # Create a dict for this set
+        {{ dict_name }} = {}
+
+{{- step_parameters(dict_name, detector, data_dict, False) }}
+        {{ dict_name }}s.append({{ dict_name }})
+
+{%- endfor %}
+
+        # Add list of dicts for {{ detector }} to total dictionary
+        ret_dict["{{ detector }}"] = {{ dict_name }}s
+{%- endif %}
+{%- endmacro -%}
+
+# Direct-assignment macro: stores a value (list, scalar or whole dict) as-is.
+# Use for passthrough cases where the per-key unpacking of `step_parameters`
+# is not wanted (e.g. lists of algorithm names, projection configs).
+{%- macro step_value(detector, data) %}
+        ret_dict["{{ detector }}"] = {{ data | pprint }}
+{%- endmacro -%}
+
+# Cheetah configuration macro
+{%- macro step_pydantic_model(data) %}
+{%- for field, sub_fields in data.items() %}
+{%- if sub_fields is mapping %}
+{{ field }}:
+{{- step_pydantic_model(sub_fields)|indent(loop.depth*2, True) }}
+{%- else %}
+{{ field }}: {{ sub_fields | tojson }}
+{%- endif %}
+{%- endfor %}
+{%- endmacro -%}

--- a/config/templates/smd1_prod_config_template.py
+++ b/config/templates/smd1_prod_config_template.py
@@ -170,8 +170,10 @@ def getDetSums(run):
 ##########################################################
 # run independent parameters
 ##########################################################
-#aliases for experiment specific PVs go here
-#epicsPV = ['slit_s1_hw']
+# These lists are either PV names, aliases, or tuples with both.
+# epicsPV = ['las_fs14_controller_time']
+# epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
+#               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
 {% if epicsPV is defined %}
 epicsPV = {{ epicsPV }} #[]
 {% else %}
@@ -182,16 +184,14 @@ epicsOncePV = {{ epicsOncePV }}
 {% else %}
 epicsOncePV = []
 {% endif %}
-#fix timetool calibration if necessary
-#ttCalib=[0.,2.,0.]
+# This is a list of float to fix the Timetool calibration if necessary. 
 {% if ttCalib is defined %}
 ttCalib = {{ ttCalib }} #[]
 {% else %}
 ttCalib = []
 {% endif %}
-#ttCalib=[1.860828, -0.002950]
-#decide which analog input to save & give them nice names
-#aioParams=[[1],['laser']]
+# This is a list of analog inputs to save and give them a name.
+# aioParams = [[1], ['laser']]
 {% if aioParams is defined %}
 aioParams = {{ aioParams }} # []
 {% else %}

--- a/config/templates/smd1_prod_config_template.py
+++ b/config/templates/smd1_prod_config_template.py
@@ -1,3 +1,4 @@
+{%- from "macros.jinja" import step_parameters, step_value -%}
 import numpy as np
 
 detnames = {{ detnames }}
@@ -8,13 +9,9 @@ def getROIs(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        roi_dict = {}
 {% for detector, params in getROIs.items() %}
-        roi_dict['ROIs'] = {{ params['ROIs'] }}
-        roi_dict['writeArea'] = {{ params['writeArea'] }}
-        roi_dict['thresADU'] = {{ params['thresADU'] }}
-
-        ret_dict['{{ detector }}'] = roi_dict
+        roi_dict = {}
+{{- step_parameters("roi_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -26,15 +23,14 @@ def getAzIntParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        az_dict = {}
 {% for detector, params in getAzIntParams.items() %}
-        az_dict['eBeam'] = {{ params['eBeam'] }}
-        az_dict['center'] = {{ params['center'] }}
-        az_dict['dis_to_sam'] = {{ params['dis_to_sam'] }}
-        az_dict['tx'] = {{ params['tx'] }}
-        az_dict['ty'] = {{ params['ty'] }}
-
-        ret_dict['{{ detector }}'] = az_dict
+        az_dict = {}
+        {%- if 'userMask' in params %}
+        az_dict['userMask'] = np.load("{{ params['userMask'] }}")
+        {{- step_parameters("az_dict", detector, params|rejectattr("userMask")) }}
+        {% else %}
+        {{- step_parameters("az_dict", detector, params) }}
+        {% endif %}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -46,23 +42,9 @@ def getAzIntPyFAIParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        az_dict = {}
 {% for detector, params in getAzIntPyFAIParams.items() %}
-{%- if params['poni_file'] -%}
-        az_dict['poni_file'] = {{ params['poni_file'] }}
-{% else %}
-        ai_kwargs = {}
-        ai_kwargs['dist'] = {{ params['ai_kwargs']['dist'] }}
-        ai_kwargs['poni1'] = {{ params['ai_kwargs']['poni1'] }}
-        ai_kwargs['poni2'] = {{ params['ai_kwargs']['poni2'] }}
-        az_dict['ai_kwargs'] = ai_kwargs
-{% endif %}
-        az_dict['npts'] = {{ params['npts'] }}
-        az_dict['npts_az'] = {{ params['npts_az'] }}
-        az_dict['int_units'] = {{ params['2th_deg'] }}
-        az_dict['return2d'] = {{ params['return2d'] }}
-
-        ret_dict['{{ detector }}'] = az_dict
+        az_dict = {}
+{{- step_parameters("az_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -74,12 +56,9 @@ def getPhotonParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        photon_dict = {}
 {% for detector, params in getPhotonsParams.items() %}
-        photon_dict['ADU_per_photon'] = {{ params['ADU_per_photon'] }}
-        photon_dict['thresADU'] = {{ params['thresADU'] }}
-
-        ret_dict['{{ detector }}'] = photon_dict
+        photon_dict = {}
+{{- step_parameters("photon_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -91,17 +70,9 @@ def getDropletParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        droplet_dict = {}
 {% for detector, params in getDropletParams.items() %}
-        droplet_dict['name'] = {{ params['name'] }}
-        #droplet_dict['mask'] = None # have to pass full array
-        droplet_dict['threshold'] = {{ params['threshold'] }}
-        droplet_dict['thresholdLow'] = {{ params['thresholdLow'] }}
-        droplet_dict['thresADU'] = {{ params['thresADU'] }}
-        droplet_dict['useRms'] = {{ params['useRms'] }}
-        droplet_dict['nData'] = {{ params['nData'] }}
-
-        ret_dict['{{ detector }}'] = droplet_dict
+        droplet_dict = {}
+{{- step_parameters("droplet_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -113,20 +84,16 @@ def getDroplet2Photons(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        d2p_dict = {}
 {% for detector, params in getDroplet2Photons.items() %}
-        d2p_dict['droplet'] = {
-            'threshold': {{ params['droplet']['threshold'] }},
-            'thresholdLow': {{ params['droplet']['thresholdLow'] }},
-            'thresADU': {{ params['droplet']['thresADU'] }},
-            'useRms': {{ params['droplet']['useRms'] }},
-        }
-
+        d2p_dict = {}
+        droplet_dict = {}
+{{- step_parameters("droplet_dict", detector, params['droplet'], False) }}
+        d2p_dict['droplet'] = droplet_dict
         d2p_dict['d2p'] = {
             'aduspphot': {{ params['aduspphot'] }},
             'cputime': {{ params['cputime'] }},
         }
-        ret_dict['{{ detector }}'] = {{ params }}
+        ret_dict['{{ detector }}'] = d2p_dict
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -138,17 +105,9 @@ def getSvdParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        svd_dict = {}
 {% for detector, params in getSvdParams.items() %}
-        svd_dict['name'] = {{ params['name'] }}
-        svd_dict['n_components'] = {{ params['n_components'] }}
-        svd_dict['n_pulse'] = {{ params['n_pulse'] }}
-        svd_dict['basis_file'] = {{ params['basis_file'] }}
-        svd_dict['delay'] = {{ params['delay'] }}
-        #svd_dict['mode'] = {{ params['mode'] }}
-        svd_dict['return_reconstructed'] = {{ params['return_reconstructed'] }}
-
-        ret_dict['{{ detector }}'] = {{ params }}
+        svd_dict = {}
+{{- step_parameters("svd_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -160,15 +119,9 @@ def getAutocorrParams(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        autocorr_dict = {}
 {% for detector, params in getAutocorrParams.items() %}
-        autocorr_dict['name'] = {{ params['name'] }}
-        autocorr_dict['thresADU'] = {{ params['thresADU'] }}
-        autocorr_dict['save_lineout'] = {{ params['save_lineout'] }}
-        autocorr_dict['save_range'] = {{ params['save_range'] }}
-        autocorr_dict['illumination_correction'] = {{ params['illumination_correction'] }}
-
-        ret_dict['{{ detector }}'] = {{ params }}
+        autocorr_dict = {}
+{{- step_parameters("autocorr_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -182,7 +135,7 @@ def getProjection_ax0(run):
 
     if run > 0:
 {% for detector, params in getProjection_ax0.items() %}
-        ret_dict['{{ detector }}'] = {{ params }}
+{{- step_value(detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -196,7 +149,7 @@ def getProjection_ax1(run):
 
     if run > 0:
 {% for detector, params in getProjection_ax1.items() %}
-        ret_dict['{{ detector }}'] = {{ params }}
+{{- step_value(detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -209,7 +162,7 @@ def getDetSums(run):
     ret_dict = {}
     if run > 0:
 {% for detector, params in detSumAlgos.items() %}
-        ret_dict['{{ detector }}'] = {{ params }}
+{{- step_value(detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}

--- a/config/templates/smd1_prod_config_template.py
+++ b/config/templates/smd1_prod_config_template.py
@@ -25,9 +25,9 @@ def getAzIntParams(run):
     if run>0:
 {% for detector, params in getAzIntParams.items() %}
         az_dict = {}
-        {%- if 'userMask' in params %}
+        {%- if 'userMask' in params and params['userMask'] %}
         az_dict['userMask'] = np.load("{{ params['userMask'] }}")
-        {{- step_parameters("az_dict", detector, params|rejectattr("userMask")) }}
+        {{- step_parameters("az_dict", detector, params, skip_keys=["userMask"]) }}
         {% else %}
         {{- step_parameters("az_dict", detector, params) }}
         {% endif %}
@@ -174,25 +174,25 @@ def getDetSums(run):
 # epicsPV = ['las_fs14_controller_time']
 # epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
 #               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
-{% if epicsPV is defined %}
+{% if epicsPV is defined and epicsPV %}
 epicsPV = {{ epicsPV }} #[]
 {% else %}
 epicsPV = []
 {% endif %}
-{% if epicsOncePV is defined %}
+{% if epicsOncePV is defined and epicsOncePV %}
 epicsOncePV = {{ epicsOncePV }}
 {% else %}
 epicsOncePV = []
 {% endif %}
 # This is a list of float to fix the Timetool calibration if necessary. 
-{% if ttCalib is defined %}
+{% if ttCalib is defined and ttCalib %}
 ttCalib = {{ ttCalib }} #[]
 {% else %}
 ttCalib = []
 {% endif %}
 # This is a list of analog inputs to save and give them a name.
 # aioParams = [[1], ['laser']]
-{% if aioParams is defined %}
+{% if aioParams is defined and aioParams %}
 aioParams = {{ aioParams }} # []
 {% else %}
 aioParams = []

--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -193,6 +193,7 @@ def get_pressio_compression(run):
 # epicsPV = ['las_fs14_controller_time']
 # epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
 #               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
+# epicsArchFilePV = [('ABCD', 'BCDEF'), ('JFDLKSFJ', 'SJKLFS')]
 {%- if epicsPV is defined %}
 epicsPV = {{ epicsPV }}
 {% else %}

--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -203,6 +203,11 @@ epicsOncePV = {{ epicsOncePV }}
 {% else %}
 epicsOncePV = []
 {% endif %}
+{%- if epicsArchFilePV is defined %}
+epicsArchFilePV = {{ epicsArchFilePV }}
+{% else %}
+epicsArchFilePV = []
+{% endif %}
 
 ##########################################################
 # psplot config

--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -120,9 +120,9 @@ def get_azav(run):
     if run>0:
 {% for detector, params in getAzIntParams.items() %}
         az_dict = {}
-        {%- if 'userMask' in params %}
+        {%- if 'userMask' in params and params['userMask'] %}
         az_dict['userMask'] = np.load("{{ params['userMask'] }}")
-        {{- step_parameters("az_dict", detector, params|rejectattr("userMask")) }}
+        {{- step_parameters("az_dict", detector, params, skip_keys=["userMask"]) }}
         {% else %}
         {{- step_parameters("az_dict", detector, params) }}
         {% endif %}
@@ -194,17 +194,17 @@ def get_pressio_compression(run):
 # epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
 #               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
 # epicsArchFilePV = [('ABCD', 'BCDEF'), ('JFDLKSFJ', 'SJKLFS')]
-{%- if epicsPV is defined %}
+{%- if epicsPV is defined and epicsPV %}
 epicsPV = {{ epicsPV }}
 {% else %}
 epicsPV = []
 {% endif %}
-{%- if epicsOncePV is defined %}
+{%- if epicsOncePV is defined and epicsOncePV %}
 epicsOncePV = {{ epicsOncePV }}
 {% else %}
 epicsOncePV = []
 {% endif %}
-{%- if epicsArchFilePV is defined %}
+{%- if epicsArchFilePV is defined and epicsArchFilePV %}
 epicsArchFilePV = {{ epicsArchFilePV }}
 {% else %}
 epicsArchFilePV = []

--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -1,32 +1,4 @@
-{%- macro step_parameters(dict_name, detector, data, add_to_ret=True) %}
-{%- if data is mapping %}
-{%- for param_name, param_value in data.items() %}
-        {% if param_value is none -%}
-        {{ dict_name }}["{{ param_name }}"] = None
-        {% else -%}
-        {{ dict_name }}["{{ param_name }}"] = {{ param_value | pprint }}
-        {% endif %}
-{%- endfor %}
-        {% if add_to_ret -%}
-        ret_dict["{{ detector }}"] = {{ dict_name }}
-        {% endif %}
-{%- else %}
-        # Create list of dicts for {{ detector }}
-        {{ dict_name }}s = []
-
-{%- for data_dict in data %}
-        # Create a dict for this set
-        {{ dict_name }} = {}
-
-{{- step_parameters(dict_name, detector, data_dict, False) }}
-        {{ dict_name }}s.append({{ dict_name }})
-
-{%- endfor %}
-
-        # Add list of dicts for {{ detector }} to total dictionary
-        ret_dict["{{ detector }}"] = {{ dict_name }}s
-{%- endif %}
-{%- endmacro -%}
+{%- from "macros.jinja" import step_parameters, step_value -%}
 import numpy as np
 
 {%- if detnames is defined and detnames %}
@@ -77,8 +49,8 @@ def getROIs(run):
     ret_dict = {}
 
     if run > 0:
-        roi_dict = {}
 {% for detector, params in getROIs.items() %}
+        roi_dict = {}
 {{- step_parameters("roi_dict", detector, params) }}
 {% endfor %}
     return ret_dict
@@ -105,19 +77,15 @@ def get_droplet2photon(run):
     ret_dict = {}
 
     if run > 0:
-        d2p_dict = {}
 {% for detector, params in getDroplet2Photons.items() %}
-        d2p_dict["droplet"] = {
-            "threshold": {{ params["droplet"]["threshold"] }},
-            "thresholdLow": {{ params["droplet"]["thresholdLow"] }},
-            "thresADU": {{ params["droplet"]["thresADU"] }},
-            "useRms": {{ params["droplet"]["useRms"] }},
-        }
+        d2p_dict = {}
+        droplet_dict = {}
+{{- step_parameters("droplet_dict", detector, params["droplet"], False) }}
+        d2p_dict["droplet"] = droplet_dict
         d2p_dict["d2p"] = {
             "aduspphot": 20,
             "cputime": {{ params["cputime"] }},
         }
-        ret_dict["{{ detector }}"] = {{ params }}
         d2p_dict["nData"] = None
         d2p_dict["get_photon_img"] = False
 
@@ -137,8 +105,8 @@ def get_droplet(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        droplet_dict = {}
 {% for detector, params in getDropletParams.items() %}
+        droplet_dict = {}
 {{- step_parameters("droplet_dict", detector, params) }}
 {% endfor %}
     return ret_dict
@@ -150,8 +118,8 @@ def get_azav(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        az_dict = {}
 {% for detector, params in getAzIntParams.items() %}
+        az_dict = {}
         {%- if 'userMask' in params %}
         az_dict['userMask'] = np.load("{{ params['userMask'] }}")
         {{- step_parameters("az_dict", detector, params|rejectattr("userMask")) }}
@@ -168,9 +136,9 @@ def get_azav_pyfai(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        az_dict = {}
 {% for detector, params in getAzIntPyFAIParams.items() %}
-        {{- step_parameters("az_dict", detector, params) }}
+        az_dict = {}
+{{- step_parameters("az_dict", detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -185,7 +153,7 @@ def get_sum_algos(run):
     ret_dict = {}
     if run > 0:
 {% for detector, params in detSumAlgos.items() %}
-        ret_dict['{{ detector }}'] = {{ params }}
+{{- step_value(detector, params) }}
 {% endfor %}
     return ret_dict
 {% endif %}
@@ -196,8 +164,8 @@ def get_pressio_compression(run):
         run=int(run)
     ret_dict = {}
     if run>0:
-        pressio_dict = {}
 {% for detector, params in getPressioCompression.items() %}
+        pressio_dict = {}
         {%- if 'compressor_id' in params %}
         compressor_id = "{{ params['compressor_id'] }}"
         {%- if 'compressor_args' in params and 'abs_error_bound' in params['compressor_args'] %}

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -39,6 +39,7 @@ SubmitSMD:
   # add them with their own set of parameters.
   #detnames: []
   #epicsPV: []
+  #epicsOncePV: []
   #ttCalib: []
   # Provide detector image sum algorithms.
   # If detSumAlgos is not defined, it will default to calib, calib_dropped and

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -109,93 +109,95 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: []
-  #xdetectors: []
-  #epicsPV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  #detSumAlgos:
-  #  all:
-  #    - "calib"
-  #    - "calib_dropped"
-  #    - "calib_dropped_square"
-  #    - "calib_thresADU1"
-  #  epix10k2M:
-  #    - "calib_thresADU5"
-  #    - "calib_max"
-  #  Rayonix:
-  #    - "calib_skipFirst_thresADU1"
-  #    - "calib_skipFirst_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
-  #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
-  #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #      thresADU: None
-  #      calcPars: True
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #    ADU_per_Photon: 1.0
-  #    phiBins: 1
-  #    qbin: 5e-3
-  #    thresRms: null
-  #    thresADUhigh: null
-  #    geomCorr: true
-  #    polCorr: true
-  #    userMask: "/path/to/numpy_array.
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #    relabel: true
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    detnames: ["epix10k2M"]
+    #xdetectors: []
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    #detSumAlgos:
+    #  all:
+    #    - "calib"
+    #    - "calib_dropped"
+    #    - "calib_dropped_square"
+    #    - "calib_thresADU1"
+    #  epix10k2M:
+    #    - "calib_thresADU5"
+    #    - "calib_max"
+    #  Rayonix:
+    #    - "calib_skipFirst_thresADU1"
+    #    - "calib_skipFirst_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
+    #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
+    #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #      thresADU: None
+    #      calcPars: True
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #    ADU_per_Photon: 1.0
+    #    phiBins: 1
+    #    qbin: 5e-3
+    #    thresRms: null
+    #    thresADUhigh: null
+    #    geomCorr: true
+    #    polCorr: true
+    #    userMask: "/path/to/numpy_array.
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #    relabel: true
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 ...

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -24,7 +24,7 @@ AnalyzeSmallDataXSS:
     - "lens_v"
     - "lens_h"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
 
@@ -45,7 +45,7 @@ AnalyzeSmallDataXAS:
   ccm: "epics/ccm_E"
   ccm_set: "epicsUser/ccm_E_setpoint" # Requested CCM setpoint PV. Makes binning better but not required.
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
   #element: null       # For EXAFS -- currently unused
@@ -64,7 +64,7 @@ AnalyzeSmallDataXES:
     - "lxt"
     - "lxt_fast"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 1000           # Minimum x-ray intensity at selected ipm
   # Optional settings.

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -24,7 +24,7 @@ AnalyzeSmallDataXSS:
     - "lens_v"
     - "lens_h"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
 
@@ -45,7 +45,7 @@ AnalyzeSmallDataXAS:
   ccm: "epics/ccm_E"
   ccm_set: "epicsUser/ccm_E_setpoint" # Requested CCM setpoint PV. Makes binning better but not required.
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 500            # Minimum x-ray intensity at selected ipm
   #element: null       # For EXAFS -- currently unused
@@ -64,7 +64,7 @@ AnalyzeSmallDataXES:
     - "lxt"
     - "lxt_fast"
   # Thresholds used for data filtering
-  thresholds:
+  intensity_thresholds:
     min_Iscat: 10           # Minimum integrated scattering intensity
     min_ipm: 1000           # Minimum x-ray intensity at selected ipm
   # Optional settings.

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -109,93 +109,97 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: []
-  #xdetectors: []
-  #epicsPV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  #detSumAlgos:
-  #  all:
-  #    - "calib"
-  #    - "calib_dropped"
-  #    - "calib_dropped_square"
-  #    - "calib_thresADU1"
-  #  epix10k2M:
-  #    - "calib_thresADU5"
-  #    - "calib_max"
-  #  Rayonix:
-  #    - "calib_skipFirst_thresADU1"
-  #    - "calib_skipFirst_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
-  #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
-  #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #      thresADU: None
-  #      calcPars: True
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #    ADU_per_Photon: 1.0
-  #    phiBins: 1
-  #    qbin: 5e-3
-  #    thresRms: null
-  #    thresADUhigh: null
-  #    geomCorr: true
-  #    polCorr: true
-  #    userMask: "/path/to/numpy_array.
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #    relabel: true
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    #detnames: []
+    #xdetectors: []
+    #epicsPV: []
+    #epicsOncePV: []
+    #epicsArchFilePV:
+    #  - ["pv", "alias"]
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    #detSumAlgos:
+    #  all:
+    #    - "calib"
+    #    - "calib_dropped"
+    #    - "calib_dropped_square"
+    #    - "calib_thresADU1"
+    #  epix10k2M:
+    #    - "calib_thresADU5"
+    #    - "calib_max"
+    #  Rayonix:
+    #    - "calib_skipFirst_thresADU1"
+    #    - "calib_skipFirst_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
+    #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
+    #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #      thresADU: None
+    #      calcPars: True
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #    ADU_per_Photon: 1.0
+    #    phiBins: 1
+    #    qbin: 5e-3
+    #    thresRms: null
+    #    thresADUhigh: null
+    #    geomCorr: true
+    #    polCorr: true
+    #    userMask: "/path/to/numpy_array.
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #    relabel: true
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 ...

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -259,7 +259,7 @@ One or more ROIs can be defined on a per detector basis using the parameters def
 ```yaml
   getROIs:
     jungfrau1M:   # Change to detector name
-      - ROI: [[1, 2], [157, 487], [294, 598]]
+      - ROI: [[[1, 2], [157, 487], [294, 598]]]
         #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
         writeArea: True   # Whether to save ROI, if False, save sum but not img.
         thresADU: None

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -73,99 +73,103 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: ["epix10k2M"]
-  #epicsPV: []
-  #ttCalib: []
-  #getPressioCompression:
-  #  epix10k2M:
-  #    compressor_id: "sz3"
-  #    # Specific arguments vary depending on compressor_id
-  #    compressor_args:
-  #      abs_error_bound: 10
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  #detSumAlgos:
-  #  all:
-  #    - "calib"
-  #    - "calib_dropped"
-  #    - "calib_dropped_square"
-  #    - "calib_thresADU1"
-  #  epix10k2M:
-  #    - "calib_thresADU5"
-  #    - "calib_max"
-  #  Rayonix:
-  #    - "calib_skipFirst_thresADU1"
-  #    - "calib_skipFirst_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
-  #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
-  #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #      thresADU: None
-  #      calcPars: True
-  #getAzIntParams:
-  #  jungfrau:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #    ADU_per_Photon: 1.0
-  #    phiBins: 1
-  #    qbin: 5e-3
-  #    thresRms: null
-  #    thresADUhigh: null
-  #    geomCorr: true
-  #    polCorr: true
-  #    userMask: "/path/to/numpy_array.
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  #producer_parameters:
+    #detnames: ["epix10k2M"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #epicsArchFilePV:
+    #  - [["pv"], ["alias"]]
+    #ttCalib: []
+    #getPressioCompression:
+    #  epix10k2M:
+    #    compressor_id: "sz3"
+    #    # Specific arguments vary depending on compressor_id
+    #    compressor_args:
+    #      abs_error_bound: 10
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    #detSumAlgos:
+    #  all:
+    #    - "calib"
+    #    - "calib_dropped"
+    #    - "calib_dropped_square"
+    #    - "calib_thresADU1"
+    #  epix10k2M:
+    #    - "calib_thresADU5"
+    #    - "calib_max"
+    #  Rayonix:
+    #    - "calib_skipFirst_thresADU1"
+    #    - "calib_skipFirst_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    - ROI: [[[1, 2], [157, 487], [294, 598]]]
+    #      #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
+    #      writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #      thresADU: None
+    #      calcPars: True
+    #getAzIntParams:
+    #  jungfrau:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #    ADU_per_Photon: 1.0
+    #    phiBins: 1
+    #    qbin: 5e-3
+    #    thresRms: null
+    #    thresADUhigh: null
+    #    geomCorr: true
+    #    polCorr: true
+    #    userMask: "/path/to/numpy_array.
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 ```
 
 This set of parameters can be split into two sections, the command-line options, and the producer parameters. These can be discussed separately.
@@ -220,6 +224,34 @@ The options for MPI resource mappings may be useful but care should be taken whe
 
 ### Production parameters
 
+#### Saving PVs
+
+Three parameters control which EPICS PVs are saved by the smalldata producer:
+
+- `epicsPV`: PVs recorded on every event. Available on both LCLS1 and LCLS2.
+- `epicsOncePV`: PVs recorded once per run. Available on both LCLS1 and LCLS2.
+- `epicsArchFilePV`: PVs retrieved from the EPICS archiver. **LCLS2 only.**
+
+All three are specified under `producer_parameters` in the YAML configuration:
+
+```yaml
+SubmitSMD:
+  producer_parameters:
+    epicsPV: ['las_fs14_controller_time']
+    epicsOncePV: ['m0c0_vset']
+    epicsArchFilePV:
+      - ["pv_name_1", "alias_1"]
+      - ["pv_name_2", "alias_2"]
+```
+
+Note that `epicsArchFilePV` entries are each a two-element list `[pv, alias]`. In the YAML this is written as a list of lists. The template will render them as Python tuples in the producer configuration:
+
+```python
+epicsArchFilePV = [("pv_name_1", "alias_1"), ("pv_name_2", "alias_2")]
+```
+
+**Important:** These parameters must live under `producer_parameters` so that they are correctly validated by the parameter model and substituted into the producer template. Placing them directly under `SubmitSMD` (outside of `producer_parameters`) will bypass validation and the values will not be passed to the producer.
+
 #### ROI Selection: `getROIs`
 
 One or more ROIs can be defined on a per detector basis using the parameters defined in this block:
@@ -227,7 +259,7 @@ One or more ROIs can be defined on a per detector basis using the parameters def
 ```yaml
   getROIs:
     jungfrau1M:   # Change to detector name
-      - ROI: [[[1, 2], [157, 487], [294, 598]]]
+      - ROI: [[1, 2], [157, 487], [294, 598]]
         #name: "abcd" # Providing a name is only required if you are creating multiple ROIs
         writeArea: True   # Whether to save ROI, if False, save sum but not img.
         thresADU: None

--- a/lute/io/models/validators.py
+++ b/lute/io/models/validators.py
@@ -36,8 +36,9 @@ def template_parameter_validator(template_params_name: str):
         cls, template_params: Optional[Any], values: Dict[str, Any]
     ) -> None:
         if template_params is not None:
-            for param, value in template_params:
-                values[param] = value
+            for param, value in template_params.dict().items():
+                if value is not None:
+                    values[param] = value
         return None
 
     return validator(template_params_name, always=True, allow_reuse=True)(

--- a/tests/functional/smd2_mfx_prod/config.yaml
+++ b/tests/functional/smd2_mfx_prod/config.yaml
@@ -6,7 +6,7 @@ run: 90
 date: "2023/10/25"
 lute_version: 0.2.0      # Do not be change unless need to force older version
 task_timeout: 30000
-work_dir: "/tmp"
+work_dir: "/sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute_output"
 ...
 ---
 ###########
@@ -81,7 +81,7 @@ SubmitSMD:
         - "calib_max"
     getROIs:
       epix100_0:   # Change to detector name
-        - ROI: [[530, 680], [270, 350]]
+        - ROI: [[[530, 680], [270, 350]]]
           writeArea: True   # Whether to save ROI, if False, save sum but not img.
           thresADU: 3.5
           calcPars: True    # Save ROI sum, mean, max along with ROI

--- a/tests/functional/smd2_mfx_prod/config.yaml
+++ b/tests/functional/smd2_mfx_prod/config.yaml
@@ -38,6 +38,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
   # **************************************************************************/
   # * Below this point you will be configuring the prod_config_mfx file ******/
   # * This will overwrite any manual changes you make to that file      ******/
@@ -50,52 +53,54 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau","epix100_0", "qadc"]
-  #epicsPV: []
-  epicsArchFilePV:
-    - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
-    - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
-    - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
-    - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
-    - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
-    - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
-    - ["MFX:LAS:MMN:11.RBV",'lens_h']
-    - ["MFX:LAS:MMN:12.RBV",'lens_v']
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  detSumAlgos:
-    epix100_0:
-      - "calib"
-      - "calib_max"
-    jungfrau:
-      - "calib"
-      - "calib_max"
-  getROIs:
-    epix100_0:   # Change to detector name
-      - ROI: [[530, 680], [270, 350]]
-        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+  producer_parameters:
+    detnames: ["jungfrau","epix100_0", "qadc"]
+    #epicsPV: []
+    #epicsOncePV: []
+    epicsArchFilePV:
+      - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
+      - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
+      - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
+      - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
+      - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
+      - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
+      - ["MFX:LAS:MMN:11.RBV",'lens_h']
+      - ["MFX:LAS:MMN:12.RBV",'lens_v']
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      epix100_0:
+        - "calib"
+        - "calib_max"
+      jungfrau:
+        - "calib"
+        - "calib_max"
+    getROIs:
+      epix100_0:   # Change to detector name
+        - ROI: [[530, 680], [270, 350]]
+          writeArea: True   # Whether to save ROI, if False, save sum but not img.
+          thresADU: 3.5
+          calcPars: True    # Save ROI sum, mean, max along with ROI
+    getAzIntParams:
+      jungfrau:
+        eBeam: 7.1
+        center: [0, 0]
+        dis_to_sam: 150
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
+        #userMask: "/path/to/mask.npy"
+    getDropletParams:
+      epix100_0:
+        threshold: 3.4375
+    #    thresholdLow: 5
         thresADU: 3.5
-        calcPars: True    # Save ROI sum, mean, max along with ROI
-  getAzIntParams:
-    jungfrau:
-      eBeam: 7.1
-      center: [0, 0]
-      dis_to_sam: 150
-      phiBins: 11
-      qbin: 0.02
-      tx: 0
-      ty: 0
-      #userMask: "/path/to/mask.npy"
-  getDropletParams:
-    epix100_0:
-      threshold: 3.4375
-  #    thresholdLow: 5
-      thresADU: 3.5
-      useRms: False
-  #    nData: 1e5
-      name: 'droplet'
+        useRms: False
+    #    nData: 1e5
+        name: 'droplet'
 ...

--- a/tests/functional/smd2_multi_node/config.yaml
+++ b/tests/functional/smd2_multi_node/config.yaml
@@ -76,19 +76,19 @@ SubmitSMD:
         tx: 0
         ty: 0
 
-  AnalyzeSmallDataXSS:
-    # smd_path: ""             # Include to analyze ONE specified smalldata file
-    # Detector selection
-    xss_detname: "jungfrau"  # Name of detector with scattering signal
-    ipm_var: "MfxDg2BmMon/totalIntensityJoules"       # ipm PV to use for x-ray intensity filtering
-    # Motor scans to search for
-    scan_var:
-      - "lxt"
-      - "lens_v"
-      - "lens_h"
-      - "lens_g"
-    # Thresholds used for data filtering
-    intensity_thresholds:
-      min_Iscat: 10           # Minimum integrated scattering intensity
-      min_ipm: 500            # Minimum x-ray intensity at selected ipm
+AnalyzeSmallDataXSS:
+  # smd_path: ""             # Include to analyze ONE specified smalldata file
+  # Detector selection
+  xss_detname: "jungfrau"  # Name of detector with scattering signal
+  ipm_var: "MfxDg2BmMon/totalIntensityJoules"       # ipm PV to use for x-ray intensity filtering
+  # Motor scans to search for
+  scan_var:
+    - "lxt"
+    - "lens_v"
+    - "lens_h"
+    - "lens_g"
+  # Thresholds used for data filtering
+  intensity_thresholds:
+    min_Iscat: 10           # Minimum integrated scattering intensity
+    min_ipm: 500            # Minimum x-ray intensity at selected ipm
 ...

--- a/tests/functional/smd2_multi_node/config.yaml
+++ b/tests/functional/smd2_multi_node/config.yaml
@@ -38,6 +38,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
   # **************************************************************************/
   # * Below this point you will be configuring the prod_config_mfx file ******/
   # * This will overwrite any manual changes you make to that file      ******/
@@ -50,40 +53,42 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau","epix100_0", "qadc"]
-  #epicsPV: []
-  epicsArchFilePV:
-    - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
-    - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
-    - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
-    - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
-    - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
-    - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
-    - ["MFX:LAS:MMN:11.RBV",'lens_h']
-    - ["MFX:LAS:MMN:12.RBV",'lens_v']
-  getAzIntParams:
-    jungfrau:
-      eBeam: 12.965
-      center: [-1107, 918]
-      dis_to_sam: 155.5
-      phiBins: 11
-      qbin: 0.02
-      tx: 0
-      ty: 0
+  producer_parameters:
+    detnames: ["jungfrau","epix100_0", "qadc"]
+    #epicsPV: []
+    #epicsOncePV: []
+    epicsArchFilePV:
+      - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
+      - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
+      - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
+      - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
+      - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
+      - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
+      - ["MFX:LAS:MMN:11.RBV",'lens_h']
+      - ["MFX:LAS:MMN:12.RBV",'lens_v']
+    getAzIntParams:
+      jungfrau:
+        eBeam: 12.965
+        center: [-1107, 918]
+        dis_to_sam: 155.5
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
 
-AnalyzeSmallDataXSS:
-  # smd_path: ""             # Include to analyze ONE specified smalldata file
-  # Detector selection
-  xss_detname: "jungfrau"  # Name of detector with scattering signal
-  ipm_var: "MfxDg2BmMon/totalIntensityJoules"       # ipm PV to use for x-ray intensity filtering
-  # Motor scans to search for
-  scan_var:
-    - "lxt"
-    - "lens_v"
-    - "lens_h"
-    - "lens_g"
-  # Thresholds used for data filtering
-  intensity_thresholds:
-    min_Iscat: 10           # Minimum integrated scattering intensity
-    min_ipm: 500            # Minimum x-ray intensity at selected ipm
+  AnalyzeSmallDataXSS:
+    # smd_path: ""             # Include to analyze ONE specified smalldata file
+    # Detector selection
+    xss_detname: "jungfrau"  # Name of detector with scattering signal
+    ipm_var: "MfxDg2BmMon/totalIntensityJoules"       # ipm PV to use for x-ray intensity filtering
+    # Motor scans to search for
+    scan_var:
+      - "lxt"
+      - "lens_v"
+      - "lens_h"
+      - "lens_g"
+    # Thresholds used for data filtering
+    intensity_thresholds:
+      min_Iscat: 10           # Minimum integrated scattering intensity
+      min_ipm: 500            # Minimum x-ray intensity at selected ipm
 ...

--- a/tests/functional/smd_mfx_default/config.yaml
+++ b/tests/functional/smd_mfx_default/config.yaml
@@ -30,6 +30,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mfx.py"
   # Producer variables. These are substituted into the producer to run specific
   # data reduction algorithms. Uncomment and modify as needed.
   # If you prefer to modify the producer file directly, leave commented.
@@ -37,5 +40,42 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["epix10k2M"]
+  producer_parameters:
+    detnames: ["epix10k2M"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      epix10k2M:
+        - calib
+        - calib_max
+    getROIs:
+      epix10k2M:   # Change to detector name
+        - ROI: [[0, 1], [30, 180], [270, 350]]
+          writeArea: True   # Whether to save ROI, if False, save sum but not img.
+          thresADU: 3.5
+          calcPars: True    # Save ROI sum, mean, max along with ROI
+    getAzIntParams:
+      epix10k2M:
+        eBeam: 7.1
+        center: [0, 0]
+        dis_to_sam: 150
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
+        #userMask: "/path/to/mask.npy"
+    getDropletParams:
+      epix10k2M:
+        threshold: 3.4375
+    #    thresholdLow: 5
+        thresADU: 3.5
+        useRms: False
+    #    nData: 1e5
+        name: 'droplet'
 ...

--- a/tests/functional/smd_mfx_default/config.yaml
+++ b/tests/functional/smd_mfx_default/config.yaml
@@ -56,7 +56,7 @@ SubmitSMD:
         - calib_max
     getROIs:
       epix10k2M:   # Change to detector name
-        - ROI: [[0, 1], [30, 180], [270, 350]]
+        - ROI: [[[0, 1], [30, 180], [270, 350]]]
           writeArea: True   # Whether to save ROI, if False, save sum but not img.
           thresADU: 3.5
           calcPars: True    # Save ROI sum, mean, max along with ROI

--- a/tests/functional/smd_xpp_default/config.yaml
+++ b/tests/functional/smd_xpp_default/config.yaml
@@ -30,6 +30,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xpp.py"
   # Producer variables. These are substituted into the producer to run specific
   # data reduction algorithms. Uncomment and modify as needed.
   # If you prefer to modify the producer file directly, leave commented.
@@ -37,5 +40,17 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau1M"]
+  producer_parameters:
+    detnames: ["jungfrau1M"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      all:
+        - "calib"
 ...


### PR DESCRIPTION
# Description

This PR fixes bad indentation and templating from `jinja` by using a standardized macro `step_parameters` both for SMD1 and SMD2 producer templates.

# Checklist

- [x] Move macros to `macros.jinja`
- [x] Refacto both producer templates to use macros when possible
- [x] Add `epicsArchFilePV` to LCLS-II template
- [x] Rewrite hutch YAMLs to use `producer_parameters`
- [x] Refine docs
- [x] Test templating for SMD1 and SMD2

# PR Type

- [x] Maintenance

# Testing

## Functional 

Added some more entries to `SubmitSMD` to parsing and templating of `prod_config_<hutch>.py`:
1. `smd_mfx_default`
```bash
>git diff origin/dev smd_mfx_default/config.yaml 
diff --git a/tests/functional/smd_mfx_default/config.yaml b/tests/functional/smd_mfx_default/config.yaml
index 3769adf..aa3ea8e 100644
--- a/tests/functional/smd_mfx_default/config.yaml
+++ b/tests/functional/smd_mfx_default/config.yaml
@@ -6,7 +6,7 @@ run: 16
 date: "2023/10/25"
 lute_version: 0.2.0      # Do not be change unless need to force older version
 task_timeout: 600
-work_dir: "/tmp"
+work_dir: "/sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute_output"
 ...
 ---
 SubmitSMD:
@@ -30,6 +30,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mfx.py"
   # Producer variables. These are substituted into the producer to run specific
   # data reduction algorithms. Uncomment and modify as needed.
   # If you prefer to modify the producer file directly, leave commented.
@@ -37,5 +40,42 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["epix10k2M"]
+  producer_parameters:
+    detnames: ["epix10k2M"]
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      epix10k2M:
+        - calib
+        - calib_max
+    getROIs:
+      epix10k2M:   # Change to detector name
+        - ROI: [[[0, 1], [30, 180], [270, 350]]]
+          writeArea: True   # Whether to save ROI, if False, save sum but not img.
+          thresADU: 3.5
+          calcPars: True    # Save ROI sum, mean, max along with ROI
+    getAzIntParams:
+      epix10k2M:
+        eBeam: 7.1
+        center: [0, 0]
+        dis_to_sam: 150
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
+        #userMask: "/path/to/mask.npy"
+    getDropletParams:
+      epix10k2M:
+        threshold: 3.4375
+    #    thresholdLow: 5
+        thresADU: 3.5
+        useRms: False
+    #    nData: 1e5
+        name: 'droplet'
```

2. `smd_xpp_default`
```bash
>git diff origin/dev smd2_mfx_prod/config.yaml  
diff --git a/tests/functional/smd2_mfx_prod/config.yaml b/tests/functional/smd2_mfx_prod/config.yaml
index 1e78c6e..fb6ded2 100644
--- a/tests/functional/smd2_mfx_prod/config.yaml
+++ b/tests/functional/smd2_mfx_prod/config.yaml
@@ -6,7 +6,7 @@ run: 90
 date: "2023/10/25"
 lute_version: 0.2.0      # Do not be change unless need to force older version
 task_timeout: 30000
-work_dir: "/tmp"
+work_dir: "/sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute_output"
 ...
 ---
 ###########
@@ -38,6 +38,9 @@ SubmitSMD:
   #wait: False
   #xtcav: False
   #noarch: False
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py" # Or the smd2 version
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
   # **************************************************************************/
   # * Below this point you will be configuring the prod_config_mfx file ******/
   # * This will overwrite any manual changes you make to that file      ******/
@@ -50,52 +53,54 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau","epix100_0", "qadc"]
-  #epicsPV: []
-  epicsArchFilePV:
-    - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
-    - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
-    - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
-    - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
-    - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
-    - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
-    - ["MFX:LAS:MMN:11.RBV",'lens_h']
-    - ["MFX:LAS:MMN:12.RBV",'lens_v']
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  detSumAlgos:
-    epix100_0:
-      - "calib"
-      - "calib_max"
-    jungfrau:
-      - "calib"
-      - "calib_max"
-  getROIs:
-    epix100_0:   # Change to detector name
-      - ROI: [[530, 680], [270, 350]]
-        writeArea: True   # Whether to save ROI, if False, save sum but not img.
+  producer_parameters:
+    detnames: ["jungfrau","epix100_0", "qadc"]
+    #epicsPV: []
+    #epicsOncePV: []
+    epicsArchFilePV:
+      - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
+      - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
+      - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
+      - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
+      - ["SP1L0:DCCM:energy:OphydReadback",'dccm_E']
+      - ["SP1L0:DCCM:energy:OphydSetpoint",'dccm_E_setpoint']
+      - ["MFX:LAS:MMN:11.RBV",'lens_h']
+      - ["MFX:LAS:MMN:12.RBV",'lens_v']
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    detSumAlgos:
+      epix100_0:
+        - "calib"
+        - "calib_max"
+      jungfrau:
+        - "calib"
+        - "calib_max"
+    getROIs:
+      epix100_0:   # Change to detector name
+        - ROI: [[[530, 680], [270, 350]]]
+          writeArea: True   # Whether to save ROI, if False, save sum but not img.
+          thresADU: 3.5
+          calcPars: True    # Save ROI sum, mean, max along with ROI
+    getAzIntParams:
+      jungfrau:
+        eBeam: 7.1
+        center: [0, 0]
+        dis_to_sam: 150
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
+        #userMask: "/path/to/mask.npy"
+    getDropletParams:
+      epix100_0:
+        threshold: 3.4375
+    #    thresholdLow: 5
         thresADU: 3.5
-        calcPars: True    # Save ROI sum, mean, max along with ROI
-  getAzIntParams:
-    jungfrau:
-      eBeam: 7.1
-      center: [0, 0]
-      dis_to_sam: 150
-      phiBins: 11
-      qbin: 0.02
-      tx: 0
-      ty: 0
-      #userMask: "/path/to/mask.npy"
-  getDropletParams:
-    epix100_0:
-      threshold: 3.4375
-  #    thresholdLow: 5
-      thresADU: 3.5
-      useRms: False
-  #    nData: 1e5
-      name: 'droplet'
+        useRms: False
+    #    nData: 1e5
+        name: 'droplet'
```

Running functional testing script:
```bash
>./submit_run_functional.sh --no_clone --run_dir $(pwd)/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok
Sourced latest psconda.sh
python -B /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/run_functional.py --no_clone --run_dir /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok
Running python -B /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/run_functional.py --no_clone --run_dir /sdf/home/l/lconreux/exp/prjlute22/results/benchmarks/geom_opt/lute/tests/../../.. --no_delete --partition=milano --account=lcls:prjlute22 --exist_ok with --partition=milano --account=lcls:prjlute22 --ntasks=1
Submitted batch job 31069157
```

```bash
Time ReadTester spent: 
- Pending: 35 s
- Running: 8 s
[2026-07-08 19:18:35.047] [HTTP:Server] [info] Shutting down server...
[2026-07-08 19:18:35.047] [HTTP:Server] [info] All server threads exited.
[2026-07-08 19:18:35.047] [LWM:Manager] [error] Exiting after workflow failed! [5/6 succeeded]
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
INFO:Launch_Func_Tests:Test workflow basic_tests was unsuccessful but this is marked as intentional.
INFO:Launch_Func_Tests:Test workflow basic_tests was unsuccessful but this is marked as intentional.
INFO:Launch_Func_Tests:Ran 9 tests. 8 were successful.
INFO:Launch_Func_Tests:Ran 9 tests. 8 were successful.
```

```
>grep "FAILED" slurm-31069157.out 
[2026-07-08 17:22:51.611] [LWM:Manager] [error] Providing logs for StreamFileConcatenator [Exited as: UPSTREAM_FAILED]
[2026-07-08 17:22:51.612] [LWM:Manager] [error] Providing logs for PartialatorMerger [Exited as: UPSTREAM_FAILED]
[2026-07-08 17:22:51.612] [LWM:Manager] [error] Providing logs for HKLManipulator [Exited as: UPSTREAM_FAILED]
[2026-07-08 17:22:51.612] [LWM:Manager] [error] Providing logs for HKLComparer [Exited as: UPSTREAM_FAILED]
[2026-07-08 17:22:51.612] [LWM:Manager] [error] Providing logs for PeakFinderSFXXpp [Exited as: FAILED]
[2026-07-08 17:22:51.613] [LWM:Manager] [error] Providing logs for CrystFELIndexer [Exited as: UPSTREAM_FAILED]
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
[2026-07-08 19:17:39.709] [LWM:Manager] [error] Providing logs for BinaryErrTester [Exited as: FAILED]
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
ERROR:Launch_Func_Tests:Maestro workflow failed: FAILED
```
`PeakFinderSFXXpp` failed because build is on python3.9 and this task requires python3.11.

Resulting `hdf5` files present all desired entries:
1. `smd_mfx_default`
```python
h5_file = "/sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute_output/mfxx49820_Run0016.h5"
with h5py.File(h5_file) as h5:
    print(h5.keys())
```
```python
<KeysViewHDF5 ['UserDataCfg', 'damage', 'ebeam', 'epics', 'epicsOnce', 'event_time', 'evr', 'fiducials', 'gas_detector', 'ipm_dg1', 'ipm_dg2', 'lightStatus', 'phase_cav']>
```

2. `smd2_mfx_prod`
```python
h5_file = "/sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute_output/mfx101262725_Run0096.h5"
with h5py.File(h5_file) as h5:
    print(h5.keys())
```
```python
<KeysViewHDF5 ['MfxDg1BmMon', 'MfxDg2BmMon', 'Sums', 'UserDataCfg', 'damage', 'ebeamh', 'enc', 'epics', 'epicsUser', 'epics_archiver', 'gasdet', 'jungfrau', 'lightStatus', 'pcav', 'scan', 'timestamp', 'timing']>
```

## Unit

```bash
>pytest unit
/sdf/group/lcls/ds/ana/sw/conda2/inst/envs/ps_20241122/lib/python3.9/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
PySide6 6.7.3 -- Qt runtime 6.7.3 -- Qt compiled 6.7.3
rootdir: /sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute
configfile: pyproject.toml
plugins: asyncio-0.24.0, qt-4.4.0, anyio-4.6.2.post1
asyncio: mode=strict, default_loop_scope=None
collected 36 items                                                                                                                                                                                                 

unit/test_db_common.py .....                                                                                                                                                                                 [ 13%]
unit/test_db_v1.py .                                                                                                                                                                                         [ 16%]
unit/test_db_v2.py .                                                                                                                                                                                         [ 19%]
unit/test_env_bootstrap_mpi.py .......                                                                                                                                                                       [ 38%]
unit/test_executor.py ......                                                                                                                                                                                 [ 55%]
unit/test_ipc.py ..                                                                                                                                                                                          [ 61%]
unit/test_ipc_bidirectional.py .                                                                                                                                                                             [ 63%]
unit/test_launch_utils.py ....                                                                                                                                                                               [ 75%]
unit/test_parsing.py ......                                                                                                                                                                                  [ 91%]
unit/test_task.py ...                                                                                                                                                                                        [100%]

================================================================================================ 36 passed in 8.22s ================================================================================================
```

```bash
>test_http 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
```

```bash
>test_server 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-07-09 09:39:35.528] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-09 09:39:35.528] [HTTP:Server] [info] Shutting down server...
[2026-07-09 09:39:35.529] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-07-09 09:39:35.529] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-09 09:39:35.629] [HTTP:Server] [info] Shutting down server...
[2026-07-09 09:39:35.629] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-07-09 09:39:35.629] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-09 09:39:35.730] [HTTP:Server] [info] Shutting down server...
[2026-07-09 09:39:35.730] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (202 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (202 ms total)
[  PASSED  ] 3 tests.
```