### PR TITLE
ENH Add beamline summaries third-party task

### DIFF
--- a/config/templates/smd.patch
+++ b/config/templates/smd.patch
@@ -33,3 +33,241 @@ index 9f52b00..2b50c9b 100755
          requests.post(
              os.environ["JID_UPDATE_COUNTERS"],
              json=[
+diff --git a/summaries/BeamlineSummaryPlots_mfx.py b/summaries/BeamlineSummaryPlots_mfx.py
+index dbd21ac..f0a3735 100755
+--- a/summaries/BeamlineSummaryPlots_mfx.py
++++ b/summaries/BeamlineSummaryPlots_mfx.py
+@@ -297,7 +297,7 @@ try:
+     ).options(color="r")
+     ipmDownTimeMed = hv.Points(
+         (eventTimeRMed, ipmDownMed),
+-        kdims=[eventTimeDim, ipmUpDim],
++        kdims=[eventTimeDim, ipmDownDim],
+         label=ipmDownDim.label,
+     ).options(color="m")
+ 
+@@ -321,10 +321,10 @@ else:
+     lxtPlot = None
+ 
+ gspec = pn.GridSpec(
+-    sizing_mode="stretch_both", max_width=700, name="Data Quality - Run %d" % run
++    sizing_mode="stretch_both", max_width=1000, max_height=1000, name="Data Quality - Run %d" % run
+ )
+-gspec[0:2, 0:8] = pn.Column(ipmTimeLayout)
+-gspec[2:5, 0:4] = pn.Column(ipmLayout)
++gspec[0:4, 0:4] = pn.Column(ipmTimeLayout)
++gspec[0:4, 4:8] = pn.Column(ipmLayout)
+ 
+ detNames: list = [
+     "jungfrau",
+@@ -343,7 +343,7 @@ for detname in detNames:
+         damageVar = h5[damageDim.name][evtFilter]
+         damagePlot = rolling(
+             hv.Curve(damageVar, vdims=[damageDim], label=f"{detname}").opts(
+-                axiswise=True, color=hv.Palette("Spectral")
++                axiswise=True, color=hv.Palette("Spectral"), title=f"Damage {detname}"
+             ),
+             rolling_window=10,
+         )
+@@ -351,12 +351,20 @@ for detname in detNames:
+         continue
+     plots.append(damagePlot)
+ 
+-multiDamagePlot = hv.Overlay(plots).opts(
+-    xlabel="Event (rolling average of 10)",
+-    ylabel="Present (Yes/No)",
+-    title="Missing/Damaged Data",
++damagePanels = (
++    hv.Layout(plots)
++    .opts(
++        hv.opts.Curve(
++            xlabel="Event (rolling average of 10)",
++            ylabel="Present (Yes/No)",
++            axiswise=True,
++        )
++    )
++    .cols(len(plots))
++    if plots
++    else hv.Curve([]).opts(title="No Damage Data")
+ )
+-gspec[2:5, 4:8] = multiDamagePlot
++gspec[4:6, 0:8] = damagePanels
+ 
+ 
+ #########################################
+@@ -365,6 +373,7 @@ gspec[2:5, 4:8] = multiDamagePlot
+ import matplotlib.pyplot as plt
+ 
+ detImgs = []
++detHists = []
+ detGrids = []
+ for detImgName in h5["Sums"].keys():
+     image = h5[f"Sums/{detImgName}"][()]
+@@ -407,14 +416,33 @@ for detImgName in h5["Sums"].keys():
+     # between panels!!
+     detImgs.append(
+         hv.Image(imageR, vdims=[imgDim], name=imgDim.label)
+-        .options(colorbar=True, cmap="rainbow")
++        .options(colorbar=True, cmap="viridis")
+         .opts(shared_axes=False)
+     )
+ 
++    hist, bins = np.histogram(imageR.flatten(), bins='auto', range=(np.nanpercentile(imageR, 1.0), np.nanpercentile(imageR, 99.0)))
++    histDim = hv.Dimension(
++        ("hist", detImgName.replace("Sums/", "").replace("_calib_img", " Pixel Histogram")),
++        range=(np.nanpercentile(imageR, 1.0), np.nanpercentile(imageR, 99.0)),
++    )
++    detHists.append(
++        hv.Histogram((hist, bins), kdims=[histDim], label=histDim.label).opts(
++            fill_color="#21918c",
++            line_color="black",
++            line_width=0.2,
++            alpha=0.85,
++            title=histDim.label,
++            xlabel="Pixel Intensity",
++            ylabel="Count",
++            invert_axes=True,
++        )
++    )
++
+     detGrid = pn.GridSpec(
+-        sizing_mode="stretch_both", max_width=700, name=detImgName.replace("Sums/", "")
++        sizing_mode="stretch_both", max_width=1600, max_height=1000, name=detImgName.replace("Sums/", "")
+     )
+-    detGrid[0, 0] = pn.Row(detImgs[-1])
++    detGrid[0:2, 0:2] = pn.Row(detImgs[-1])
++    detGrid[0:2, 2] = pn.Row(detHists[-1])
+     detGrids.append(detGrid)
+ 
+ if nOff > 100:
+@@ -464,18 +492,82 @@ if nOff > 100:
+         )
+         detImgs.append(
+             hv.Image(imageR, vdims=[imgOffDim], name=imgOffDim.label).options(
+-                colorbar=True, cmap="rainbow"
++                colorbar=True, cmap="viridis"
+             )
+         )
+ 
+         detGrid = pn.GridSpec(
+             sizing_mode="stretch_both",
+-            max_width=700,
++            max_width=1600,
++            max_height=1000,
+             name="%s, dropped shots" % detName,
+         )
+         detGrid[0, 0] = pn.Row(detImgs[-1])
+         detGrids.append(detGrid)
+ 
++#################
++# Intensity Plots
++#################
++
++# IPM CORRELATION
++#################
++corrGrids = []
++for detName in detNames:
++    try:
++        azav = h5[f"{detName}/azav_azav"][evtFilter]
++    except:
++        try:
++            azav = h5[f"{detName}/pyfai_azav"][evtFilter]
++        except:
++            continue
++
++    if len(azav.shape) > 2:
++        total_scatt = np.nanmean(azav, axis=(1, 2))
++    else:
++        total_scatt = np.nanmean(azav, axis=1)
++
++    scatterDim = hv.Dimension((f"{detName} Scattering", f"{detName} Scattering"))
++    corrGrid = pn.GridSpec(
++        sizing_mode="stretch_both", max_width=1000, max_height=1000, name=f"{detName} Correlation with IPM"
++    )
++
++    # ip4
++    try:
++        ipmDim = hv.Dimension((f"{detName} DG1", f"{detName} DG1"))
++        ip4_plot = hv.HexTiles(
++            (ipmUpVar, total_scatt), kdims=[ipmDim, scatterDim]
++        ).opts(cmap="viridis", xlabel=ipmDim.label, ylabel=scatterDim.label, title=f"{detName} Scattering vs DG1")
++        corrGrid[0:2, 0:2] = ip4_plot
++    except Exception as e:
++        print(e)
++        ip4_plot = None
++
++    # ip5
++    try:
++        ipmDim = hv.Dimension((f"{detName} DG2", f"{detName} DG2"))
++        ip5_plot = hv.HexTiles(
++            (ipmDownVar, total_scatt), kdims=[ipmDim, scatterDim]
++        ).opts(cmap="viridis", xlabel=ipmDim.label, ylabel=scatterDim.label, title=f"{detName} Scattering vs DG2")
++        corrGrid[0:2, 2:4] = ip5_plot
++    except Exception as e:
++        print(e)
++        ip5_plot = None
++
++
++    try:
++        timeDim = hv.Dimension(("Time", "Time"))
++        time_plot = hv.HexTiles(
++            (eventTimeR, total_scatt), kdims=[timeDim, scatterDim]
++        ).opts(cmap="viridis", xlabel=timeDim.label, ylabel=scatterDim.label, title=f"{detName} Scattering vs Time")
++        corrGrid[2:4, 0:4] = time_plot
++    except Exception as e:
++        print(e)
++        time_plot = None
++
++    if ip4_plot or ip5_plot or time_plot:
++        corrGrids.append(corrGrid)
++
++
+ #############
+ # XES Plots
+ #############
+@@ -580,7 +672,7 @@ for det in ["epix100_0", "epix100_1"]:  # detNames:
+         )
+         # dimg_flip = np.fliplr(dimg)
+ 
+-        xes_grid = pn.GridSpec(max_width=700, name=f"XES (Droplet) - {det}")
++        xes_grid = pn.GridSpec(max_width=1000, max_height=1000, name=f"XES (Droplet) - {det}")
+         img_dim = hv.Dimension(("Image", "Image"))
+         spatial_dim = hv.Dimension(("Spatial Projection", "Spatial Projection"))
+         xes_dim = hv.Dimension(("XES Spectrum", "XES Spectrum"))
+@@ -609,7 +701,7 @@ for det in ["epix100_0", "epix100_1"]:  # detNames:
+         )
+ 
+         # DO ROI PROCESSING -----
+-        xes_roi_grid = pn.GridSpec(max_width=700, name=f"XES (ROIs) - {det}")
++        xes_roi_grid = pn.GridSpec(max_width=1000, max_height=1000, name=f"XES (ROIs) - {det}")
+         roi_nums, spatial_projs, xes_projs = processROIData(h5=h5, det_name=det)
+         for idx in range(len(roi_nums)):
+             roi_num: str = roi_nums[idx]
+@@ -647,7 +739,7 @@ for det in ["epix100_0", "epix100_1"]:  # detNames:
+ ###########
+ # FEE Plots
+ ###########
+-feeGrid = pn.GridSpec(max_width=700, name="FEE Stats")
++feeGrid = pn.GridSpec(max_width=1000, max_height=1000, name="FEE Stats")
+ try:
+     feeDamageDim = hv.Dimension(("damage/feespec", "FEE Present"))
+     feeDamageVar = h5[feeDamageDim.name][()]
+@@ -690,6 +782,9 @@ for xes_grid in xesPlots:
+ for detGrid in detGrids:
+     tabs.append(detGrid)
+ 
++for corrGrid in corrGrids:
++    tabs.append(corrGrid)
++
+ tabs.append(feeGrid)
+ 
+ if int(os.environ.get("RUN_NUM", "-1")) > 0:
+@@ -701,7 +796,7 @@ if int(os.environ.get("RUN_NUM", "-1")) > 0:
+ if save_elog:
+     from summaries.summary_utils import prepareHtmlReport
+ 
+-    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
++    pageTitleFormat = "BeamlineSummary/{run:04d}"
+     prepareHtmlReport(tabs, expname, run, pageTitleFormat)
+     postDetectorDamageMsg(
+         h5=h5,

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -15,6 +15,10 @@ Classes:
     AnalyzeSmallDataXESParameters(TaskParameters): Parameter model for the
         AnalyzeSmallDataXES Task. Used to determine spatial/temporal overlap
         based on XES difference signal and provide basic XES feedback.
+
+    RunBeamlineSummaryParameters(ThirdPartyParameters): Parameters for running
+        Small Data beamline summary scripts. Used to provide basic feedback on
+        beamline performance and data quality.
 """
 
 __all__ = [
@@ -22,6 +26,7 @@ __all__ = [
     "AnalyzeSmallDataXSSParameters",
     "AnalyzeSmallDataXASParameters",
     "AnalyzeSmallDataXESParameters",
+    "SummarizeBeamlineParameters",
 ]
 __author__ = "Gabriel Dorlhiac"
 
@@ -41,6 +46,7 @@ from pydantic import (
 
 from lute.io.models.base import TaskParameters, ThirdPartyParameters, TemplateConfig
 from lute.io.models.validators import validate_smd_path, template_parameter_validator
+from lute.io.db import read_latest_db_entry
 
 
 class SubmitSMDParameters(ThirdPartyParameters):
@@ -808,3 +814,64 @@ class AnalyzeSmallDataXESParameters(TaskParameters):
         0,
         description="If non-zero load ROIs in batches. Slower but may help OOM errors.",
     )
+
+
+class SummarizeBeamlineParameters(ThirdPartyParameters):
+    """Parameters for running Small Data beamline summary scripts.
+
+    This task runs the beamline summary scripts that generate summary plots for each run based on the Small Data HDF5 file.
+    """
+
+    class Config(ThirdPartyParameters.Config):
+        """Identical to super-class Config but includes a result."""
+
+        set_result: bool = False
+        """Whether the Executor should mark a specified parameter as a result."""
+
+    executable: str = Field("python", description="Python executable.", flag_type="")
+    python_script: str = Field(
+        "",
+        description="Path to the beamline summary Python script",
+        flag_type="",
+    )
+
+    experiment: str = Field(
+        os.environ.get("EXPERIMENT", ""),
+        description="Experiment Tag.",
+        flag_type="--",
+    )
+
+    run: str = Field(
+        os.environ.get("RUN_NUM", ""),
+        description="Run Number.",
+        flag_type="--",
+    )
+
+    postElog: bool = Field(
+        True,
+        description="Whether to post summary plots to the eLog. Requires url and credentials in environment variables.",
+        flag_type="--",
+    )
+
+    @validator("python_script", always=True)
+    def validate_summary_scripts(cls, python_script: str, values: Dict[str, Any]) -> str:
+        if python_script == "":
+            exp: str = values["lute_config"].experiment
+            hutch: str = exp[:3]
+            # Try from producer path
+            producer: Optional[str] = read_latest_db_entry(
+                f"{values['lute_config'].work_dir}", "SubmitSMD", "producer"
+            )
+            if producer:
+                smd_root: str = str(Path(producer).parent)
+            else:
+                # Try from default path
+                smd_root: str = f"/sdf/data/lcls/ds/{hutch}/{exp}/results/smalldata_tools"
+                if not os.path.exists(smd_root):
+                    raise ValueError(
+                        "Could not find smalldata_tools."
+                        "Please provide a valid path to the beamline summary script."
+                    )
+            path = f"{smd_root}/summaries/BeamlineSummaryPlots_{hutch}.py"
+            return path
+        return python_script

--- a/lute/io/models/smd.py
+++ b/lute/io/models/smd.py
@@ -854,7 +854,9 @@ class SummarizeBeamlineParameters(ThirdPartyParameters):
     )
 
     @validator("python_script", always=True)
-    def validate_summary_scripts(cls, python_script: str, values: Dict[str, Any]) -> str:
+    def validate_summary_scripts(
+        cls, python_script: str, values: Dict[str, Any]
+    ) -> str:
         if python_script == "":
             exp: str = values["lute_config"].experiment
             hutch: str = exp[:3]
@@ -866,7 +868,9 @@ class SummarizeBeamlineParameters(ThirdPartyParameters):
                 smd_root: str = str(Path(producer).parent)
             else:
                 # Try from default path
-                smd_root: str = f"/sdf/data/lcls/ds/{hutch}/{exp}/results/smalldata_tools"
+                smd_root: str = (
+                    f"/sdf/data/lcls/ds/{hutch}/{exp}/results/smalldata_tools"
+                )
                 if not os.path.exists(smd_root):
                     raise ValueError(
                         "Could not find smalldata_tools."

--- a/lute/managed_tasks.py
+++ b/lute/managed_tasks.py
@@ -7,7 +7,7 @@ here.
 import os
 
 from lute.execution.executor import Executor, MPIExecutor
-from lute.tasks.util.environment import setup_smd2_env
+from lute.tasks.util.environment import setup_smd1_env, setup_smd2_env
 from lute.tasks.tasklets import (
     clone_smalldata,
     compare_hkl_fom_summary,
@@ -52,6 +52,7 @@ SmallDataProducer.add_tasklet(
     set_result=False,
     set_summary=False,
 )
+SmallDataProducer.update_environment(setup_smd1_env)
 
 SmallDataProducer2: Executor = Executor("SubmitSMD")
 """Runs the production of a LCLS2 smalldata HDF5 file."""
@@ -117,6 +118,9 @@ SmallDataXASAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXAS")
 
 SmallDataXESAnalyzer: MPIExecutor = MPIExecutor("AnalyzeSmallDataXES")
 """Process XES results from a Small Data HDF5 file."""
+
+BeamlineSummarizer: Executor = Executor("SummarizeBeamline")
+"""Runs Small Data beamline summary scripts."""
 
 # Geometry
 ##########

--- a/lute/tasks/util/environment.py
+++ b/lute/tasks/util/environment.py
@@ -16,6 +16,7 @@ from typing import List, Dict, Optional
 
 import requests
 
+
 def setup_smd1_env() -> Dict[str, str]:
     """Setup environment variables smalldata_tools uses with psana1.
 
@@ -46,6 +47,7 @@ def setup_smd1_env() -> Dict[str, str]:
             print(e)
 
     return psana_vars
+
 
 def setup_smd2_env() -> Dict[str, str]:
     """Setup environment variables smalldata_tools uses with psana2.

--- a/lute/tasks/util/environment.py
+++ b/lute/tasks/util/environment.py
@@ -1,10 +1,11 @@
 """Functions containing more complex logic for Task environment configuration.
 
 Functions:
+    setup_smd1_env(): Sets up psana1 environment variables.
     setup_smd2_env(): Sets up psana2 environment variables.
 """
 
-__all__ = ["setup_smd2_env"]
+__all__ = ["setup_smd1_env", "setup_smd2_env"]
 __author__ = "Gabriel Dorlhiac"
 
 import os
@@ -15,6 +16,36 @@ from typing import List, Dict, Optional
 
 import requests
 
+def setup_smd1_env() -> Dict[str, str]:
+    """Setup environment variables smalldata_tools uses with psana1.
+
+    Tries to setup psana1 environment variables for setting up live mode.
+
+    Returns:
+        psana_vars (Dict[str,str]): Dictionary of relevant psana environment variables.
+    """
+    psana_vars: Dict[str, str] = {}
+    exp: Optional[str] = os.getenv("EXPERIMENT")
+    run: Optional[str] = os.getenv("RUN_NUM")
+    if exp and run:
+        base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
+        endpoint: str = f"{exp}/ws/{run}/files_for_live_mode_at_location"
+        full_url: str = f"{base_url}/{endpoint}"
+        try:
+            resp: requests.models.Response = requests.get(
+                full_url, params={"location": "S3DF"}
+            )
+            resp.raise_for_status()
+            data_dir = resp.json()["value"]["all_present"]
+
+            if data_dir:
+                psana_vars["SIT_PSDM_DATA"] = "/sdf/data/lcls/ds"
+            else:
+                psana_vars["SIT_PSDM_DATA"] = "/sdf/data/lcls/drpsrcf/ffb"
+        except Exception as e:
+            print(e)
+
+    return psana_vars
 
 def setup_smd2_env() -> Dict[str, str]:
     """Setup environment variables smalldata_tools uses with psana2.

--- a/workflows/common/summaries.dag
+++ b/workflows/common/summaries.dag
@@ -1,0 +1,16 @@
+!LUTE_DAG
+- !branch_daq2
+  daq2:
+    task_name: "SmallDataProducer2"
+    slurm_params: ""
+    next:
+    - task_name: "BeamlineSummarizer"
+      slurm_params: ""
+      next: []
+  daq1:
+    task_name: "SmallDataProducer"
+    slurm_params: ""
+    next:
+    - task_name: "BeamlineSummarizer"
+      slurm_params: ""
+      next: []


### PR DESCRIPTION
# Description

This small PR aims at adding a third-party task that calls the beamline summary script from `lute`. This will help centralizing all data analysis in feedback in one `lute` workflow.

# Checklist

- [ ] `SummarizeBeamlineParameters` model with hutch beamline summary script validator
- [ ] `BeamlineSummarizer` in `managed_tasks.py`
- [ ] Patch smd for latest changes for MFX ?

# PR Type

- [ ] Enhancement/New feature

# Test