### PR TITLE
BUG/MNT Add `aduspphot` to `smd2_prod_config`

### DIFF
--- a/config/templates/smd2_prod_config_template.py
+++ b/config/templates/smd2_prod_config_template.py
@@ -95,7 +95,7 @@ def get_droplet2photon(run):
 {{- step_parameters("droplet_dict", detector, params["droplet"], False) }}
         d2p_dict["droplet"] = droplet_dict
         d2p_dict["d2p"] = {
-            "aduspphot": 20,
+            "aduspphot": {{ params["aduspphot"] }},
             "cputime": {{ params["cputime"] }},
         }
         d2p_dict["nData"] = None


### PR DESCRIPTION
# Description

This PR address some parameter which was hard coded in the SMD2 template for whatever reason.

## Checklist
- [x] Make `aduspphot` configurable

## PR Type:
- [x] Bug fix

## Address issues:
- https://github.com/slac-lcls/lute/issues/139

# Testing

## Functional

## Unit

# Screenshots

