### PR TITLE
UTL Prepare nightly builds and PEP503 Simple Index

### DIFF
--- a/.github/workflows/build_index.yml
+++ b/.github/workflows/build_index.yml
@@ -1,0 +1,52 @@
+name: Build Simple Package Index
+on:
+  release:
+    types: [published, created, edited]
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update_index:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == "slac-lcls"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1                 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run build_index.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python utilities/wheels/build_index.py
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
+        with:
+          ref: gh-pages
+          path: gh-pages-dir
+
+      - name: Update index files in wheels/
+        run: |
+          mkdir -p gh-pages-dir/wheels
+          # Copy generated index files to the wheels directory on gh-pages
+          cp -r dist/* gh-pages-dir/wheels/
+
+      - name: Commit and push changes
+        working-directory: gh-pages-dir
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "<>"
+          git add wheels
+          git commit -m "Update static PEP 503 package index [skip ci]" || echo "No changes to commit"
+          git push origin gh-pages

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -1,0 +1,153 @@
+name: Build Nightly Wheels and Add to Simple Index
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  # Build binaries
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: github.repository_owner == "slac-lcls"
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # Add back Mac and Windows builds when maestro supports them
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
+
+      # Cache pip (for speedup)
+      - name: Cache pip
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9                        # v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Cache ccache (for speedup)
+      - name: Cache ccache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9                        # v6
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-ccache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Update Version name for Nightly Build
+        shell: bash
+        run: |
+          python -c "import re; p = 'meson.build'; c = open(p).read(); open(p, 'w').write(re.sub(r\"version:\s*'([0-9]+\.[0-9]+\.[0-9]+)'\", r\"version: '\1+dev'\", c))"
+
+      - name: Build wheels
+        # Check pyproject.toml for supported versions and additional config
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55                    # v4.1.0
+        env:
+          CIBW_TEST_REQUIRES: "pytest"
+          # Include the C++ test suite binaries
+          CIBW_TEST_COMMAND: "test_http && test_server && test_maestro_api && pytest {project}/tests/unit"
+          CIBW_AFTER_BUILD: "ccache -s"
+          # Could not do tests, but then I can't run them above
+          # CIBW_CONFIG_SETTINGS: "setup-args=\"-Dinstall_tests=false\" setup-args=\"-Dinstall_utilities=false\""
+
+      # Instead of disabling, will just remove them from the wheels afterwards
+      # Not sure this will work on platforms other than Linux? Not building for those though..
+      - name: Prune tests from wheels
+        run: |
+          for whl in wheelhouse/*.whl; do
+            echo "Pruning $whl..."
+            # Find all files inside the wheel that match our test names
+            # and delete them regardless of which .data/scripts folder they are in
+            zip -d "$whl" "*test_http" "*test_server" "*test_maestro_api" "*activate_installation"
+          done
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a              # v7.0.1
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  # Build source distribution
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    if: github.repository_owner == "slac-lcls"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1                 # v6
+        with:
+          python-version: "3.11" # Shouldn't matter
+
+      # Meson setup runs, so we still need these unfortunately (for subprojects)
+      # The code will not actually be compiled for the sdist
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y cmake ninja-build
+
+      - name: Update Version name for Nightly Build
+        shell: bash
+        run: |
+          python -c "import re; p = 'meson.build'; c = open(p).read(); open(p, 'w').write(re.sub(r\"version:\s*'([0-9]+\.[0-9]+\.[0-9]+)'\", r\"version: '\1+dev'\", c))"
+
+      - name: Build sdist
+        run: |
+          python -m pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a              # v7.0.1
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  # Create release, publish
+  create_and_publish_nighly:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+    if: github.repository_owner == "slac-lcls"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
+        with:
+          ref: dev
+
+      - name: Prep Nightly Tag
+        id: prep
+        run: |
+          VERSION=$(python3 -c "import re; f = open('meson.build'); m = re.search(r\"version\s*:\s*'([^']+)'\", f.read()); print(m.group(1) if m else ''); f.close()")
+          echo "tag_name=v${VERSION}+dev" >> $GITHUB_OUTPUT
+
+      - name: Gather build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c            # v8
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Clean Existing Nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete "${{ steps.prep.outputs.tag_name }}" --yes || true
+          git push --delete origin "${{ steps.prep.outputs.tag_name }}" || true
+          git tag -d "${{ steps.prep.outputs.tag_name }}" || true
+
+      - name: Create Nightly Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b          # v3.0.1
+        with:
+          tag_name: ${{ steps.prep.outputs.tag_name }}
+          target_commitish: dev
+          files: dist/*
+          prerelease: true
+          generate_release_notes: true

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'lute',
     'cpp',
-    version: '0.2.0',
+    version: '0.3.0',
     default_options: [
         'cpp_std=c++20',
     ],

--- a/utilities/wheels/build_index.py
+++ b/utilities/wheels/build_index.py
@@ -1,6 +1,6 @@
 """A script to construct a PEP503 compatible simple package index."""
 
-__all__ = []
+__all__: "List[str]" = []
 __author__ = "Gabriel Dorlhiac"
 
 import os
@@ -92,7 +92,7 @@ def fetch_repo_releases(org: str, repo_name: str) -> List[Dict[str, Any]]:
     return releases
 
 
-def main():
+def main() -> None:
     # Structure: index_data[normalized_package_name] = list of (filename, url)
     index_data: Dict[str, List[Tuple[str, str]]] = {}
 
@@ -152,9 +152,9 @@ def main():
     root_index_path: str = os.path.join(OUTPUT_DIR, "index.html")
     with open(root_index_path, "w", encoding="utf-8") as f:
         f.write("<!DOCTYPE html>\n<html>\n<head>\n")
-        f.write(f"  <title>LUTE Simple Index</title>\n")
+        f.write("  <title>LUTE Simple Index</title>\n")
         f.write("</head>\n<body>\n")
-        f.write(f"  <h1>LUTE Simple Index</h1>\n")
+        f.write("  <h1>LUTE Simple Index</h1>\n")
         for pkg in sorted(index_data.keys()):
             # Sub-directory link must match the normalized name
             f.write(f'  <a href="{pkg}/">{pkg}</a><br/>\n')

--- a/utilities/wheels/build_index.py
+++ b/utilities/wheels/build_index.py
@@ -1,0 +1,200 @@
+"""A script to construct a PEP503 compatible simple package index."""
+
+__all__ = []
+__author__ = "Gabriel Dorlhiac"
+
+import os
+import re
+import sys
+import urllib.parse
+import requests
+from typing import Any, Dict, List, Optional, Tuple
+
+# --- Configuration ---
+ORG: str = "slac-lcls"
+LUTE_REPO: str = "lute"
+OUTPUT_DIR: str = "wheels"
+
+# --- Setup GitHub API Authentication ---
+GITHUB_TOKEN: Optional[str] = os.getenv("GITHUB_TOKEN")
+headers = {
+    "Accept": "application/vnd.github.v3+json",
+}
+if GITHUB_TOKEN:
+    headers["Authorization"] = f"token {GITHUB_TOKEN}"
+
+session: requests.Session = requests.Session()
+session.headers.update(headers)
+
+
+def normalize_package_name(name: str) -> str:
+    """Normalize package names according to PEP 503.
+
+    Args:
+        name (str): The retrieved package name.
+
+    Returns:
+        norm_name (str): The PEP 503 normalized name.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def fetch_org_repos(org: str) -> List[Dict[str, Any]]:
+    """Retrieve all public/accessible repositories for the organization.
+
+    Args:
+        org (str): The organization name on GitHub to fetch repositories for.
+
+    Returns:
+        repos (List[Dict[str, Any]]): A list of repositories and metadata for the org.
+    """
+    repos: List[Dict[str, Any]] = []
+    url: Optional[str] = f"https://api.github.com/orgs/{org}/repos?per_page=100"
+    while url:
+        response: requests.models.Response = session.get(url)
+        if response.status_code != 200:
+            print(
+                f"Error fetching repos: {response.status_code} - {response.text}",
+                file=sys.stderr,
+            )
+            break
+        repos.extend(response.json())
+        # Parse next page link header if pagination exists
+        url = response.links.get("next", {}).get("url")
+    return repos
+
+
+def fetch_repo_releases(org: str, repo_name: str) -> List[Dict[str, Any]]:
+    """Retrieve all releases and pre-releases for a given repository.
+
+    Args:
+        org (str): The organization name on GitHub.
+
+        repo_name (str): The name of the organization's repo.
+
+    Returns:
+        releases (List[Dict[str, Any]]): A list of releases and metadata for the provided repo.
+    """
+    releases: List[Dict[str, Any]] = []
+    url: Optional[str] = (
+        f"https://api.github.com/repos/{org}/{repo_name}/releases?per_page=100"
+    )
+    while url:
+        response: requests.models.Response = session.get(url)
+        if response.status_code != 200:
+            print(
+                f"Error fetching releases for {repo_name}: {response.status_code}",
+                file=sys.stderr,
+            )
+            break
+        releases.extend(response.json())
+        url = response.links.get("next", {}).get("url")
+    return releases
+
+
+def main():
+    # Structure: index_data[normalized_package_name] = list of (filename, url)
+    index_data: Dict[str, List[Tuple[str, str]]] = {}
+
+    print(f"Fetching repositories for organization '{ORG}'...")
+    repos: List[Dict[str, str]] = fetch_org_repos(ORG)
+    print(f"Found {len(repos)} repositories.")
+
+    for repo in repos:
+        repo_name: str = repo["name"]
+        if repo_name != LUTE_REPO:
+            continue
+
+        print(f"Processing releases for {repo_name}...")
+        releases: List[Dict[str, Any]] = fetch_repo_releases(ORG, repo_name)
+
+        for release in releases:
+            assets: List[Dict[str, Any]] = release.get("assets", [])
+            for asset in assets:
+                name: str = asset["name"]
+                # Only index python packages (wheels, tarballs, zips)
+                if name.endswith((".whl", ".tar.gz", ".zip", ".tar.bz2")):
+                    # Get package name from wheel filename (e.g. ncarray-0.1.0-...)
+                    # PEP 427: distribution-version-python-abi-platform.whl
+                    pkg_name: str = name.split("-")[0]
+                    norm_pkg_name: str = normalize_package_name(pkg_name)
+
+                    download_url: str = asset["browser_download_url"]
+
+                    # Add the SHA256 hash
+                    digest: Optional[str] = asset.get("digest")
+                    if digest and ":" in digest:
+                        algo: str
+                        hash_val: str
+                        algo, hash_val = digest.split(":")
+                        download_url = (
+                            f"{download_url}#{algo.lower()}={hash_val.lower()}"
+                        )
+
+                    # Add the upload timestamp for pip/UV compat
+                    upload_time: Optional[str] = asset.get("created_at")
+                    if upload_time:
+                        if "#" in download_url:
+                            download_url = f"{download_url}&upload_time={upload_time}"
+                        else:
+                            download_url = f"{download_url}#upload_time={upload_time}"
+
+                    if norm_pkg_name not in index_data:
+                        index_data[norm_pkg_name] = []
+
+                    # Store package metadata
+                    index_data[norm_pkg_name].append((name, download_url))
+
+    print("Generating static PEP 503 index pages...")
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # Write the package-level root index (wheels/index.html)
+    root_index_path: str = os.path.join(OUTPUT_DIR, "index.html")
+    with open(root_index_path, "w", encoding="utf-8") as f:
+        f.write("<!DOCTYPE html>\n<html>\n<head>\n")
+        f.write(f"  <title>LUTE Simple Index</title>\n")
+        f.write("</head>\n<body>\n")
+        f.write(f"  <h1>LUTE Simple Index</h1>\n")
+        for pkg in sorted(index_data.keys()):
+            # Sub-directory link must match the normalized name
+            f.write(f'  <a href="{pkg}/">{pkg}</a><br/>\n')
+        f.write("</body>\n</html>\n")
+
+    # Write individual package pages (wheels/<pkg_name>/index.html)
+    for pkg, files in index_data.items():
+        pkg_dir: str = os.path.join(OUTPUT_DIR, pkg)
+        os.makedirs(pkg_dir, exist_ok=True)
+
+        pkg_index_path: str = os.path.join(pkg_dir, "index.html")
+        with open(pkg_index_path, "w", encoding="utf-8") as f:
+            f.write("<!DOCTYPE html>\n<html>\n<head>\n")
+            f.write(f"  <title>{pkg} Releases</title>\n")
+            f.write("</head>\n<body>\n")
+            f.write(f"  <h1>{pkg} Releases</h1>\n")
+
+            # Sort files by filename so older releases are at the top, newer at bottom
+            for filename, url in sorted(files, key=lambda x: x[0]):
+                # Escaping URL characters just in case -- but have to handle
+                # #sha256=... separately
+                base_url: str
+                fragment: Optional[str]
+                if "#" in url:
+                    base_url, fragment = url.split("#", 1)
+                else:
+                    base_url, fragment = url, None
+
+                parsed_url: urllib.parse.ParseResult = urllib.parse.urlparse(base_url)
+                safe_path: str = urllib.parse.quote(parsed_url.path)
+                safe_url = parsed_url._replace(path=safe_path).geturl()
+                if fragment:
+                    safe_url = f"{safe_url}#{fragment}"
+
+                f.write(f'  <a href="{safe_url}">{filename}</a><br/>\n')
+
+            f.write("</body>\n</html>\n")
+
+    print(f"Done! Static index files generated in '{OUTPUT_DIR}/'.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

This PR provides CI to run nightly wheel builds at 02:00. These will be created always with the next version (based on the `meson.build`) + the tag `+dev`.

The PR also provides a script and associated CI to create a PEP503 simple package index for retrieving LUTE wheels. This should be available at https://slac-lcls.github.io/lute/wheels .

So using pip you could run:
```bash
pip install lute-lcls=0.3.0+dev --extra-index-url https://slac-lcls.github.io/lute/wheels
```

To get the current nighly/dev wheel for the next version (0.3.0 at time of PR). Both the nightly build and index creation CI have `workflow_dispatch` triggers so should be runnable manually at any time as well when a one-off is required.


## Checklist
- [x] `release_nightly.yml` workflow for creating nightly builds from the dev branch.
- [x] `utilities/wheels/build_index.py` for a script to create a PEP 503 simple index.
- [x] `build_index.yml` for the CI to run the index-building script.

## PR Type:
- [x] New feature/Enhancement

## Address issues:

# Testing

## Functional

## Unit

# Screenshots
