### PR TITLE
MNT Update `lute` docs and configuration hutch YAMLs to reflect latest changes

### DIFF
--- a/config/cxi.yaml
+++ b/config/cxi.yaml
@@ -18,7 +18,13 @@ work_dir: ""
 # For out of memory issues try setting gather_interval
 SubmitSMD:
   # Command line arguments
-  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
+  #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
+  # LCLS1 (psana1)
+  producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_cxi.py"
   #run: 99
   #experiment: ""
   #stn: 0

--- a/config/mec.yaml
+++ b/config/mec.yaml
@@ -17,25 +17,14 @@ work_dir: ""
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
-  # ── Virtual environment install ────────────────────────────────────────────
-  # When using --fresh_install (venv), psana is not importable at parse time.
-  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
-  # Uncomment the block matching your DAQ generation and fill in the hutch name.
-  #
-  # LCLS1 (psana1):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd1_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mec.py"
-  #
-  # LCLS2 (psana2):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd2_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mec.py"
-  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
-  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
+  #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
+  # LCLS1 (psana1)
+  producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mec.py"
   #run: 99
   #experiment: ""
   #stn: 0

--- a/config/mec.yaml
+++ b/config/mec.yaml
@@ -17,6 +17,23 @@ work_dir: ""
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
+  # ── Virtual environment install ────────────────────────────────────────────
+  # When using --fresh_install (venv), psana is not importable at parse time.
+  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
+  # Uncomment the block matching your DAQ generation and fill in the hutch name.
+  #
+  # LCLS1 (psana1):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd1_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mec.py"
+  #
+  # LCLS2 (psana2):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd2_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mec.py"
+  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
   #run: 99

--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -96,27 +96,14 @@ ConvertSMDToNexus:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
-  # ── Virtual environment install ────────────────────────────────────────────
-  # When using --fresh_install (venv), psana is not importable at parse time.
-  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
-  # Uncomment the block matching your DAQ generation and fill in the hutch name.
-  #
-  # LCLS2 (psana2) — primary for MFX (LCLS-II instrument):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd2_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
-  #
-  # LCLS1 (psana1):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd1_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mfx.py"
-  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
-  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  # LCLS2 (psana2)
+  producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
   #run: 99
   #experiment: ""
   #stn: 0

--- a/config/mfx.yaml
+++ b/config/mfx.yaml
@@ -96,6 +96,23 @@ ConvertSMDToNexus:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
+  # ── Virtual environment install ────────────────────────────────────────────
+  # When using --fresh_install (venv), psana is not importable at parse time.
+  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
+  # Uncomment the block matching your DAQ generation and fill in the hutch name.
+  #
+  # LCLS2 (psana2) — primary for MFX (LCLS-II instrument):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd2_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_mfx.py"
+  #
+  # LCLS1 (psana1):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd1_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_mfx.py"
+  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -37,84 +37,85 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  #detnames: []
-  #epicsPV: []
-  #epicsOncePV: []
-  #ttCalib: []
-  # Provide detector image sum algorithms.
-  # If detSumAlgos is not defined, it will default to calib, calib_dropped and
-  # calib_dropped_square for every detector. You can add processing algorithms for
-  # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
-  # will apply to every detector defined in detnames by placing them under "all"
-  #detSumAlgos:
-  #  all:
-  #    - "calib"
-  #    - "calib_dropped"
-  #    - "calib_dropped_square"
-  #    - "calib_thresADU1"
-  #  epix10k2M:
-  #    - "calib_thresADU5"
-  #    - "calib_max"
-  #  Rayonix:
-  #    - "calib_skipFirst_thresADU1"
-  #    - "calib_skipFirst_max"
-  #getROIs:
-  #  jungfrau1M:   # Change to detector name
-  #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
-  #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
-  #    thresADU: None
-  #getAzIntParams:
-  #  Rayonix:
-  #    eBeam: 18
-  #    center: [87526.79161840, 92773.3296889500]
-  #    dis_to_sam: 80.0
-  #    tx: 0
-  #    ty: 0
-  #getAzIntPyFAIParams:
-  #  Rayonix:
-  #    pix_size: 176e-6
-  #    ai_kwargs:
-  #      dist: 1
-  #      poni1: 960 * 1.76e-4
-  #      poni2: 960 * 1.76e-4
-  #    npts: 512
-  #    int_units: "2th_deg"
-  #    return2d: False
-  #getPhotonsParams:
-  #  jungfrau1M:
-  #    ADU_per_photon: 9.5
-  #    thresADU: 0.8
-  #getDropletParams:
-  #  epix_1:
-  #    threshold: 5
-  #    thresholdLow: 5
-  #    thresADU: 60
-  #    useRms: True
-  #    nData: 1e5
-  #getDroplet2Photons:
-  #  epix_alc1:
-  #    droplet:
-  #      threshold: 10
-  #      thresholdLow: 3
-  #      thresADU: 10
-  #      useRms: True
-  #    d2p:
-  #      aduspphot: 162
-  #      mask: np.load('path_to_mask.npy')
-  #      cputime: True
-  #    nData: 3e4
-  #getSvdParams:
-  #  acq_0:
-  #    basis_file: None
-  #    n_pulse: 1
-  #    delay: None
-  #    return_reconstructed: True
-  #getAutocorrParams:
-  #  epix_2:
-  #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
-  #    thresAdu: [72.0, 1.0e6]
-  #    save_range: [70, 50]
-  #    save_lineout: True
+  producer_parameters:
+    #detnames: []
+    #epicsPV: []
+    #epicsOncePV: []
+    #ttCalib: []
+    # Provide detector image sum algorithms.
+    # If detSumAlgos is not defined, it will default to calib, calib_dropped and
+    # calib_dropped_square for every detector. You can add processing algorithms for
+    # single detectors (e.g. epix10k2M or Rayonix) as below, or add algorithms which
+    # will apply to every detector defined in detnames by placing them under "all"
+    #detSumAlgos:
+    #  all:
+    #    - "calib"
+    #    - "calib_dropped"
+    #    - "calib_dropped_square"
+    #    - "calib_thresADU1"
+    #  epix10k2M:
+    #    - "calib_thresADU5"
+    #    - "calib_max"
+    #  Rayonix:
+    #    - "calib_skipFirst_thresADU1"
+    #    - "calib_skipFirst_max"
+    #getROIs:
+    #  jungfrau1M:   # Change to detector name
+    #    ROIs: [[[1, 2], [157, 487], [294, 598]]]
+    #    writeArea: True   # Whether to save ROI, if False, save sum but not img.
+    #    thresADU: None
+    #getAzIntParams:
+    #  Rayonix:
+    #    eBeam: 18
+    #    center: [87526.79161840, 92773.3296889500]
+    #    dis_to_sam: 80.0
+    #    tx: 0
+    #    ty: 0
+    #getAzIntPyFAIParams:
+    #  Rayonix:
+    #    pix_size: 176e-6
+    #    ai_kwargs:
+    #      dist: 1
+    #      poni1: 960 * 1.76e-4
+    #      poni2: 960 * 1.76e-4
+    #    npts: 512
+    #    int_units: "2th_deg"
+    #    return2d: False
+    #getPhotonsParams:
+    #  jungfrau1M:
+    #    ADU_per_photon: 9.5
+    #    thresADU: 0.8
+    #getDropletParams:
+    #  epix_1:
+    #    threshold: 5
+    #    thresholdLow: 5
+    #    thresADU: 60
+    #    useRms: True
+    #    nData: 1e5
+    #getDroplet2Photons:
+    #  epix_alc1:
+    #    droplet:
+    #      threshold: 10
+    #      thresholdLow: 3
+    #      thresADU: 10
+    #      useRms: True
+    #    d2p:
+    #      aduspphot: 162
+    #      mask: np.load('path_to_mask.npy')
+    #      cputime: True
+    #    nData: 3e4
+    #getSvdParams:
+    #  acq_0:
+    #    basis_file: None
+    #    n_pulse: 1
+    #    delay: None
+    #    return_reconstructed: True
+    #getAutocorrParams:
+    #  epix_2:
+    #    mask: "/sdf/home/e/example/dataAna/mask_epix.npy"
+    #    thresAdu: [72.0, 1.0e6]
+    #    save_range: [70, 50]
+    #    save_lineout: True
 
 
 AnalyzeSmallDataXSS:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,7 +11,12 @@ work_dir: "/sdf/scratch/users/d/dorlhiac"
 ---
 SubmitSMD:
   # Command line arguments
+  #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
+  #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
   producer: "/sdf/data/lcls/ds/mfx/mfxl1013621/results/smalldata_tools/producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py"
+    output_path: "/sdf/data/lcls/ds/mfx/mfxl1013621/results/smalldata_tools/producers/smalldata_producer_template.py"
   run: 99
   experiment: "mfxl1013621"
   #stn: 0

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -76,27 +76,14 @@ AnalyzeSmallDataXES:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
-  # ── Virtual environment install ────────────────────────────────────────────
-  # When using --fresh_install (venv), psana is not importable at parse time.
-  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
-  # Uncomment the block matching your DAQ generation and fill in the hutch name.
-  #
-  # LCLS1 (psana1):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd1_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xcs.py"
-  #
-  # LCLS2 (psana2):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd2_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_xcs.py"
-  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
-  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  # LCLS1 (psana1)
+  producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xcs.py"
   #run: 99
   #experiment: ""
   #stn: 0

--- a/config/xcs.yaml
+++ b/config/xcs.yaml
@@ -76,6 +76,23 @@ AnalyzeSmallDataXES:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
+  # ── Virtual environment install ────────────────────────────────────────────
+  # When using --fresh_install (venv), psana is not importable at parse time.
+  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
+  # Uncomment the block matching your DAQ generation and fill in the hutch name.
+  #
+  # LCLS1 (psana1):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd1_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xcs.py"
+  #
+  # LCLS2 (psana2):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd2_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_xcs.py"
+  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -76,6 +76,23 @@ AnalyzeSmallDataXES:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
+  # ── Virtual environment install ────────────────────────────────────────────
+  # When using --fresh_install (venv), psana is not importable at parse time.
+  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
+  # Uncomment the block matching your DAQ generation and fill in the hutch name.
+  #
+  # LCLS1 (psana1):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd1_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xpp.py"
+  #
+  # LCLS2 (psana2):
+  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  #lute_template_cfg:
+  #  template_name: "smd2_prod_config_template.py"
+  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_xpp.py"
+  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar

--- a/config/xpp.yaml
+++ b/config/xpp.yaml
@@ -76,27 +76,14 @@ AnalyzeSmallDataXES:
 # Set `directory` if you want to write to a different folder
 # For out of memory issues try setting gather_interval
 SubmitSMD:
-  # ── Virtual environment install ────────────────────────────────────────────
-  # When using --fresh_install (venv), psana is not importable at parse time.
-  # The `producer` and `lute_template_cfg` fields cannot be auto-determined.
-  # Uncomment the block matching your DAQ generation and fill in the hutch name.
-  #
-  # LCLS1 (psana1):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd1_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_xpp.py"
-  #
-  # LCLS2 (psana2):
-  #producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
-  #lute_template_cfg:
-  #  template_name: "smd2_prod_config_template.py"
-  #  output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_xpp.py"
-  # ───────────────────────────────────────────────────────────────────────────
   # Command line arguments
   #map_by: "core"   # MPI resource mapping - take care with changing unless familiar
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
-  #producer: "/path/to/smalldata_tools/producers/smd_producer.py"
+  # LCLS2 (psana2)
+  producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_xpp.py"
   #run: 99
   #experiment: ""
   #stn: 0

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -13,7 +13,7 @@ Usage: `setup_lute [-h] [-d] -e EXPERIMENT [-fi] [-fb] [-D DIRECTORY] [--test] [
 Parameters:
 
 - `-e EXPERIMENT, --experiment EXPERIMENT`: The experiment to perform setup for.
-- `-fi, --fresh_install`: Install a new version of LUTE in the experiment folder via an isolated virtual environment (`lute-lcls` from PyPI). This allows for local modifications of code. Otherwise, the central installation will be used (which cannot be modified).
+- `-fi, --fresh_install`: **(Recommended)** Install `lute-lcls` from PyPI into isolated Python virtual environments (`lute_env_py39`, `lute_env_py311`) in the experiment folder. No compilation required. Uses stable release tags or nightly `dev` builds.
 - `-fb, --fresh_build`: Install a new version of LUTE by cloning the repository and building from source. Use this if you need to modify LUTE's C-extensions or want full source access.
 - `-D DIRECTORY, --directory DIRECTORY`: Subdirectory name within the experiment results folder to use for LUTE output. If not specified, the results folder is used directly.
 - `--test`: Use test Airflow instance. Only needed for bleeding-edge workflows.
@@ -30,7 +30,7 @@ The example starting points are:
 - `sfx` : Perform end-to-end SFX analysis with molecular replacement.
 - `smd` : Run managed `smalldata_tools` and downstream analysis/summaries.
 
-Providing SLURM arguments is not required, but **highly recommended**. The setup script will try to set some default values for `--partition`, `--account`, and `--ntasks`, depending on the experiment and workflow you are running. If these three arguments are not provided, it will prompt you for each one and tell you the default it has selected. Press enter (or any key) to accept. Otherwise, press `Ctrl-C` to exit the setup, and pass the arguments manually.
+Providing SLURM arguments is not required, but **highly recommended**. The setup script will prompt for sensible defaults for `--partition`, `--account`, `--nodes`, and `--ntasks` if they are not provided. For `--partition` and `--account`, workflow-specific defaults are selected based on the experiment; for `--nodes` and `--ntasks`, the default is 1. Press enter (or any key) to accept each default, or press `Ctrl-C` to exit and pass the arguments manually.
 
 The `setup_lute` script will create the eLog job for your selected workflow. Results will be presented back to you in the eLog. The script will also produce a configuration file which will live at `/sdf/data/lcls/ds/<hutch>/<experiment>/results/lute_output/<hutch>_lute.yaml`. You will want to modify this configuration prior to running. See [Basic Usage](/#basic-usage) below for more information.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -8,15 +8,17 @@ This package is used to run arbitrary analysis code (first-party or third-party)
 #### On S3DF for experiment analysis
 You, or your analysis point-of-contact should run the provided `setup_lute` script located at `/sdf/group/lcls/ds/tools/lute/dev/lute/utilities/setup_lute`
 
-Usage: `setup_lute [-h] [-d] -e EXPERIMENT [-f] [--test] [-v VERSION] [-w WORKFLOW] [SLURM_ARGS ...]`
+Usage: `setup_lute [-h] [-d] -e EXPERIMENT [-fi] [-fb] [-D DIRECTORY] [--test] [-v VERSION] [-W WORKFLOW [WORKFLOW ...]] [SLURM_ARGS ...]`
 
 Parameters:
 
 - `-e EXPERIMENT, --experiment EXPERIMENT`: The experiment to perform setup for.
-- `-f, --fresh_install`: Install a new version of LUTE in the experiment folder. This allows for local modifications of code. Otherwise, the central installation will be used (which cannot be modified).
+- `-fi, --fresh_install`: Install a new version of LUTE in the experiment folder via an isolated virtual environment (`lute-lcls` from PyPI). This allows for local modifications of code. Otherwise, the central installation will be used (which cannot be modified).
+- `-fb, --fresh_build`: Install a new version of LUTE by cloning the repository and building from source. Use this if you need to modify LUTE's C-extensions or want full source access.
+- `-D DIRECTORY, --directory DIRECTORY`: Subdirectory name within the experiment results folder to use for LUTE output. If not specified, the results folder is used directly.
 - `--test`: Use test Airflow instance. Only needed for bleeding-edge workflows.
 - `-v VERSION, --version VERSION`: Version of LUTE to use. Corresponds to release tag or `dev`. Defaults to `dev`.
-- `-W WORKFLOW, --workflow WORKFLOW`: Which analysis workflow to run. Defaults to `smd`.
+- `-W WORKFLOW [WORKFLOW ...], --workflow WORKFLOW [WORKFLOW ...]`: Which analysis workflow(s) to run. Accepts one or more workflow names, e.g. `-W smd bayfai`. Defaults to `smd`.
 - `-d, --debug`: Turn on verbose logging.
 - `[SLURM ARGS]`: This is any number of SLURM arguments you want to run your workflow with. You will likely want to provide `--ntasks` at a minimum.
 
@@ -30,7 +32,7 @@ The example starting points are:
 
 Providing SLURM arguments is not required, but **highly recommended**. The setup script will try to set some default values for `--partition`, `--account`, and `--ntasks`, depending on the experiment and workflow you are running. If these three arguments are not provided, it will prompt you for each one and tell you the default it has selected. Press enter (or any key) to accept. Otherwise, press `Ctrl-C` to exit the setup, and pass the arguments manually.
 
-The `setup_lute` script will create the eLog job for your selected workflow. Results will be presented back to you in the eLog. The script will also produce a configuration file which will live at `/sdf/data/lcls/ds/<hutch>/<experiment>/results/lute_output/<hutch>.yaml`. You will want to modify this configuration prior to running. See [Basic Usage](/#basic-usage) below for more information.
+The `setup_lute` script will create the eLog job for your selected workflow. Results will be presented back to you in the eLog. The script will also produce a configuration file which will live at `/sdf/data/lcls/ds/<hutch>/<experiment>/results/lute_output/<hutch>_lute.yaml`. You will want to modify this configuration prior to running. See [Basic Usage](/#basic-usage) below for more information.
 
 #### Locally or otherwise
 LUTE is publically available on [GitHub](https://github.com/slac-lcls/lute). In order to run it, the first step is to clone the repository:
@@ -76,7 +78,7 @@ Running analysis with LUTE is the process of submitting one or more **managed** 
 **Note:** You configure `Task`s, but submit **managed** `Task`s. If you run the help utility described below, and in the usage manual, you can find which **managed** `Task`s correspond to which `Task`s. In general, `Task`s are verbs and the `Executor`s that run them (i.e. **managed** `Task`s) are nouns. E.g. the `FindPeaksSFX` `Task`, is run by submitting the `PeakFinderSFX` **managed** `Task`. There may be many **managed** `Task`s which submit the same underlying `Task`, but in different environments.
 
 ### Config YAML
-If you ran the `setup_lute` script you will already have a `<hutch>.yaml` file located in your experiment results folder. This YAML file is commented by `Task`. You will **need** to modify a few of these parameters for some of the `Task`s. E.g. a partial example of the config file may look like this:
+If you ran the `setup_lute` script you will already have a `<hutch>_lute.yaml` file located in your experiment results folder. This YAML file is commented by `Task`. You will **need** to modify a few of these parameters for some of the `Task`s. E.g. a partial example of the config file may look like this:
 
 ```yaml
 %YAML 1.3

--- a/docs/usage/hello_world.md
+++ b/docs/usage/hello_world.md
@@ -2,9 +2,14 @@
 This simple example will walk you through running the `Test` `Task`, which simply counts to 10 and then succeed or fails depending on the configuration.
 Please note that this should be run on psana in S3DF, as for now it relies on the specific path of the `psconda` environment.
 
-Clone the Lute repository and run the installation script:
+Install LUTE using `setup_lute` (see [Installation](/usage/installation) for full details).
+The recommended path is the virtual environment install:
 ```bash
-> ./build.sh
+# Recommended: virtual environment install (no compilation required)
+> setup_lute -fi -e <EXPERIMENT>
+
+# Alternative: source build (for developers who need to modify C-extensions)
+> setup_lute -fb -e <EXPERIMENT>
 ```
 
 Start by creating the following `yaml` configuration file for the `Task`.

--- a/docs/usage/hello_world.md
+++ b/docs/usage/hello_world.md
@@ -36,9 +36,14 @@ Start by sourcing the relevant environments:
 ```bash
 > source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
 ```
-and
+and activate the LUTE installation. The activation step depends on how LUTE was installed:
+
 ```bash
-> source <PATH_TO_LUTE>/install/bin/activate_installation
+# If you used --fresh_install (virtual environment):
+source lute_envs/lute_env_py311/bin/activate   # or lute_env_py39
+
+# If you used --fresh_build (source build):
+source <PATH_TO_LUTE>/install/bin/activate_installation
 ```
 
 Now, simply call

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -32,7 +32,7 @@ This will:
    - `lute_envs/lute_env_py39/`
    - `lute_envs/lute_env_py311/`
 3. Install `lute-lcls` from PyPI into each environment. Stable release tags
-   (e.g. `0.3.0`) and a nightly `dev` build are available.
+   (e.g. `0.2.0`) and a nightly `dev` build are available.
 4. Produce a configuration file at
    `<results>/lute_output/<hutch>_lute.yaml`.
 
@@ -41,7 +41,7 @@ This will:
 | `VERSION` value | Package installed |
 |---|---|
 | `dev` | Nightly pre-release wheel (built from `dev` branch via CI) |
-| `0.3.0`, etc. | Pinned stable release from PyPI |
+| `0.2.0`, etc. | Pinned stable release from PyPI |
 
 ### Environment variables set at runtime
 
@@ -61,16 +61,15 @@ path is used; otherwise `bin/activate_installation` (meson build) is used.
 
 ```bash
 # Activate the primary virtual environment (Python 3.9 or 3.11)
-source <results>/lute_envs/lute_env_py311/bin/activate   # or lute_env_py39
+source <path>/<to>/lute_envs/lute_env_py311/bin/activate   # or lute_env_py39
 ```
 
 ---
 
 ## Developer / Advanced: Source Build
 
-If you need to modify LUTE's C-extensions (e.g. Peakfinder8) or want full
-source access, use the `setup_lute -fb` / `--fresh_build` flag, or build
-manually with `build.sh`.
+If you need to modify LUTE's source code, use the `setup_lute -fb` / `--fresh_build` flag,
+or build manually with `build.sh` after cloning the repository.
 
 ### Using `setup_lute -fb`
 

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -51,13 +51,16 @@ For a **stable release** (available on the standard PyPI index):
 pip install lute-lcls==0.3.0
 ```
 
+*Nota Bene*
+Version 0.3.0 will be released soon!
+
 For a **nightly build**: wheels are built and published at 3 AM from the `dev`
 branch and are available from a self-hosted PEP 503 simple package index at
 `https://slac-lcls.github.io/lute/wheels`. Pass `--extra-index-url` to pip:
 
 ```bash
 # Pin to a specific nightly (version identifier uses the +dev local label):
-pip install lute-lcls==v0.3.0+dev --extra-index-url https://slac-lcls.github.io/lute/wheels
+pip install lute-lcls==0.3.0+dev --extra-index-url https://slac-lcls.github.io/lute/wheels
 
 # Or install the latest nightly without pinning a version:
 pip install lute-lcls --extra-index-url https://slac-lcls.github.io/lute/wheels --pre

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -9,7 +9,79 @@ It can therefore be retrieved on the command-line using:
 # or git clone https://github.com/slac-lcls/lute.git for https
 ```
 
-## Building the Package
+---
+
+## Recommended: Virtual Environment Install
+
+The simplest way to install `LUTE` is via a Python virtual environment using the
+`lute-lcls` package published on PyPI. This requires no C-extension compilation
+and is the recommended path for all experiment users.
+
+### Using `setup_lute -fi`
+
+On S3DF, run the provided `setup_lute` script with the `-fi` / `--fresh_install` flag:
+
+```bash
+setup_lute -fi -e <EXPERIMENT> [-v VERSION] [-W WORKFLOW [WORKFLOW ...]] [SLURM_ARGS ...]
+```
+
+This will:
+
+1. Create a `lute_envs/` directory inside your experiment results folder.
+2. Build two virtual environments — one for each supported Python version:
+   - `lute_envs/lute_env_py39/`
+   - `lute_envs/lute_env_py311/`
+3. Install `lute-lcls` from PyPI into each environment. Stable release tags
+   (e.g. `0.3.0`) and a nightly `dev` build are available.
+4. Produce a configuration file at
+   `<results>/lute_output/<hutch>_lute.yaml`.
+
+### Available versions
+
+| `VERSION` value | Package installed |
+|---|---|
+| `dev` | Nightly pre-release wheel (built from `dev` branch via CI) |
+| `0.3.0`, etc. | Pinned stable release from PyPI |
+
+### Environment variables set at runtime
+
+When using the virtual-environment install the submission scripts
+(`submit_slurm.sh`) automatically detect and export these variables:
+
+| Variable | Meaning |
+|---|---|
+| `LUTE_VIRTUAL_ENV` | Path to the active primary virtual environment directory |
+| `LUTE_VIRTUAL_ENV_PY39` | Path to the Python 3.9 interpreter in `lute_env_py39` |
+| `LUTE_VIRTUAL_ENV_PY311` | Path to the Python 3.11 interpreter in `lute_env_py311` |
+
+Detection logic: if `bin/activate` is present in the LUTE bin path the venv
+path is used; otherwise `bin/activate_installation` (meson build) is used.
+
+### Activating manually (for interactive use)
+
+```bash
+# Activate the primary virtual environment (Python 3.9 or 3.11)
+source <results>/lute_envs/lute_env_py311/bin/activate   # or lute_env_py39
+```
+
+---
+
+## Developer / Advanced: Source Build
+
+If you need to modify LUTE's C-extensions (e.g. Peakfinder8) or want full
+source access, use the `setup_lute -fb` / `--fresh_build` flag, or build
+manually with `build.sh`.
+
+### Using `setup_lute -fb`
+
+```bash
+setup_lute -fb -e <EXPERIMENT> [-v VERSION] [-W WORKFLOW [WORKFLOW ...]] [SLURM_ARGS ...]
+```
+
+This clones the repository into your results folder and runs `build.sh -e -r`
+automatically.
+
+### Building manually with `build.sh`
 
 At the top level of the directory is a script `build.sh` for building the code on S3DF.
 

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -43,6 +43,26 @@ This will:
 | `dev` | Nightly pre-release wheel (built from `dev` branch via CI) |
 | `0.2.0`, etc. | Pinned stable release from PyPI |
 
+### Installing manually (without `setup_lute`)
+
+For a **stable release** (available on the standard PyPI index):
+
+```bash
+pip install lute-lcls==0.3.0
+```
+
+For a **nightly build**: wheels are built and published at 3 AM from the `dev`
+branch and are available from a self-hosted PEP 503 simple package index at
+`https://slac-lcls.github.io/lute/wheels`. Pass `--extra-index-url` to pip:
+
+```bash
+# Pin to a specific nightly (version identifier uses the +dev local label):
+pip install lute-lcls==v0.3.0+dev --extra-index-url https://slac-lcls.github.io/lute/wheels
+
+# Or install the latest nightly without pinning a version:
+pip install lute-lcls --extra-index-url https://slac-lcls.github.io/lute/wheels --pre
+```
+
 ### Environment variables set at runtime
 
 When using the virtual-environment install the submission scripts

--- a/docs/usage/running_lute.md
+++ b/docs/usage/running_lute.md
@@ -191,6 +191,21 @@ A number of environment variables can be set to control certain aspects of LUTE 
 - `LUTE_DB_SPEC_VERSION`: Set to determine the database specification version. Either 1 or 2, currently.
 - `LUTE_MAESTRO_LOG_LEVEL`: Set the logging level for the workflow manager `maestro`. Can be `trace`, `debug`, `info`, `warning`, `error`. The settings can also be set per logger. E.g. `LUTE_MAESTRO_LOG_LEVEL=debug,HTTP:Server=trace`.
 
+#### Virtual Environment Variables
+
+When LUTE is installed via `setup_lute -fi` (virtual environment install), the submission
+scripts automatically detect the install type and export additional variables:
+
+| Variable | Set by | Meaning |
+|---|---|---|
+| `LUTE_VIRTUAL_ENV` | `submit_slurm.sh` (venv path) | Path to the active primary virtual environment directory |
+| `LUTE_VIRTUAL_ENV_PY39` | `submit_slurm.sh` (venv path) | Path to the Python 3.9 interpreter in the sibling `lute_env_py39` virtual environment |
+| `LUTE_VIRTUAL_ENV_PY311` | `submit_slurm.sh` (venv path) | Path to the Python 3.11 interpreter in the sibling `lute_env_py311` virtual environment |
+
+**Install-type detection:** the submit scripts check whether `bin/activate` is present
+in the LUTE bin path. If so, the venv path is used and the variables above are exported.
+Otherwise, `bin/activate_installation` (meson/prefix build) is sourced instead.
+
 A number of other environment variables are used (`LUTE_PATH`, `LUTE_EXECUTOR_HOST`, as examples). These, however, are set internally and are not intended to be managed by users. They will appear in the database records, however.
 
 #### Debug Environment Variables

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -81,7 +81,7 @@ SubmitSMD:
     template_name: "smd2_prod_config_template.py"
     output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_<hutch>.py"
   producer_parameters:
-    detnames: ["epix10k2M"]
+    detnames: ["jungfrau"]
     # ...
 ```
 
@@ -94,11 +94,6 @@ these paths resolve to real filesystem paths by the time the validators execute.
 > **Important:** `producer_parameters` must always be nested under that key — not
 > directly under `SubmitSMD` — or the values are silently ignored and never passed
 > to the producer.
-
-The hutch YAML templates (`config/mfx.yaml`, `config/xcs.yaml`, etc.) include
-commented-out blocks for both DAQ generations in the `SubmitSMD` section. Uncomment
-the block that matches your case.
-
 ---
 
 ## Configuration
@@ -112,6 +107,9 @@ SubmitSMD:
   #bind_to: "core"  # MPI resource binding - take care with changing unless familiar
   #np: 5
   #producer: "/path/to/producer"
+  #lute_template_cfg:
+    #template_name: "smdX_prod_config_template.py"
+    #output_path: "path/to/prod_config_hutch"
   #run: "{{ run }}"
   #experiment: "{{ experiment }}"
   #stn: 0

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -33,6 +33,74 @@ smalldata_tools (via the `Task` `SubmitSMD`) can be run in various environments 
 - `SmallDataProducer2`: Run the psana2 smalldata_tools production
 - `SmallDataProducerSpack`: Run the psana2 smalldata_tools production, **in the spack environment**. This is required for compression features.
 
+## Running with a Virtual Environment Install
+
+When LUTE is installed with `setup_lute -fi` (the `--fresh_install` virtual-environment
+path), the executor runs inside the venv Python. The psana conda environment is only
+sourced in the batch script that spawns the Task subprocess — **after** parameter
+parsing. This matters for `SubmitSMD` because two Pydantic validators in
+`lute/io/models/smd.py` (lines 573–646, `validate_producer_path` and `use_producer`)
+call `import psana` at parse time to auto-determine the correct producer path and
+template. In the venv `psana` is absent, so these validators raise:
+
+```
+ValueError: psana not available, cannot determine producer path
+```
+
+To avoid this error you must set `producer` and `lute_template_cfg` explicitly in
+your YAML.
+
+### Fields to set
+
+| Field | Type | Description |
+|---|---|---|
+| `producer` | string | Absolute path to `smd_producer.py` for the target DAQ generation |
+| `lute_template_cfg` | mapping | Nested object with `template_name` and `output_path` |
+
+Both fields live directly under `SubmitSMD:` (not under `producer_parameters:`).
+
+### LCLS1 (psana1) example
+
+```yaml
+SubmitSMD:
+  producer: "{{ work_dir }}/smalldata_tools/lcls1_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd1_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls1_producers/prod_config_<hutch>.py"
+  producer_parameters:
+    detnames: ["epix10k2M"]
+    # ...
+```
+
+### LCLS2 (psana2) example
+
+```yaml
+SubmitSMD:
+  producer: "{{ work_dir }}/smalldata_tools/lcls2_producers/smd_producer.py"
+  lute_template_cfg:
+    template_name: "smd2_prod_config_template.py"
+    output_path: "{{ work_dir }}/smalldata_tools/lcls2_producers/prod_config_<hutch>.py"
+  producer_parameters:
+    detnames: ["epix10k2M"]
+    # ...
+```
+
+The `{{ work_dir }}` placeholder is substituted before Pydantic validation runs, so
+these paths resolve to real filesystem paths by the time the validators execute.
+`smalldata_tools` itself will be cloned to `<work_dir>/smalldata_tools/` (three
+`.parent` steps up from the `producer` path, as implemented in
+`lute/tasks/tasklets.py:186`).
+
+> **Important:** `producer_parameters` must always be nested under that key — not
+> directly under `SubmitSMD` — or the values are silently ignored and never passed
+> to the producer.
+
+The hutch YAML templates (`config/mfx.yaml`, `config/xcs.yaml`, etc.) include
+commented-out blocks for both DAQ generations in the `SubmitSMD` section. Uncomment
+the block that matches your case.
+
+---
+
 ## Configuration
 
 The starting YAML for smalldata_tools may look like:

--- a/docs/usage/tasks/smalldata_tools.md
+++ b/docs/usage/tasks/smalldata_tools.md
@@ -56,6 +56,7 @@ your YAML.
 |---|---|---|
 | `producer` | string | Absolute path to `smd_producer.py` for the target DAQ generation |
 | `lute_template_cfg` | mapping | Nested object with `template_name` and `output_path` |
+| `producer_parameters` | mapping | Nested object with `detnames` and `smalldata` reduction algorithms |
 
 Both fields live directly under `SubmitSMD:` (not under `producer_parameters:`).
 

--- a/tests/functional/smd2_bayfai/config.yaml
+++ b/tests/functional/smd2_bayfai/config.yaml
@@ -50,11 +50,12 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau"]
-  detSumAlgos:
-    jungfrau:
-      - calib
-      - calib_max
+  producer_parameters:
+    detnames: ["jungfrau"]
+    detSumAlgos:
+      jungfrau:
+        - calib
+        - calib_max
 
 ###########
 # BayFAI

--- a/tests/functional/smd2_xss/config.yaml
+++ b/tests/functional/smd2_xss/config.yaml
@@ -50,25 +50,26 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames: ["jungfrau"]
-  epicsArchFilePV:
-    - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
-    - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
-    - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
-    - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
-    - ["SP1L0:DCCM:energy:OphydReadback", 'dccm_E']
-    - ["SP1L0:DCCM:energy:OphydSetpoint", 'dccm_E_setpoint']
-    - ["MFX:LAS:MMN:11.RBV", 'lens_h']
-    - ["MFX:LAS:MMN:12.RBV", 'lens_v']
-  getAzIntParams:
-    jungfrau:
-      eBeam: 12.965
-      center: [-1107, 918]
-      dis_to_sam: 155.5
-      phiBins: 11
-      qbin: 0.02
-      tx: 0
-      ty: 0
+  producer_parameters:
+    detnames: ["jungfrau"]
+    epicsArchFilePV:
+      - ["SP1L0:DCCM:MMS:TH1.RBV", 'dccm_th1']
+      - ["SP1L0:DCCM:MMS:TH2.RBV", 'dccm_th2']
+      - ["SP1L0:DCCM:MMS:TH1", 'dccm_th1_setpoint']
+      - ["SP1L0:DCCM:MMS:TH2", 'dccm_th2_setpoint']
+      - ["SP1L0:DCCM:energy:OphydReadback", 'dccm_E']
+      - ["SP1L0:DCCM:energy:OphydSetpoint", 'dccm_E_setpoint']
+      - ["MFX:LAS:MMN:11.RBV", 'lens_h']
+      - ["MFX:LAS:MMN:12.RBV", 'lens_v']
+    getAzIntParams:
+      jungfrau:
+        eBeam: 12.965
+        center: [-1107, 918]
+        dis_to_sam: 155.5
+        phiBins: 11
+        qbin: 0.02
+        tx: 0
+        ty: 0
 
 ###########################
 # TR-Scattering Analysis

--- a/tests/functional/smd_bayfai/config.yaml
+++ b/tests/functional/smd_bayfai/config.yaml
@@ -43,12 +43,13 @@ SubmitSMD:
   # detector. This detector MUST MATCH one of the detectors in `detnames`.
   # In the future this will be automated. If you have multiple detectors you can
   # add them with their own set of parameters.
-  detnames:
-    - "epix10k2M"
-  detSumAlgos:
-    epix10k2M:
-      - calib
-      - calib_max
+  producer_parameters:
+    detnames:
+      - "epix10k2M"
+    detSumAlgos:
+      epix10k2M:
+        - calib
+        - calib_max
 
 ###########
 # BayFAI

--- a/utilities/setup/setup_lute.py
+++ b/utilities/setup/setup_lute.py
@@ -212,8 +212,14 @@ class LuteEnvBuilder:
             _run_subprocess_log(cmd)
 
         # Install lute-lcls.
+        extra_index_args: List[str] = []
         if self.lute_version == "dev":
-            pkg_spec = f"lute-lcls"
+            pkg_spec = "lute-lcls"
+            extra_index_args = [
+                "--extra-index-url",
+                "https://slac-lcls.github.io/lute/wheels",
+                "--pre",
+            ]
         else:
             pkg_spec = f"lute-lcls=={self.lute_version}"
         logger.info(f"Installing {pkg_spec} into {env_dir}...")
@@ -221,7 +227,8 @@ class LuteEnvBuilder:
             [venv_python, "-m", "pip", "install", "--upgrade", "pip"],
         )
         _run_subprocess_log(
-            [venv_python, "-m", "pip", "install", "--ignore-installed", pkg_spec],
+            [venv_python, "-m", "pip", "install", "--ignore-installed", pkg_spec]
+            + extra_index_args,
         )
 
         # Write LUTE environment variables into the activation script
@@ -421,7 +428,8 @@ def main() -> None:
         type=str,
         help=(
             "Version of LUTE to use. Corresponds to release tag or `dev`. "
-            "Defaults to `dev`. If `dev`, only works with `--fresh_build`."
+            "Defaults to `dev`. If `fresh_install`, this fetches the latest "
+            "version of LUTE and adds the nightly build wheels."
         ),
         default="dev",
     )


### PR DESCRIPTION
# Description

This PR aims at updating the docs and the YAMLs mainly. It also updates the setup script to be able to build in a virtual environment the latest release along with the newly setup nightly build wheels.

# Checklist

- [x] Update installation documentation
- [x] Update `smalldata` usage documentation
- [x] Update hutch and test configuration YAMLs
- [x] Setup script to fetch latest release + wheels if `dev` is asked

# PR Type

- [x] Maintenance

# Setup

I tried setup `lute` for `mfx102101026` by running this first to setup latest changes.

```bash
(base) [lconreux@sdfiana024 ~]$ psana
(ana-4.0.68-py3) [lconreux@sdfiana024 ~]$ source ~/lute_env_py39/bin/activate
(lute_env_py39) (ana-4.0.68-py3) [lconreux@sdfiana024 ~]$ kinit
Password for lconreux@SLAC.STANFORD.EDU: 
(lute_env_py39) (ana-4.0.68-py3) [lconreux@sdfiana024 ~]$ cd /sdf/data/lcls/ds/prj/prjlute22/results/benchmarks/geom_opt/lute
(lute_env_py39) (ana-4.0.68-py3) [lconreux@sdfiana024 lute]$ pip install .
```

Then, this makes the `setup_lute` script available to call, to setup for `mfx102101026` with virtual environments:
```bash
(lute_env_py39) (ana-4.0.68-py3) [lconreux@sdfiana023 ~]$ setup_lute -e mfx102101026 -fi -D lconreux -W smd bayfai
INFO:lute_utilities.setup.setup_lute:Creating python3.9 env at /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_envs/lute_env_py39...
INFO:lute_utilities.setup.setup_lute:Installing lute-lcls into /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_envs/lute_env_py39...
INFO:lute_utilities.setup.setup_lute:Requirement already satisfied: pip in /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_envs/lute_env_py39/lib/python3.9/site-packages (22.0.4)
Collecting pip
  Using cached pip-26.0.1-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.0.4
    Uninstalling pip-22.0.4:
      Successfully uninstalled pip-22.0.4
Successfully installed pip-26.0.1

INFO:lute_utilities.setup.setup_lute:Looking in indexes: https://pypi.org/simple, https://slac-lcls.github.io/lute/wheels
Collecting lute-lcls
  Downloading https://github.com/slac-lcls/lute/releases/download/v0.3.0%2Bdev/lute_lcls-0.3.0%2Bdev-cp39-cp39-manylinux_2_28_x86_64.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 35.3 MB/s  0:00:00
Collecting pyyaml (from lute-lcls)
  Using cached pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.4 kB)
Collecting pydantic<2,>1.10.0 (from lute-lcls)
  Using cached pydantic-1.10.26-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (155 kB)
Collecting numpy (from lute-lcls)
  Using cached numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Collecting requests (from lute-lcls)
  Using cached requests-2.32.5-py3-none-any.whl.metadata (4.9 kB)
Collecting zmq (from lute-lcls)
  Using cached zmq-0.0.0-py3-none-any.whl
Collecting jinja2 (from lute-lcls)
  Using cached jinja2-3.1.6-py3-none-any.whl.metadata (2.9 kB)
Collecting typing-extensions>=4.2.0 (from pydantic<2,>1.10.0->lute-lcls)
  Using cached typing_extensions-4.16.0-py3-none-any.whl.metadata (3.3 kB)
Collecting MarkupSafe>=2.0 (from jinja2->lute-lcls)
  Using cached markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.7 kB)
Collecting charset_normalizer<4,>=2 (from requests->lute-lcls)
  Using cached charset_normalizer-3.4.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (41 kB)
Collecting idna<4,>=2.5 (from requests->lute-lcls)
  Using cached idna-3.18-py3-none-any.whl.metadata (6.1 kB)
Collecting urllib3<3,>=1.21.1 (from requests->lute-lcls)
  Using cached urllib3-2.6.3-py3-none-any.whl.metadata (6.9 kB)
Collecting certifi>=2017.4.17 (from requests->lute-lcls)
  Using cached certifi-2026.6.17-py3-none-any.whl.metadata (2.5 kB)
Collecting pyzmq (from zmq->lute-lcls)
  Using cached pyzmq-27.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (6.0 kB)
Using cached pydantic-1.10.26-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (2.9 MB)
Using cached typing_extensions-4.16.0-py3-none-any.whl (45 kB)
Using cached jinja2-3.1.6-py3-none-any.whl (134 kB)
Using cached markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (20 kB)
Using cached numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.5 MB)
Using cached pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (750 kB)
Using cached requests-2.32.5-py3-none-any.whl (64 kB)
Using cached charset_normalizer-3.4.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (214 kB)
Using cached idna-3.18-py3-none-any.whl (65 kB)
Using cached urllib3-2.6.3-py3-none-any.whl (131 kB)
Using cached certifi-2026.6.17-py3-none-any.whl (133 kB)
Using cached pyzmq-27.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (863 kB)
Installing collected packages: urllib3, typing-extensions, pyzmq, pyyaml, numpy, MarkupSafe, idna, charset_normalizer, certifi, zmq, requests, pydantic, jinja2, lute-lcls

Successfully installed MarkupSafe-3.0.3 certifi-2026.6.17 charset_normalizer-3.4.9 idna-3.18 jinja2-3.1.6 lute-lcls-0.3.0+dev numpy-2.0.2 pydantic-1.10.26 pyyaml-6.0.3 pyzmq-27.1.0 requests-2.32.5 typing-extensions-4.16.0 urllib3-2.6.3 zmq-0.0.0

INFO:lute_utilities.setup.setup_lute:Creating python3.11 env at /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_envs/lute_env_py311...
...
WARNING:lute_utilities.setup.setup_lute:No queue/partition provided. Defaulting to milano. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No account provided. Defaulting to lcls:mfx102101026. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No nodes provided. Defaulting to 1. Any key to continue. Ctrl-C to exit.

WARNING:lute_utilities.setup.setup_lute:No ntasks provided. Defaulting to 1. Any key to continue. Ctrl-C to exit.

INFO:lute_utilities.setup.setup_lute:Updated slurm_params in DAG file: /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_output/smd.dag
INFO:lute_utilities.setup.setup_lute:Updated slurm_params in DAG file: /sdf/data/lcls/ds/mfx/mfx102101026/results/lconreux/lute_output/bayfai.dag
INFO:lute_utilities.setup.setup_lute:Creating eLog workflow for lute_smd
INFO:lute_utilities.setup.setup_lute:Creating eLog workflow for lute_bayfai
```

Running from the eLog on run 1:
```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): pswww.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://pswww.slac.stanford.edu:443 "GET /ws-jwt/lgbk/lgbk/mfx102101026/ws/runs/1 HTTP/1.1" 200 14882
[2026-07-14 17:46:12.274] [LWM:Manager] [info] Running workflows with SlurmLauncher.
[2026-07-14 17:46:12.274] [HTTP:Server] [info] Starting server on 0.0.0.0:45985 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-14 17:46:12.275] [LWM:Manager] [info] Beginning workflow.
[2026-07-14 17:46:12.275] [LWM:SlurmLauncher] [info] Will launch SmallDataProducer2 with: /sdf/data/lcls/ds/mfx/mfx102101026/results/lute_envs/lute_env_py39/bin/submit_slurm --taskname SmallDataProducer2 --config /sdf/data/lcls/ds/mfx/mfx102101026/results/lute_output/mfx_lute.yaml --psana2 --account=lcls:mfx102101026 --partition=milano --ntasks-per-node=50 --nodes=4
```
