### PR TITLE
BUG/MNT Auditwheel issue and guarding `cd`

### DIFF
--- a/launch_scripts/submit_launch_airflow.sh
+++ b/launch_scripts/submit_launch_airflow.sh
@@ -30,7 +30,7 @@ cp $KERB_CACHE_PATH $HOME/.tmp_cache/kerbcache
 echo $?
 export KRB5CCNAME="FILE:${HOME}/.tmp_cache/kerbcache"
 
-LUTE_BIN_PATH="$(cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
+LUTE_BIN_PATH="$(builtin cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
 
 # Detect install type
 if [[ -f "${LUTE_BIN_PATH}/activate" ]]; then
@@ -45,10 +45,10 @@ if [[ -f "${LUTE_BIN_PATH}/activate" ]]; then
     LUTE_ENVS_PARENT="$(dirname "$(dirname "${LUTE_BIN_PATH}")")"
     for env_dir in "${LUTE_ENVS_PARENT}"/lute_env_py*/bin/activate; do
         if [[ -f "${env_dir}" ]]; then
-            env_name="$(basename "$(dirname "$(dirname "${env_dir}")")")" 
+            env_name="$(basename "$(dirname "$(dirname "${env_dir}")")")"
             # Extract version: "lute_env_pyXYZ" → "XYZ"
             py_ver="${env_name#lute_env_py}"
-            export "LUTE_VIRTUAL_ENV_PY${py_ver}"="$(dirname "$(dirname "${env_dir}")")/bin/python" 
+            export "LUTE_VIRTUAL_ENV_PY${py_ver}"="$(dirname "$(dirname "${env_dir}")")/bin/python"
         fi
     done
 else

--- a/launch_scripts/submit_slurm.sh
+++ b/launch_scripts/submit_slurm.sh
@@ -156,7 +156,7 @@ SCRIPT_DIR="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )"
 export LUTE_PATH="$( echo $SCRIPT_DIR | sed s/launch_scripts//g | sed s/bin//g )"
 EXECUTABLE="run_task.py"
 
-LUTE_BIN_PATH="$(cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
+LUTE_BIN_PATH="$(builtin cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
 
 if [[ $SCRIPT_DIR == *"launch_scripts"* ]]; then
     EXECUTABLE="${LUTE_PATH}run_task.py"

--- a/utilities/activate_installation
+++ b/utilities/activate_installation
@@ -3,7 +3,7 @@
 # installation. It should only be used when LUTE has been installed at a
 # non-standard prefix. In most cases this is the usual operating procedure.
 
-LUTE_BIN_PATH="$(cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
+LUTE_BIN_PATH="$(builtin cd "$(dirname ${BASH_SOURCE[0]})" &> /dev/null && pwd)"
 LUTE_INSTALL_PATH="$(echo $LUTE_BIN_PATH | sed s/bin//g)"
 echo "Using LUTE installation at $LUTE_INSTALL_PATH"
 PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')

--- a/workflows/maestro/meson.build
+++ b/workflows/maestro/meson.build
@@ -94,12 +94,11 @@ test_http = executable(
     ],
     dependencies: [
         gtest_dep,
-        lwm_dep,
         spdlog_dep,
         rapidjson_dep,
     ],
     install: get_option('install_tests'),
-    install_rpath: py3.get_install_dir() / 'maestro/_maestro',
+    install_rpath: '$ORIGIN',
     include_directories: maestro_headers,
 )
 test('HTTP parsing tests', test_http)
@@ -114,12 +113,11 @@ test_server = executable(
     ],
     dependencies: [
         gtest_dep,
-        lwm_dep,
         spdlog_dep,
         rapidjson_dep,
     ],
     install: get_option('install_tests'),
-    install_rpath: py3.get_install_dir() / 'maestro/_maestro',
+    install_rpath: '$ORIGIN',
     include_directories: maestro_headers,
     link_args: ['-lpthread'],
 )
@@ -133,16 +131,16 @@ test_maestro_api = executable(
         'src/server/handler.cc',
         'src/lwm/launcher.cc',
         'src/lwm/job.cc',
+        'src/lwm/job_registry.cc',
         'src/parallel/threadpool.cc'
     ],
     dependencies: [
         gtest_dep,
-        lwm_dep,
         spdlog_dep,
         rapidjson_dep,
     ],
     install: get_option('install_tests'),
-    install_rpath: py3.get_install_dir() / 'maestro/_maestro',
+    install_rpath: '$ORIGIN',
     include_directories: maestro_headers,
     link_args: ['-lpthread'],
 )


### PR DESCRIPTION
# Description

This PR addresses to issues:
- The `maestro` build file was recently updated to include `lwm_dep` in test executable dependencies. While correct, this is causign auditwheel issues in traversing the wheels for shared library dependencies. This is likely because the tests are not truly part of the wheel proper. Instead of changing auditwheel configuraiton or sosmething similar, we can simply remove the dependency from the test executables. In this case we can get away with that as the various translation units are compiled directly into the test binaries. They still run fine.
- We haven't seen an issue yet, but in a separate case, a similar use of `cd` for determining a bash files location failed because users are overriding the builtin `cd` command with a function. Probably for use with AI agents. A fairly simple guard for this is to replace the use of `cd` with `builtin cd` ensuring an overrides are avoided when we need to use the command.


## Checklist
- [x] Remove `lwm_dep` from test executables
- [x] Update use of `cd` to `builtin cd` in bash scripts using it to deremine source file location.

## PR Type:
- [x] Bug fix/maintenance

## Address issues:
- `auditwheel` failing in CI builds.

# Testing

## Functional

## Unit

The updated test binary builds run fine after the changes:
```bash
> ./install/bin/test_http 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from HTTPTest
[ RUN      ] HTTPTest.ParseSimpleRequest
[       OK ] HTTPTest.ParseSimpleRequest (0 ms)
[ RUN      ] HTTPTest.ParseHeaders
[       OK ] HTTPTest.ParseHeaders (0 ms)
[ RUN      ] HTTPTest.ResponseToString
[       OK ] HTTPTest.ResponseToString (0 ms)
[ RUN      ] HTTPTest.MethodToString
[       OK ] HTTPTest.MethodToString (0 ms)
[ RUN      ] HTTPTest.CodeToString
[       OK ] HTTPTest.CodeToString (0 ms)
[----------] 5 tests from HTTPTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

> ./install/bin/test_server 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from ServerTest
[ RUN      ] ServerTest.StartStop
[2026-07-20 11:02:08.938] [HTTP:Server] [info] Starting server on 127.0.0.1:18888 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-20 11:02:08.938] [HTTP:Server] [info] Shutting down server...
[2026-07-20 11:02:08.938] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.StartStop (0 ms)
[ RUN      ] ServerTest.HandleRequest
[2026-07-20 11:02:08.938] [HTTP:Server] [info] Starting server on 127.0.0.1:18889 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-20 11:02:09.039] [HTTP:Server] [info] Shutting down server...
[2026-07-20 11:02:09.039] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.HandleRequest (100 ms)
[ RUN      ] ServerTest.LargeLogRequest
[2026-07-20 11:02:09.039] [HTTP:Server] [info] Starting server on 127.0.0.1:18890 with 5 threads, using 64 shards, with a backlog size of 1000 and 10000 maximum events.
[2026-07-20 11:02:09.139] [HTTP:Server] [info] Shutting down server...
[2026-07-20 11:02:09.139] [HTTP:Server] [info] All server threads exited.
[       OK ] ServerTest.LargeLogRequest (100 ms)
[----------] 3 tests from ServerTest (201 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (201 ms total)
[  PASSED  ] 3 tests.

> ./install/bin/test_maestro_api 
Running main() from ../subprojects/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from MaestroAPITest
[ RUN      ] MaestroAPITest.StatusUpdateBasic
[       OK ] MaestroAPITest.StatusUpdateBasic (0 ms)
[ RUN      ] MaestroAPITest.StatusUpdateExtended
[       OK ] MaestroAPITest.StatusUpdateExtended (0 ms)
[ RUN      ] MaestroAPITest.TasksListEmpty
[       OK ] MaestroAPITest.TasksListEmpty (0 ms)
[ RUN      ] MaestroAPITest.RPCOperations
[       OK ] MaestroAPITest.RPCOperations (0 ms)
[ RUN      ] MaestroAPITest.RPCBadRequest
[       OK ] MaestroAPITest.RPCBadRequest (0 ms)
[----------] 5 tests from MaestroAPITest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

```

# Screenshots

